### PR TITLE
Bump babylon_anarchy_governor to v0.17.1

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,7 +1,7 @@
 # Component Versions
 agnosticv_operator_version: v0.29.0
 babylon_anarchy_version: v0.21.1
-babylon_anarchy_governor_version: v0.17.0
+babylon_anarchy_governor_version: v0.17.1
 poolboy_version: v1.1.3
 replik8s_version: v0.5.0
 user_namespace_operator_version: v0.3.1


### PR DESCRIPTION
- Adds no_log to ansible job check