### PR TITLE
Remove passing cloud_tags in service-provision playbook

### DIFF
--- a/openshift/config/common/helm/babylon-config/templates/babylon-resourceprovider.yaml
+++ b/openshift/config/common/helm/babylon-config/templates/babylon-resourceprovider.yaml
@@ -32,6 +32,8 @@ spec:
         job_vars:
           guid: >-
             {{ "{{: resource_handle.metadata.name[5:] if resource_handle.metadata.name.startswith('guid-') else resource_handle.metadata.name :}}" }}
+          uuid: >-
+            {{ "{{: resource_handle.metadata.uid :}}" }}
   updateFilters:
   - pathMatch: /spec/vars/desired_state
   validation:

--- a/playbooks/service-provision.yaml
+++ b/playbooks/service-provision.yaml
@@ -81,8 +81,12 @@
                 governor: "{{ catalog_item_name }}"
                 vars:
                   desired_state: started
+                  # Set job_vars, excluding "guid" and "cloud_tags", which are
+                  # handled by babylon provisioning.
                   job_vars: >-
-                    {{ vars.catalog_item_params | dict2items | json_query("[?key!='guid']") | items2dict }}
+                    {{ vars.catalog_item_params | dict2items
+                     | json_query("[?key!='guid' && key!='cloud_tags']")
+                     | items2dict }}
 
   - name: Get Tower credentials and access information
     k8s_info:


### PR DESCRIPTION
For consistent behavior with pre-provisioned pools the cloud tags need to be assigned before a resource claim is created.