### PR TITLE
Fix PR comments when no component changes

### DIFF
--- a/agnosticv-operator/helm/crds/agnosticvcomponents.yaml
+++ b/agnosticv-operator/helm/crds/agnosticvcomponents.yaml
@@ -58,6 +58,10 @@ spec:
                 description: >-
                   Component path within AgnosticV repositiory.
                 type: string
+              pullRequestCommitHash:
+                description: >-
+                  Pull commit hash if component is managed by a pull request.
+                type: string
               pullRequestNumber:
                 description: >-
                   Pull request number if component is managed by a pull request.

--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -262,6 +262,10 @@ class AgnosticVComponent(KopfObject):
         return self.spec['path']
 
     @property
+    def pull_request_commit_hash(self):
+        return self.spec.get('pullRequestCommitHash')
+
+    @property
     def pull_request_number(self):
         return self.spec.get('pullRequestNumber')
 


### PR DESCRIPTION
- Track commit hash on components from pull requests.
- Comment back on PR on updated hash even when components are unchanged.