### PR TITLE
Bump agnosticv-operator to v0.7.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.6.2
+agnosticv_operator_version: v0.7.0
 babylon_anarchy_version: v0.14.1
 babylon_anarchy_governor_version: v0.8.0
 poolboy_version: v0.6.1


### PR DESCRIPTION
Adds packaging python requirement for comparing versions as required to implement `__meta__.deployer.git_tag_prefix`