### PR TITLE
Fix unittest location

### DIFF
--- a/playbooks/unittest-filter-plugins.py
+++ b/playbooks/unittest-filter-plugins.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
-from parameters import babylon_extract_parameter_vars
+from filter_plugins.parameters import babylon_extract_parameter_vars
 
 class TestParametersFilter(unittest.TestCase):
     def test_00(self):


### PR DESCRIPTION
It seems unittests must not be located within the `filter_plugins` folder or else ansible will try to load the unittests as a plugin.