### PR TITLE
Bump anarchy to 0.13.1, babylon_anarchy_governor 0.7.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,7 +1,7 @@
 # Component Versions
 agnosticv_operator_version: v0.6.1
-babylon_anarchy_version: v0.13.0
-babylon_anarchy_governor_version: v0.6.1
+babylon_anarchy_version: v0.13.1
+babylon_anarchy_governor_version: v0.7.0
 poolboy_version: v0.5.0
 
 babylon_anarchy_governor_repository: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git


### PR DESCRIPTION
This fixes action execution issue in Anarchy and adds support for vault_credentials for babylon_anarchy_governor.