### PR TITLE
Add CatalogItem spec features

### DIFF
--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -486,10 +486,10 @@ class AgnosticVComponent(KopfObject):
                 },
             },
             "spec": {
-                #"category": self.catalog_category,
-                #"description": self.catalog_description,
-                #"icon": self.catalog_icon,
-                #"keywords": self.catalog_keywords,
+                "category": self.catalog_category,
+                "description": self.catalog_description,
+                "displayName": self.catalog_display_name,
+                "keywords": self.catalog_keywords,
                 "lastUpdate": self.last_update,
                 "lifespan": {
                     "default": self.lifespan_default,
@@ -507,6 +507,7 @@ class AgnosticVComponent(KopfObject):
         # FIXME - weird default behavior from agnosticv-operator
         if self.catalog_icon:
             definition['metadata']['annotations'][f"{Babylon.catalog_api_group}/icon"] = json.dumps(self.catalog_icon)
+            definition['spec']['icon'] = self.catalog_icon
         else:
             definition['metadata']['annotations'][f"{Babylon.catalog_api_group}/icon"] = ''
 
@@ -526,13 +527,14 @@ class AgnosticVComponent(KopfObject):
             definition['metadata']['labels'][f"{Babylon.catalog_api_group}/stage"] = self.stage
 
         for idx, linked_component in enumerate(self.linked_components):
-            #if not 'linkedComponents' in definition['spec']:
-            #    definition['spec']['linkedComponents'] = []
+            if not 'linkedComponents' in definition['spec']:
+                definition['spec']['linkedComponents'] = []
 
-            #definition['spec']['linkedComponents'].append({
-            #    "displayName": linked_component.display_name,
-            #    "name": linked_component.name,
-            #})
+            definition['spec']['linkedComponents'].append({
+                "name": linked_component.name,
+            })
+            if linked_component.display_name:
+                definition['spec']['linkedComponents'][-1]['displayName'] = linked_component.display_name
 
             definition['spec']['resources'].append({
                 "name": linked_component.name or linked_component.short_name,

--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -160,6 +160,10 @@ class AgnosticVComponent(KopfObject):
         return self.catalog_meta.get('display_name', self.name)
 
     @property
+    def catalog_external_url(self):
+        return self.catalog_meta.get('externalUrl')
+
+    @property
     def catalog_icon(self):
         # FIXME - default icon dict?
         return self.catalog_meta.get('icon', {})
@@ -511,6 +515,9 @@ class AgnosticVComponent(KopfObject):
 
         if self.bookbag:
             definition['spec']['bookbag'] = self.bookbag
+
+        if self.catalog_external_url:
+            definition['spec']['externalUrl'] = self.catalog_external_url
 
         for key, value in self.catalog_labels.items():
             definition['metadata']['labels'][f"{Babylon.catalog_api_group}/{key}"] = value
@@ -1207,9 +1214,10 @@ class AgnosticVComponent(KopfObject):
         await self.manage_config(logger=logger)
 
     async def manage_config(self, logger):
-        await self.__manage_anarchy_governor(logger=logger)
         await self.__manage_catalog_item(logger=logger)
-        await self.__manage_resource_provider(logger=logger)
+        if not self.catalog_external_url:
+            await self.__manage_anarchy_governor(logger=logger)
+            await self.__manage_resource_provider(logger=logger)
 
 
 class LinkedComponent:


### PR DESCRIPTION
- Add support for `__meta__.catalog.externalUrl`
- Add CatalogItem attributes to `spec` that are currently in `metadata.attributes`