### PR TITLE
Do not fail if variables are out of sync

### DIFF
--- a/playbooks/service-provision.yaml
+++ b/playbooks/service-provision.yaml
@@ -89,14 +89,19 @@
       delay: 5
       retries: 60
     rescue:
-    - name: Report failure waiting for AnarchyGovernor vars sync
+    - name: Report failure waiting for AnarchyGovernor doesn't exist
+      when: r_governor.resources | length == 0
       fail:
         msg: |-
-         {% if r_governor.resources | length == 0 %}
          AnarchyGovernor {{ catalog_item_name }} not found in {{ anarchy_namespace }} namespace.
-         {% else %}
+         Check agnosticv-operator logs:
+           oc logs -n agnosticv-operator deployment/agnosticv-operator
+
+    - name: Report failure waiting for AnarchyGovernor vars sync
+      ignore_errors: true
+      fail:
+        msg: |-
          AnarchyGovernor {{ catalog_item_name }} in {{ anarchy_namespace }} job_vars do not match agnosticv.
-         {% endif %}
          Check agnosticv-operator logs:
            oc logs -n agnosticv-operator deployment/agnosticv-operator
 


### PR DESCRIPTION
When agnosticv-operator didn't catch up with current state, just print a
warning.
We don't want to break prod in that situation, only potentially notify
admins that are testing something.

When the governor doesn't exist, fail.