### PR TITLE
Bump agnosticv-operator to v0.23.0

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.22.1
+agnosticv_operator_version: v0.23.0
 babylon_anarchy_version: v0.20.0
 babylon_anarchy_governor_version: v0.12.0
 poolboy_version: v0.12.0


### PR DESCRIPTION
Adds unique GUIDs with numeric suffix to deployments with multiple
components.