### PR TITLE
Adding parameter to specify if anarchy namespace should be created

### DIFF
--- a/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
+++ b/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
@@ -1,5 +1,5 @@
 {{ range $anarchyNamespace := .Values.anarchy.namespaces }}
-  {{- if or ($anarchyNamespace.create) (eq ($anarchyNamespace.create | toString) "<nil>") }}
+  {{- if or $anarchyNamespace.create (not (hasKey $anarchyNamespace "create")) }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
+++ b/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
@@ -1,10 +1,11 @@
 {{ range $anarchyNamespace := .Values.anarchy.namespaces }}
+  {{- if $anarchyNamespace.create }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $anarchyNamespace.name }}
-  {{- with $anarchyCommune := $anarchyNamespace.commune }}
+    {{- with $anarchyCommune := $anarchyNamespace.commune }}
   annotations:
     helm.sh/resource-policy: keep
     meta.helm.sh/release-name: {{ $anarchyNamespace.name }}
@@ -23,23 +24,24 @@ spec:
   namespace:
     create: false
     name: {{ $anarchyNamespace.name }}
-  {{- $anarchyCommune | toYaml | nindent 2 }}
+    {{- $anarchyCommune | toYaml | nindent 2 }}
   replicaCount: {{ $anarchyCommune.replicaCount | default 1 }}
   runners:
-    {{- range $anarchyRunner := ($anarchyCommune.runners | default (list (dict "name" "default"))) }}
+      {{- range $anarchyRunner := ($anarchyCommune.runners | default (list (dict "name" "default"))) }}
   - name: default
     minReplicas: {{ $anarchyRunner.minReplicas | default 1 }}
     resources:
-      {{- with $anarchyRunnerResources := ($anarchyRunner.resources | default (dict "_" "_")) }}
+        {{- with $anarchyRunnerResources := ($anarchyRunner.resources | default (dict "_" "_")) }}
       limits:
-        {{- with $anarchyRunnerResourceLimits := ($anarchyRunnerResources.limits | default (dict "_" "_")) }}
+          {{- with $anarchyRunnerResourceLimits := ($anarchyRunnerResources.limits | default (dict "_" "_")) }}
         cpu: "{{ $anarchyRunnerResourceLimits.cpu | default "1" }}"
         memory: "{{ $anarchyRunnerResourceLimits.memory | default "512Mi" }}"
-        {{- end }}
+          {{- end }}
       requests:
-        {{- with $anarchyRunnerResourceRequests := ($anarchyRunnerResources.requests | default (dict "_" "_")) }}
+          {{- with $anarchyRunnerResourceRequests := ($anarchyRunnerResources.requests | default (dict "_" "_")) }}
         cpu: "{{ $anarchyRunnerResourceRequests.cpu | default "500m" }}"
         memory: "{{ $anarchyRunnerResourceRequests.memory | default "256Mi" }}"
+          {{- end }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
+++ b/openshift/config/common/helm/babylon-config/templates/anarchy.yaml
@@ -1,5 +1,5 @@
 {{ range $anarchyNamespace := .Values.anarchy.namespaces }}
-  {{- if $anarchyNamespace.create }}
+  {{- if or ($anarchyNamespace.create) (eq ($anarchyNamespace.create | toString) "<nil>") }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/openshift/config/common/helm/babylon-config/values.yaml
+++ b/openshift/config/common/helm/babylon-config/values.yaml
@@ -1,4 +1,9 @@
 ---
+#
+# New namespace will be created if anarchy.namespaces[].create is boolean 'true' or
+# not defined. 
+
+
 anarchy:
   apiGroup: anarchy.gpte.redhat.com
   namespaces:

--- a/openshift/config/common/helm/babylon-config/values.yaml
+++ b/openshift/config/common/helm/babylon-config/values.yaml
@@ -3,6 +3,7 @@ anarchy:
   apiGroup: anarchy.gpte.redhat.com
   namespaces:
   - name: anarchy-operator
+    create: true
   secrets: []
 
 poolboy:


### PR DESCRIPTION
The `anarchy.namespace[].create` is define whether new namespace should be created or existent will be re-used.

If `anarchy.namespacep[].create` value is equal to boolean 'true' or undefined the namespace definition will be created by Helm. 