### PR TITLE
Implement Quotas for count (Catalog UI)

### DIFF
--- a/catalog/ui/src/app/Catalog/Catalog.tsx
+++ b/catalog/ui/src/app/Catalog/Catalog.tsx
@@ -7,6 +7,7 @@ import {
 import {
   selectCatalogItems,
   selectResourceClaims,
+  selectUserNamespace,
   selectCatalogNamespaces,
   selectUserGroups,
   selectInterface,
@@ -87,16 +88,14 @@ export interface CatalogProps {
   location?: any;
 }
 
-const getCatalogItemsFromServices = (allResourceClaims: any) => {
+const getCatalogItemsFromServices = (allResourceClaims: any, currentUserNamespace: any) => {
   const catalogItems = [];
-  const resourceClaimLists = Object.values(allResourceClaims !== null ? allResourceClaims : {});
-  for (const resourceClaimList of resourceClaimLists){
-    for (const resourceClaim of resourceClaimList as any){
+  const resourceClaimList = allResourceClaims?.[currentUserNamespace.name] || {};
+  for (const resourceClaim of resourceClaimList){
       const catalogItemName = resourceClaim.metadata.labels['babylon.gpte.redhat.com/catalogItemName'];
       const catalogItemNamespace = resourceClaim.metadata.labels['babylon.gpte.redhat.com/catalogItemNamespace'];
       catalogItems.push({catalogItemName, catalogItemNamespace});
     }
-  }
   return catalogItems;
 };
 
@@ -126,6 +125,7 @@ const Catalog: React.FunctionComponent<CatalogProps> = ({
   const userInterface = useSelector(selectInterface);
   const userIsAdmin = useSelector(selectUserIsAdmin);
   const allResourceClaims = useSelector(selectResourceClaims);
+  const currentUserNamespace = useSelector(selectUserNamespace);
   const catalogItems = useSelector(selectCatalogItems);
   const catalogNamespaces = useSelector(selectCatalogNamespaces);
   const catalogNamespace = catalogNamespaceName ? (catalogNamespaces.find(ns => ns.name == catalogNamespaceName) || {name: catalogNamespaceName, displayName: catalogNamespaceName, description: ""}) : null;
@@ -146,7 +146,7 @@ const Catalog: React.FunctionComponent<CatalogProps> = ({
 
   const selectedCatalogItemName = selectedCatalogItem?.metadata?.name;
   const selectedCatalogItemNamespace = selectedCatalogItem?.metadata?.namespace;
-  const catalogItemList = getCatalogItemsFromServices(allResourceClaims);
+  const catalogItemList = getCatalogItemsFromServices(allResourceClaims, currentUserNamespace);
 
   function category(catalogItem: { metadata: { labels: { [x: string]: string | null; }; }; }): string | null {
     if (catalogItem.metadata.labels) {


### PR DESCRIPTION
- Link : https://issues.redhat.com/browse/GPTEINFRA-1844?_sscc=t
- Users that are not administrators can only have 1 instance of a catalog item.
- Users that are not administrators can only have 3 unique services.
- Disable the "request service" button and Present the error messages to users, if they try to provision and have exceeded the limit.
![Screenshot from 2021-10-19 18-10-49](https://user-images.githubusercontent.com/90457770/137911813-e3ecd83d-f35c-4805-bb22-828f2a1aceba.png)
![Screenshot from 2021-10-19 17-52-03](https://user-images.githubusercontent.com/90457770/137913681-563f9f32-1d7a-403a-962e-9877c39290c1.png)
