### PR TITLE
bump agnosticv-operator version

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.30.2
+agnosticv_operator_version: v0.31.0
 babylon_anarchy_version: v0.22.4
 babylon_anarchy_governor_version: v0.17.1
 poolboy_version: v1.2.0


### PR DESCRIPTION
* includes: https://github.com/rhpds/agnosticv-operator/pull/124
2 new features:

1.
This change, if applied, adds a feature in agnosticv-operator to report back into all PRs, based on a certain kind of activity in commits. The feature will be enabled only on **integration**.

It gets the list of PRs from the list of new commits using the convention setup in https://github.com/rhpds/agnosticv/pull/7589 : All commits that start with the string Auto-merge #....

We parse only the new commits, so we process the list of PRs only once and should not comment more than once for a change.

We will use that in conjunction with the integration branch.

2.
Also introduce a new variable `quick_start: true|false` (default=false) to skip updating all catalog items at startup.

That feature will be enabled ad-hoc by admins when needed.