### PR TITLE
Bump babylon_anarchy_governor to v0.0.6

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -2,7 +2,7 @@
 agnosticv_operator_version: v0.0.25
 agnosticv_repositories: []
 anarchy_version: v0.4.1
-babylon_anarchy_governor_version: v0.0.4
+babylon_anarchy_governor_version: v0.0.6
 k8s_config_version: 0.2.0
 poolboy_version: v0.2.13
 user_namespace_operator_version: v0.1.5


### PR DESCRIPTION
Adds timeout 0 to calls to dark tower.