### PR TITLE
Bump babylon_anarchy_governor to v0.8.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,7 +1,7 @@
 # Component Versions
 agnosticv_operator_version: v0.6.2
 babylon_anarchy_version: v0.13.2
-babylon_anarchy_governor_version: v0.7.0
+babylon_anarchy_governor_version: v0.8.0
 poolboy_version: v0.5.0
 
 babylon_anarchy_governor_repository: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git


### PR DESCRIPTION
This brings in the `__meta__.deployer.git_tag_prefix` feature.