### PR TITLE
Bump agnosticv-operator to v0.31.8

### DIFF
--- a/openshift/config/common/vars.yaml
+++ b/openshift/config/common/vars.yaml
@@ -1,5 +1,5 @@
 # Component Versions
-agnosticv_operator_version: v0.31.7
+agnosticv_operator_version: v0.31.8
 babylon_anarchy_version: v0.22.4
 babylon_anarchy_governor_version: v0.17.1
 poolboy_version: v1.3.2


### PR DESCRIPTION
- Fixes start timestamp comparison in ResourceProvider