### PR TITLE
Support Browser refresh for impersonate users

### DIFF
--- a/catalog/ui/src/app/store/index.ts
+++ b/catalog/ui/src/app/store/index.ts
@@ -224,7 +224,7 @@ function reduce_clearImpersonation(state, action) {
   state.resourceClaims = null;
   startWatchCatalogItems();
   startWatchResourceClaims();
-  sessionStorage.clear();
+  sessionStorage.removeItem('impersonateUser');
 }
 
 function reduce_deleteResourceClaim(state, action) {


### PR DESCRIPTION
- Session Storage to store impersonate user name. 
- Impersonate user data will be stored for a particular session and data will get cleared once the user closes the browser window or the tab.
- Session storage data will get cleared when user click on 'logout' and 'clear user impersonation'.
