### PR TITLE
Bump agnosticv-operator to v0.13.2

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.13.1
+agnosticv_operator_version: v0.13.2
 babylon_anarchy_version: v0.16.25
 babylon_anarchy_governor_version: v0.9.0
 poolboy_version: v0.10.0


### PR DESCRIPTION
This release of agnosticv-operator includes update to agnosticv cli to include a fix to ignore hidden files starting with `.` in agnosticv repositories.