### PR TITLE
Add type conversion for provision parameter vars

### DIFF
--- a/playbooks/filter_plugins/parameters.py
+++ b/playbooks/filter_plugins/parameters.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Johnathan Kupferer <jkupfere@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import string_types
+
+import yaml
+
+def babylon_extract_parameter_vars(vars_dict):
+    parameter_vars = dict()
+    parameters = vars_dict.get('__meta__', {}).get('catalog', {}).get('parameters')
+
+    # Cloud tags may passed as a YAML string which must be interpreted.
+    # Strip out guid and uuid from cloud tags as these will conflict with Babylon assignment.
+    if 'cloud_tags' in vars_dict and isinstance(vars_dict['cloud_tags'], string_types):
+        vars_dict['cloud_tags'] = {
+            k: v for k, v in yaml.safe_load(vars_dict['cloud_tags']).items() if k not in ('guid', 'uuid')
+        }
+
+    if parameters == None:
+        # No parameters configured, so must pass all vars as parameter vars
+        for varname, value in vars_dict.items():
+            if varname not in ('__meta__', 'agnosticv_meta', 'cloud_tags', 'guid', 'uuid'):
+                parameter_vars[varname] = value
+    else:
+        # Pass parameter vars with expected type conversions
+        for parameter in parameters:
+            # Use explicit variable name for parameter if set, otherwise use parameter name as variable name
+            # unless parameter sets an annotation.
+            varname = parameter.get('variable', None if 'annotation' in parameter else parameter['name'])
+            vartype = parameter.get('openAPIV3Schema', {}).get('type')
+            if varname and varname in vars_dict:
+                raw_value = vars_dict[varname]
+                if vartype == 'boolean':
+                    parameter_vars[varname] = raw_value.lower() in ('1', 'true', 'yes')
+                elif vartype == 'integer':
+                    parameter_vars[varname] = int(raw_value)
+                elif vartype == 'number':
+                    parameter_vars[varname] = float(raw_value)
+                elif vartype == 'string':
+                    parameter_vars[varname] = str(raw_value)
+                else:
+                    parameter_vars[varname] = raw_value
+
+
+    return parameter_vars
+
+class FilterModule(object):
+    ''' Ansible core jinja2 filters '''
+
+    def filters(self):
+        return {
+            'babylon_extract_parameter_vars': babylon_extract_parameter_vars,
+        }

--- a/playbooks/service-provision.yaml
+++ b/playbooks/service-provision.yaml
@@ -55,10 +55,6 @@
         {{ vars.catalog_item_params.guid }}
       uuid: >-
         {{ vars.catalog_item_params.uuid }}
-      # Take cloud_tags, but drop values to ignore, guid and uuid
-      cloud_tags: >-
-        {{ vars.catalog_item_params.cloud_tags | default('{}') | from_yaml
-         | dict2items | json_query("[?key!='guid' && key!='uuid']") | items2dict }}
       resource_claim_name: >-
         {{ catalog_item_name }}-{{ vars.catalog_item_params.guid }}
 
@@ -112,7 +108,7 @@
         metadata:
           annotations:
             openshift.io/description: User Namespace for {{ cloudforms_username }}
-            openshift.io/display-name: "{{ user_namespace }}"
+            openshift.io/display-name: "User {{ cloudforms_username }}"
             openshift.io/requester: "{{ cloudforms_username }}"
           name: "{{ user_namespace }}"
 
@@ -136,16 +132,6 @@
 
   - name: Create ResourceClaim {{ resource_claim_name }}
     vars:
-      __meta_catalog_parameter_names: >-
-        {{ vars.catalog_item_params | json_query('__meta__.catalog.parameters[].name') }}
-      __job_vars_from_configured_parameters: >-
-        {{ vars.catalog_item_params | dict2items
-         | json_query("[?contains(`" ~ __meta_catalog_parameter_names | to_json ~ "`, key)]")
-         | items2dict | combine({"cloud_tags": vars.cloud_tags} if 'cloud_tags' in __meta_catalog_parameter_names else {}) }}
-      __job_vars_all: >-
-        {{ vars.catalog_item_params | dict2items
-         | json_query("[?key!='guid' && key!='uuid' && key!='cloud_tags']")
-         | items2dict | combine({"cloud_tags": vars.cloud_tags}) }}
       # Resource definition for common ResourceProvider
       __babylon_provider_resource_item:
         provider:
@@ -166,13 +152,7 @@
             vars:
               # Indicate that environment should start if match to a stopped environment
               desired_state: started
-              # Set job_vars, excluding "guid" and "uuid" and insert filtered "cloud_tags"
-              job_vars: >-
-                {% if __meta_catalog_parameter_names != '' -%}
-                {{ __job_vars_from_configured_parameters }}
-                {%- else -%}
-                {{ __job_vars_all }}
-                {%- endif %}
+              job_vars: "{{ vars.catalog_item_params | babylon_extract_parameter_vars }}"
       # Resource definition to use when ResourceProvider is specific to the AgnosticV item
       __provider_specific_resource_item:
         provider:
@@ -183,7 +163,7 @@
         template:
           spec:
             vars:
-              job_vars: "{{ __job_vars_from_configured_parameters }}"
+              job_vars: "{{ vars.catalog_item_params | babylon_extract_parameter_vars }}"
     k8s:
       kubeconfig: "{{ kubeconfig }}"
       definition:


### PR DESCRIPTION
The parameter configuration in our CFME compatibility playbooks had not kept up with recent changes to parameter validation. This PR fixes parameter types in variables and removes parameter variables that are marked as annotation only.