### PR TITLE
Bump agnosticv-operator version to v0.1.1

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.1.0
+agnosticv_operator_version: v0.1.1
 agnosticv_repositories: []
 anarchy_version: v0.8.4
 babylon_anarchy_governor_version: v0.0.7


### PR DESCRIPTION
This will cause agnosticv-operator to set python requirements in Anarchy governor definitions.