### PR TITLE
Bump anarchy to v0.15.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,6 +1,6 @@
 # Component Versions
 agnosticv_operator_version: v0.9.3
-babylon_anarchy_version: v0.14.2
+babylon_anarchy_version: v0.15.0
 babylon_anarchy_governor_version: v0.8.3
 poolboy_version: v0.8.1
 


### PR DESCRIPTION
This enables update handling after delete handlers have started as well as exposing previous version of an anarchysubject to the update handler.