### PR TITLE
Do not verify SSL

### DIFF
--- a/playbooks/service-destroy.yaml
+++ b/playbooks/service-destroy.yaml
@@ -120,6 +120,7 @@
       dest: "{{ output_dir }}/secrets/tower.rc"
       content: |
         export TOWER_HOST="https://{{ tower_hostname }}"
+        export TOWER_VERIFY_SSL=false
         export TOWER_USERNAME={{ tower_user | to_json }}
         export TOWER_PASSWORD={{ tower_password | to_json }}
         export TOWER_JOB={{ tower_job | to_json }}

--- a/playbooks/service-lifecycle.yaml
+++ b/playbooks/service-lifecycle.yaml
@@ -164,6 +164,7 @@
       dest: "{{ output_dir }}/secrets/tower.rc"
       content: |
         export TOWER_HOST="https://{{ tower_hostname }}"
+        export TOWER_VERIFY_SSL=false
         export TOWER_USERNAME={{ tower_user | to_json }}
         export TOWER_PASSWORD={{ tower_password | to_json }}
         export TOWER_JOB={{ tower_job | to_json }}

--- a/playbooks/service-provision.yaml
+++ b/playbooks/service-provision.yaml
@@ -162,6 +162,7 @@
       dest: "{{ output_dir }}/secrets/tower.rc"
       content: |
         export TOWER_HOST="https://{{ tower_hostname }}"
+        export TOWER_VERIFY_SSL=false
         export TOWER_USERNAME={{ tower_user | to_json }}
         export TOWER_PASSWORD={{ tower_password | to_json }}
         export TOWER_JOB={{ tower_job | to_json }}


### PR DESCRIPTION
Dark tower APIs do not have proper certificate.

Until they are fixed (letsencrypt?) don't verify SSL.