### PR TITLE
Bump agnosticv-operator to v0.20.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.18.0
+agnosticv_operator_version: v0.20.0
 babylon_anarchy_version: v0.19.2
 babylon_anarchy_governor_version: v0.10.3
 poolboy_version: v0.11.1


### PR DESCRIPTION
Enables Ansible tower/controller configuration and updates CRDs from v1beta1 to v1.