### PR TITLE
Add support for ssh secret with ssh-privatekey

### DIFF
--- a/agnosticv-operator/helm/crds/agnosticvrepos.yaml
+++ b/agnosticv-operator/helm/crds/agnosticvrepos.yaml
@@ -168,7 +168,7 @@ spec:
                 type: string
               sshKey:
                 description: >-
-                  Secret name containing Git access key in `id_rsa` data.
+                  Secret name containing Git access key in `id_rsa` or `ssh-privatekey` data.
                 type: string
               url:
                 description: >-

--- a/agnosticv-operator/operator/agnosticvrepo.py
+++ b/agnosticv-operator/operator/agnosticvrepo.py
@@ -381,10 +381,10 @@ class AgnosticVRepo(CachedKopfObject):
             name = self.ssh_key_secret_name,
             namespace = self.namespace
         )
-        secret_data = secret.data.get('id_rsa')
+        secret_data = secret.data.get('ssh-privatekey', secret.data.get('id_rsa'))
         if not secret_data:
             raise kopf.TemporaryError(
-                f"Secret {self.ssh_key_secret_name} does not have id_rsa in data",
+                f"Secret {self.ssh_key_secret_name} does not have ssh-privatekey or id_rsa in data",
                 delay = 600,
             )
         return b64decode(secret_data).decode('utf-8')


### PR DESCRIPTION
The kubernetes-secret-generator tool generates SSH keypairs with secrets using the keys "ssh-privatekey" and "ssh-publickey". This change adds support for using kubernetes-secret-generator with agnosticv-operator deploy key secrets.