### PR TITLE
Set anarchy to version v0.8.6

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,7 +1,7 @@
 # Component Versions
 agnosticv_operator_version: v0.1.1
 agnosticv_repositories: []
-anarchy_version: v0.8.5
+anarchy_version: v0.8.6
 babylon_anarchy_governor_version: v0.0.7
 babylon_aws_sandbox_version: v0.0.1
 k8s_config_version: v0.4.4


### PR DESCRIPTION
This release resolves issues encountered during summit v2.