### PR TITLE
Bump babylon_anarchy_governor to v0.4.2

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,7 +1,7 @@
 # Component Versions
 agnosticv_operator_version: v0.5.0
 babylon_anarchy_version: v0.12.5
-babylon_anarchy_governor_version: v0.4.1
+babylon_anarchy_governor_version: v0.4.2
 poolboy_version: v0.3.12
 
 babylon_anarchy_governor_repository: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git


### PR DESCRIPTION
This fixes issue caused by passing extra_vars on job launch.