### PR TITLE
Allow ServiceAccount 'opentlc-mgr' to manage secrets in 'gpte' ns

### DIFF
--- a/openshift/config/common/files/rolebindings/opentlc-secret-manager-admin.yaml
+++ b/openshift/config/common/files/rolebindings/opentlc-secret-manager-admin.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: opentlc-secret-manager-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: opentlc-secret-manager-admin
+subjects:
+- kind: ServiceAccount
+  name: opentlc-mgr
+  namespace: gpte

--- a/openshift/config/common/files/roles/opentlc-secret-manager-admin.yaml
+++ b/openshift/config/common/files/roles/opentlc-secret-manager-admin.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: opentlc-secret-manager-admin
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create

--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -22,6 +22,10 @@ babylon_resources:
     resources:
       - name: opentlc-mgr service account
         file: serviceaccounts/opentlc-mgr.yaml
+      - name: opentlc-secret-manager-admin role
+        file: roles/opentlc-secret-manager-admin.yaml
+      - name: OpenTLC secret manager Admin role binding
+        file: rolebindings/opentlc-secret-manager-admin.yaml
       - name: anarchy-operator role
         file: roles/anarchy-operator.yaml
       - name: anarchy-operator rolebinding


### PR DESCRIPTION
Secret manager service accounts should be able to create secrets