### PR TITLE
Remove @hot-loader/react-dom

### DIFF
--- a/catalog/ui/package-lock.json
+++ b/catalog/ui/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@hot-loader/react-dom": "^17.0.1",
         "@monaco-editor/react": "^4.2.2",
         "@patternfly/patternfly": "^4.132.2",
         "@patternfly/react-core": "^4.152.4",
@@ -70,7 +69,6 @@
         "prop-types": "^15.6.1",
         "raw-loader": "^4.0.2",
         "react-docgen-typescript-loader": "^3.7.2",
-        "react-hot-loader": "^4.13.0",
         "react-router-dom": "^5.3.0",
         "regenerator-runtime": "^0.13.9",
         "rimraf": "^3.0.2",
@@ -2195,25 +2193,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "node_modules/@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      }
-    },
-    "node_modules/@hot-loader/react-dom/node_modules/scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -24743,34 +24722,6 @@
         "shallowequal": "^1.1.0"
       }
     },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/react-inspector": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
@@ -32092,27 +32043,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -50324,30 +50254,6 @@
         "prop-types": "^15.7.2",
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
-      }
-    },
-    "react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
       }
     },
     "react-inspector": {

--- a/catalog/ui/package.json
+++ b/catalog/ui/package.json
@@ -11,7 +11,7 @@
     "dr:surge": "node dr-surge.js",
     "build": "webpack --config webpack.prod.js && npm run dr:surge",
     "start": "sirv dist --cors --single --host --port 8080",
-    "start:dev": "webpack serve --hot --color --progress --config webpack.dev.js",
+    "start:dev": "webpack serve --color --progress --config webpack.dev.js",
     "test": "jest",
     "eslint": "eslint --ext .tsx,.js ./src/",
     "lint": "npm run eslint",
@@ -58,7 +58,6 @@
     "prop-types": "^15.6.1",
     "raw-loader": "^4.0.2",
     "react-docgen-typescript-loader": "^3.7.2",
-    "react-hot-loader": "^4.13.0",
     "react-router-dom": "^5.3.0",
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
@@ -78,7 +77,6 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@hot-loader/react-dom": "^17.0.1",
     "@monaco-editor/react": "^4.2.2",
     "@patternfly/patternfly": "^4.132.2",
     "@patternfly/react-core": "^4.152.4",

--- a/catalog/ui/src/app/Support/Support.tsx
+++ b/catalog/ui/src/app/Support/Support.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { hot } from 'react-hot-loader/root';
 import { CubesIcon } from '@patternfly/react-icons';
 import { PageSection, Title } from '@patternfly/react-core';
 
@@ -7,7 +6,7 @@ export interface ISupportProps {
   sampleProp?: string;
 }
 
-let Support: React.FunctionComponent<ISupportProps> = () => (
+const Support: React.FunctionComponent<ISupportProps> = () => (
   <PageSection>
     <Title headingLevel="h1" size="lg">
       Support
@@ -16,5 +15,4 @@ let Support: React.FunctionComponent<ISupportProps> = () => (
   </PageSection>
 );
 
-Support = hot(Support); // enable HMR for this async module
 export { Support };

--- a/catalog/ui/src/app/index.tsx
+++ b/catalog/ui/src/app/index.tsx
@@ -1,4 +1,3 @@
-import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { useLocation, BrowserRouter, Route, Switch } from 'react-router-dom';
@@ -22,4 +21,4 @@ const App: React.FunctionComponent = () => (
   </BrowserRouter>
 );
 
-export default hot(App);
+export default App;

--- a/catalog/ui/webpack.common.js
+++ b/catalog/ui/webpack.common.js
@@ -7,9 +7,6 @@ const BG_IMAGES_DIRNAME = 'bgimages';
 const ASSET_PATH = process.env.ASSET_PATH || '/';
 module.exports = (env) => {
   return {
-    entry: {
-      app: ['react-hot-loader/patch', path.resolve(__dirname, 'src', 'index.tsx')],
-    },
     module: {
       rules: [
         {
@@ -136,9 +133,6 @@ module.exports = (env) => {
       }),
     ],
     resolve: {
-      alias: {
-        'react-dom': '@hot-loader/react-dom',
-      },
       extensions: ['.js', '.ts', '.tsx', '.jsx'],
       plugins: [
         new TsconfigPathsPlugin({

--- a/catalog/ui/webpack.dev.js
+++ b/catalog/ui/webpack.dev.js
@@ -21,7 +21,6 @@ module.exports = merge(common('development'), {
         { from: /^\/services\/.*/, to: '/index.html' },
       ],
     },
-    hot: true,
     overlay: true,
     open: true,
     proxy: {


### PR DESCRIPTION
- React hot loader is currently used in production code however is intended to be used only for dev.
- Furthermore it was entirely removed from the patternfly-react-seed https://github.com/patternfly/patternfly-react-seed/pull/109/files 