### PR TITLE
Adding SMTP username and password parameters for the authentication

### DIFF
--- a/notifier/Development.adoc
+++ b/notifier/Development.adoc
@@ -61,7 +61,14 @@ odo config set --env SMTP_HOST="mx00.opentlc.com"
 odo config set --env SMTP_PORT="19587"
 ----------------------------------------------------
 +
-Set `SMTP_TLS_CERT` and `SMTP_TLS_KEY`:
+Set `SMTP_USER` and `SMTP_USER_PASSWORD` (optional):
++
+-----------------------------------
+odo config set --env SMTP_USER="smtp_user_name@smtpserver.org"
+odo config set --env SMTP_USER_PASSWORD="****************"
+-----------------------------------
++
+Set `SMTP_TLS_CERT` and `SMTP_TLS_KEY` (optional):
 +
 -----------------------------------
 sed -i devfile.yaml -e "/- name: SMTP_TLS_CERT/{n;s|value: .*|value: $(jq -Rs . < client.crt | sed 's/\\/\\\\/g')|}"

--- a/notifier/helm/templates/_helpers.tpl
+++ b/notifier/helm/templates/_helpers.tpl
@@ -113,3 +113,14 @@ Image for redis
      {{- .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Generate SMTP secret name if not defined
+*/}}
+{{- define "babylon-notifier.smtpSecret" -}}
+  {{- if .Values.smtp.account.secretName }}
+    {{- .Values.smtp.account.secretName }}
+  {{- else }}
+    {{- include "babylon-notifier.name" . }}-smtp-credentials
+  {{- end }}
+{{- end -}}

--- a/notifier/helm/templates/deployment.yaml
+++ b/notifier/helm/templates/deployment.yaml
@@ -38,12 +38,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: smtp_account
-              name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+              name: {{ include "babylon-notifier.smtpSecret" . | quote }}
         - name: SMTP_USER_PASSWORD
           valueFrom:
             secretKeyRef:
               key: smtp_password
-              name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+              name: {{ include "babylon-notifier.smtpSecret" . | quote }}
         {{- end }}
         - name: REDIS_HOST
           value: {{ include "babylon-notifier.redisName" . | quote }}

--- a/notifier/helm/templates/deployment.yaml
+++ b/notifier/helm/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - name: SMTP_TLS_KEY_FILE
           value: /smtp-tls/tls.key
         {{- end }}
+        {{- if .Values.smtp.tlsca }}
+        - name: SMTP_TLS_CA_CERT_FILE
+          value: /smtp-tls-ca/tls-ca.crt
+        {{- end }}
         {{- if .Values.smtp.account }}
         - name: SMTP_USER
           valueFrom:
@@ -71,6 +75,11 @@ spec:
           mountPath: /smtp-tls
           readOnly: true
         {{- end }}
+        {{- if .Values.smtp.tlsca }}
+        - name: smtp-tls-ca
+          mountPath: /smtp-tls-ca
+          readOnly: true
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -96,5 +105,11 @@ spec:
         secret:
           defaultMode: 0440
           secretName: {{ include "babylon-notifier.name" . }}-tls
+      {{- end }}
+      {{- if .Values.smtp.tlsca }}
+      - name: smtp-tls-ca
+        secret:
+          defaultMode: 0440
+          secretName: {{ include "babylon-notifier.name" . }}-tls-ca
       {{- end }}
 {{ end }}

--- a/notifier/helm/templates/deployment.yaml
+++ b/notifier/helm/templates/deployment.yaml
@@ -27,10 +27,24 @@ spec:
           value: {{ required ".Values.smtp.host is required!" .Values.smtp.host | quote }}
         - name: SMTP_PORT
           value: {{ required ".Values.smtp.port is required!" .Values.smtp.port | quote }}
+        {{- if .Values.smtp.tls }}
         - name: SMTP_TLS_CERT_FILE
           value: /smtp-tls/tls.crt
         - name: SMTP_TLS_KEY_FILE
           value: /smtp-tls/tls.key
+        {{- end }}
+        {{- if .Values.smtp.account }}
+        - name: SMTP_USER
+          valueFrom:
+            secretKeyRef:
+              key: smtp_account
+              name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+        - name: SMTP_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: smtp_password
+              name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+        {{- end }}
         - name: REDIS_HOST
           value: {{ include "babylon-notifier.redisName" . | quote }}
         - name: REDIS_PASSWORD
@@ -52,9 +66,11 @@ spec:
             port: 8080
           timeoutSeconds: 1
         volumeMounts:
+        {{- if .Values.smtp.tls }}
         - name: smtp-tls
           mountPath: /smtp-tls
           readOnly: true
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -75,8 +91,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.smtp.tls }}
       - name: smtp-tls
         secret:
           defaultMode: 0440
           secretName: {{ include "babylon-notifier.name" . }}-tls
+      {{- end }}
 {{ end }}

--- a/notifier/helm/templates/smtp-secret.yaml
+++ b/notifier/helm/templates/smtp-secret.yaml
@@ -1,12 +1,14 @@
-{{ if .Values.smtp.account }}
+{{- if .Values.smtp.account }}
+{{- if .Values.smtp.account.generateSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+  name: {{ include "babylon-notifier.smtpSecret" . | quote }}
   namespace: {{ include "babylon-notifier.namespaceName" . }}
   labels:
     {{- include "babylon-notifier.labels" . | nindent 4 }}
 data:
   smtp_account: {{ required ".Values.smtp.account.username is required!" .Values.smtp.account.username | b64enc }}
   smtp_password: {{ required ".Values.smtp.account.password is required!" .Values.smtp.account.password | b64enc }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/notifier/helm/templates/smtp-secret.yaml
+++ b/notifier/helm/templates/smtp-secret.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.smtp.account }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "babylon-notifier.name" . }}-smtp-credentials
+  namespace: {{ include "babylon-notifier.namespaceName" . }}
+  labels:
+    {{- include "babylon-notifier.labels" . | nindent 4 }}
+data:
+  smtp_account: {{ required ".Values.smtp.account.username is required!" .Values.smtp.account.username | b64enc }}
+  smtp_password: {{ required ".Values.smtp.account.password is required!" .Values.smtp.account.password | b64enc }}
+{{ end }}

--- a/notifier/helm/templates/tls-ca-secret.yaml
+++ b/notifier/helm/templates/tls-ca-secret.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.smtp.tlsca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "babylon-notifier.name" . }}-tls-ca
+  namespace: {{ include "babylon-notifier.namespaceName" . }}
+  labels:
+    {{- include "babylon-notifier.labels" . | nindent 4 }}
+data:
+  tls-ca.crt: {{ required ".Values.smtp.tlsca.crt is required!" .Values.smtp.tlsca.crt | b64enc }}
+{{ end }}

--- a/notifier/helm/values.yaml
+++ b/notifier/helm/values.yaml
@@ -39,6 +39,8 @@ smtp:
   #tls:
   #  crt:
   #  key:
+  # tlsca:
+    # crt:
   # account:
     # generateSecret: false
     # secretName: # default use chart name + '-smtp-credentials'

--- a/notifier/helm/values.yaml
+++ b/notifier/helm/values.yaml
@@ -27,12 +27,23 @@ serviceAccount:
   name:
 
 smtp:
+  # account - Specifies account details for SMTP server authentication (optional)
+  # account.generateSecret - Whether new secret with SMTP username/password will be generated.
+  #                  Will try to mount secret with "secretName" if generateSecret == false
+  # account.secretName - Override default secret name (chart name + '-smtp-credentials')
+  # account.username - Account used for the SMTP server authentication
+  # account.password - Password used for the SMTP Server authentication
   from:
   host:
   port: 25
   #tls:
   #  crt:
   #  key:
+  # account:
+    # generateSecret: false
+    # secretName: # default use chart name + '-smtp-credentials'
+    # username:
+    # password:
 
 resources:
   limits:

--- a/notifier/operator/operator.py
+++ b/notifier/operator/operator.py
@@ -43,6 +43,8 @@ smtp_host = os.environ.get('SMTP_HOST', None)
 smtp_port = int(os.environ.get('SMTP_PORT', 25))
 smtp_user = os.environ.get('SMTP_USER', None)
 smtp_user_password = os.environ.get('SMTP_USER_PASSWORD', None)
+smtp_tls_ca_cert = os.environ.get('SMTP_TLS_CA_CERT', None)
+smtp_tls_ca_cert_file = os.environ.get('SMTP_TLS_CA_CERT_FILE', None)
 smtp_tls_cert = os.environ.get('SMTP_TLS_CERT', None)
 smtp_tls_cert_file = os.environ.get('SMTP_TLS_CERT_FILE', None)
 smtp_tls_key = os.environ.get('SMTP_TLS_KEY', None)
@@ -63,7 +65,10 @@ if smtp_tls_cert:
     with open(smtp_tls_cert_fd, 'w') as f:
         f.write(f"{smtp_tls_cert}\n{smtp_tls_key}\n")
 
-tls_context = smtplib.ssl.create_default_context()
+tls_context = smtplib.ssl.create_default_context(
+    cadata = smtp_tls_ca_cert,
+    cafile = smtp_tls_ca_cert_file,
+)
 
 if smtp_tls_cert_file and smtp_tls_key_file:
     tls_context.load_cert_chain(smtp_tls_cert_file, smtp_tls_key_file)

--- a/notifier/operator/operator.py
+++ b/notifier/operator/operator.py
@@ -41,6 +41,8 @@ redis_port = int(os.environ.get('REDIS_PORT', 6379))
 smtp_from = os.environ.get('SMTP_FROM', None)
 smtp_host = os.environ.get('SMTP_HOST', None)
 smtp_port = int(os.environ.get('SMTP_PORT', 25))
+smtp_user = os.environ.get('SMTP_USER', None)
+smtp_user_password = os.environ.get('SMTP_USER_PASSWORD', None)
 smtp_tls_cert = os.environ.get('SMTP_TLS_CERT', None)
 smtp_tls_cert_file = os.environ.get('SMTP_TLS_CERT_FILE', None)
 smtp_tls_key = os.environ.get('SMTP_TLS_KEY', None)
@@ -54,10 +56,6 @@ if not smtp_from:
     raise Exception('Environment variable SMTP_FROM must be set')
 if not smtp_host:
     raise Exception('Environment variable SMTP_HOST must be set')
-if not smtp_tls_cert and not smtp_tls_cert_file:
-    raise Exception('Environment variable SMTP_TLS_CERT or SMTP_TLS_CERT_FILE must be set')
-if not smtp_tls_key and not smtp_tls_key_file:
-    raise Exception('Environment variable SMTP_TLS_KEY or SMTP_TLS_KEY_FILE must be set')
 
 # Write cert and key to tmp file and load
 if smtp_tls_cert:
@@ -65,8 +63,10 @@ if smtp_tls_cert:
     with open(smtp_tls_cert_fd, 'w') as f:
         f.write(f"{smtp_tls_cert}\n{smtp_tls_key}\n")
 
-tls_context = smtplib.ssl.SSLContext()
-tls_context.load_cert_chain(smtp_tls_cert_file, smtp_tls_key_file)
+tls_context = smtplib.ssl.create_default_context()
+
+if smtp_tls_cert_file and smtp_tls_key_file:
+    tls_context.load_cert_chain(smtp_tls_cert_file, smtp_tls_key_file)
 
 j2env = jinja2.Environment(
     loader = jinja2.FileSystemLoader([
@@ -741,4 +741,7 @@ def send_notification_email(
         port = smtp_port,
     ) as smtp:
         smtp.starttls(context = tls_context)
+        if smtp_user and smtp_user_password:
+            smtp.login(smtp_user, smtp_user_password)
         smtp.sendmail(smtp_from, to, msg.as_string())
+        smtp.quit()


### PR DESCRIPTION
Some SMTP servers (e.g. smtp.gmail.com) requires account authentication with password. Two optional environment variable `SMTP_USER` and `SMTP_USER_PASSWORD` were added in order to support it.

The `SMTP_TLS_CERT` and `SMTP_TLS_KEY` environment variables are not required for `smtp.gmail.com` server and they were made optional.

Helm Chart was updated to configure SMTP server accounts details e.g.:
```
smtp:
  account:
    generateSecret: true
    secretName: smtp-secret
    username: login@smtp-mail.org
    password: secret_password
```
where:
- `account` - Specifies account details for SMTP server authentication (optional)
- `account.generateSecret` - Whether new secret with SMTP username/password will be generated. Will try to mount secret with "secretName" if generateSecret == false
- `account.secretName` - Override default secret name (chart name + '-smtp-credentials')
- `account.username` - Account used for the SMTP server authentication
- `account.password` - Password used for the SMTP Server authentication