### PR TITLE
Fix k8s-config preTasks

### DIFF
--- a/openshift/config/common/templates/anarchy-k8s-config/anarchygovernors/gitops.yaml.j2
+++ b/openshift/config/common/templates/anarchy-k8s-config/anarchygovernors/gitops.yaml.j2
@@ -26,7 +26,7 @@ spec:
 
   actions:
     configure:
-      pre_tasks:
+      preTasks:
       - name: Check value of k8s_config_environment_level
         fail:
           msg: k8s_config_environment_level must be set to 'dev', 'test', or 'prod'


### PR DESCRIPTION
This was set as `pre_tasks` when `preTasks` is required.