### PR TITLE
Add WorkshopUserAssignment objects for babylon-workshop-manager

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -105,7 +105,8 @@ spec:
                 type: boolean
               userAssignments:
                 description: >-
-                  Users for multi-user workshop environments.
+                  Deprecated in favor of WorkshopUserAssignments objects.
+                  This value will be kept up to date in the current release while synchronizing to the new objects.
                 type: array
                 items:
                   type: object

--- a/helm/crds/workshopuserassignments.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshopuserassignments.babylon.gpte.redhat.com.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workshopuserassignments.babylon.gpte.redhat.com
+spec:
+  conversion:
+    strategy: None
+  group: babylon.gpte.redhat.com
+  names:
+    kind: WorkshopUserAssignment
+    listKind: WorkshopUserAssignmentList
+    plural: workshopuserassignments
+    singular: workshopuserassignment
+  scope: Namespaced
+  versions:
+  - name: v1
+    additionalPrinterColumns:
+    - name: ResourceClaim
+      type: string
+      jsonPath: .spec.resourceClaimName
+    - name: User
+      type: string
+      jsonPath: .spec.userName
+    - name: Assignment
+      type: string
+      jsonPath: .spec.assignment.email
+    schema:
+      openAPIV3Schema:
+        description: >-
+          Workshop user assignment for a workshop which may represent an assigned seat to a user or an available, unassigned, seat.
+        required:
+        - resourceClaimName
+        - workshopName
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            properties:
+              name:
+                maxLength: 63
+                pattern: ^[a-z0-9A-Z]([a-z0-9A-Z\-._]*[a-z0-9A-Z])?$
+                type: string
+            type: object
+          spec:
+            description: Specification of WorkshopUserAssignment.
+            type: object
+            properties:
+              assignment:
+                description: >-
+                  Assignment for workshop participant.
+                type: object
+                required:
+                - email
+                properties:
+                  email:
+                    description: >-
+                      Email address used to identify workshop participant.
+                    type: string
+              data:
+                description: >-
+                  Any data items reported for the user from the service provisioning.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              labUserInterface:
+                description: >-
+                  Lab user interface information for user access.
+                type: object
+                properties:
+                  redirect:
+                    description: >-
+                      Configure that users should be automatically redirected to the lab user interface.
+                    type: boolean
+                  url:
+                    description: >-
+                      URL for the lab user interface.
+                    type: string
+              messages:
+                description: >-
+                  Any messages reported for the user from the service provisioning.
+                type: string
+              resourceClaimName:
+                description: >-
+                  ResourceClaim name.
+                type: string
+              userName:
+                description: >-
+                  User name for lab as reported from the service provisioning.
+                type: string
+              workshopName:
+                description: >-
+                  Workshop name reference.
+                type: string
+          status:
+            description: Status of Workshop
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              diffBase:
+                description: Kopf diffbase
+                type: string
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/workshopManager/clusterrole.yaml
+++ b/helm/templates/workshopManager/clusterrole.yaml
@@ -59,6 +59,8 @@ rules:
   - workshops/status
   - workshopprovisions
   - workshopprovisions/status
+  - workshopuserassignments
+  - workshopuserassignments/status
   verbs:
   - create
   - delete

--- a/workshop-manager/Dockerfile
+++ b/workshop-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-cop/python-kopf-s2i:v1.36
+FROM quay.io/redhat-cop/python-kopf-s2i:v1.37
 
 USER root
 

--- a/workshop-manager/build-template.yaml
+++ b/workshop-manager/build-template.yaml
@@ -14,7 +14,7 @@ parameters:
 - name: GIT_REF
   value: main
 - name: KOPF_S2I_IMAGE
-  value: quay.io/redhat-cop/python-kopf-s2i:v1.36
+  value: quay.io/redhat-cop/python-kopf-s2i:v1.37
 
 objects:
 - apiVersion: image.openshift.io/v1

--- a/workshop-manager/helm/templates/rbac.yaml
+++ b/workshop-manager/helm/templates/rbac.yaml
@@ -55,6 +55,8 @@ rules:
   - workshops/status
   - workshopprovisions
   - workshopprovisions/status
+  - workshopuserassignments
+  - workshoppuserassignments/status
   verbs:
   - create
   - delete

--- a/workshop-manager/operator/babylon.py
+++ b/workshop-manager/operator/babylon.py
@@ -19,16 +19,18 @@ class Babylon():
     lab_ui_url_annotation = f"{babylon_domain}/labUserInterfaceUrl"
     lab_ui_urls_annotation = f"{babylon_domain}/labUserInterfaceUrls"
     notifier_annotation = f"{babylon_domain}/notifier"
+    purpose_annotation = f"{demo_domain}/purpose"
+    purpose_activity_annotation = f"{demo_domain}/purpose-activity"
     requester_annotation = f"{babylon_domain}/requester"
+    resource_claim_label = f"{poolboy_domain}/resource-claim"
     resource_pool_annotation = f"{poolboy_domain}/resource-pool-name"
     url_annotation = f"{babylon_domain}/url"
     workshop_label = f"{babylon_domain}/workshop"
     workshop_id_label = f"{babylon_domain}/workshop-id"
     workshop_uid_label = f"{babylon_domain}/workshop-uid"
     workshop_provision_label = f"{babylon_domain}/workshop-provision"
-    purpose_annotation = f"{demo_domain}/purpose"
-    purpose_activity_annotation = f"{demo_domain}/purpose-activity"
     salesforce_id_annotation = f"{demo_domain}/salesforce-id"
+    user_name_label = f"{babylon_domain}/user-name"
 
     @classmethod
     async def on_cleanup(cls):

--- a/workshop-manager/operator/cachedkopfobject.py
+++ b/workshop-manager/operator/cachedkopfobject.py
@@ -5,8 +5,12 @@ from kopfobject import KopfObject
 
 class CachedKopfObject(KopfObject):
     @classmethod
+    def cache_key_from_kwargs(cls, name, namespace, **kwargs):
+        return (namespace, name)
+
+    @classmethod
     def load(cls, name, namespace, **kwargs):
-        key = (namespace, name)
+        key = cls.cache_key_from_kwargs(name=name, namespace=namespace, **kwargs)
         obj = cls.cache.get(key)
         if obj:
             obj.update(**kwargs)
@@ -26,6 +30,22 @@ class CachedKopfObject(KopfObject):
         return obj
 
     @classmethod
+    async def list(cls, namespace, label_selector=None):
+        async for definition in cls.list_definitions(namespace=namespace, label_selector=label_selector):
+            cache_key = cls.cache_key_from_kwargs(
+                name = definition['metadata']['name'],
+                namespace = definition['metadata'].get('namespace'),
+                spec = definition.get('spec'),
+            )
+            obj = cls.cache.get(cache_key)
+            if obj:
+                obj.update_from_definition(definition)
+            else:
+                obj = cls.from_definition(definition)
+                cls.cache[obj.cache_key] = obj
+            yield obj
+
+    @classmethod
     async def preload(cls):
         _continue = None
         while True:
@@ -38,7 +58,7 @@ class CachedKopfObject(KopfObject):
             )
             for definition in obj_list.get('items', []):
                 obj = cls.from_definition(definition)
-                cls.cache[(obj.namespace, obj.name)] = obj
+                cls.cache[obj.cache_key] = obj
             _continue = obj_list['metadata'].get('continue')
             if not _continue:
                 return
@@ -46,3 +66,11 @@ class CachedKopfObject(KopfObject):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.lock = asyncio.Lock()
+
+    @property
+    def cache_key(self):
+        return (self.namespace, self.name)
+
+    async def delete(self):
+        await super().delete()
+        self.cache.pop(self.cache_key)

--- a/workshop-manager/operator/k8sobject.py
+++ b/workshop-manager/operator/k8sobject.py
@@ -61,6 +61,10 @@ class K8sObject:
         return self.metadata.get('annotations', {})
 
     @property
+    def api_group_version(self):
+        return f"{self.api_group}/{self.api_version}"
+
+    @property
     def creation_datetime(self):
         return datetime.strptime(
             self.creation_timestamp, '%Y-%m-%dT%H:%M:%SZ'
@@ -93,6 +97,19 @@ class K8sObject:
     @property
     def status(self):
         return self.definition.get('status', {})
+
+    @property
+    def uid(self):
+        return self.metadata['uid']
+
+    def as_owner_ref(self):
+        return {
+            "apiVersion": self.api_group_version,
+            "controller": True,
+            "kind": self.kind,
+            "name": self.name,
+            "uid": self.uid,
+        }
 
     async def delete(self):
         try:

--- a/workshop-manager/operator/kopfobject.py
+++ b/workshop-manager/operator/kopfobject.py
@@ -34,6 +34,30 @@ class KopfObject:
             version = cls.api_version,
         )
 
+    @classmethod
+    async def list(cls, namespace, label_selector=None):
+        async for definition in cls.list_definitions(namespace=namespace, label_selector=label_selector):
+            yield cls.from_definition(definition)
+
+    @classmethod
+    async def list_definitions(cls, namespace, label_selector=None):
+        _continue = None
+        while True:
+            obj_list = await Babylon.custom_objects_api.list_namespaced_custom_object(
+                group = cls.api_group,
+                label_selector = label_selector,
+                namespace = namespace,
+                plural = cls.plural,
+                version = cls.api_version,
+                limit = 20,
+                _continue = _continue
+            )
+            for definition in obj_list.get('items', []):
+                yield definition
+            _continue = obj_list['metadata'].get('continue')
+            if not _continue:
+                return
+
     def __init__(self, annotations, labels, meta, name, namespace, spec, status, uid, definition=None, **_):
         self.annotations = annotations
         self.definition = definition

--- a/workshop-manager/operator/userassignment.py
+++ b/workshop-manager/operator/userassignment.py
@@ -10,13 +10,17 @@ class UserAssignment:
         user_name = None,
     ):
         if definition:
+            self.assignment = definition.get('assignment')
             self.data = definition.get('data')
             self.messages = definition.get('messages')
             self.resource_claim_name = definition.get('resourceClaimName')
             self.user_name = definition.get('userName')
             if 'labUserInterface' in definition:
                 self.lab_user_interface = LabUserInterface(definition=definition['labUserInterface'])
+            else:
+                self.lab_user_interface = None
         else:
+            self.assignment = None
             self.data = data
             self.lab_user_interface = lab_user_interface
             self.messages = messages

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -204,6 +204,7 @@ class WorkshopProvision(CachedKopfObject):
 
     async def handle_resume(self, logger):
         async with self.lock:
+            logger.info(f"Handling resume for {self}")
             await self.set_owner_references(logger=logger)
 
     async def handle_update(self, logger):
@@ -281,6 +282,7 @@ class WorkshopProvision(CachedKopfObject):
 
         resource_claim_count = 0
         provisioning_count = 0
+
         async for resource_claim in self.list_resource_claims():
             resource_claim_count += 1
             await resource_claim.adjust_action_schedule_and_lifetime(
@@ -289,12 +291,7 @@ class WorkshopProvision(CachedKopfObject):
                 start_datetime = self.action_schedule_start,
                 stop_datetime = self.action_schedule_stop,
             )
-            if resource_claim.provision_complete:
-                await workshop.manage_user_assignments_for_resource_claim(
-                    logger = logger,
-                    resource_claim = resource_claim,
-                )
-            else:
+            if not resource_claim.provision_complete:
                 provisioning_count += 1
 
         # Do not start any provisions if lifespan start is in the future

--- a/workshop-manager/operator/workshopuserassignment.py
+++ b/workshop-manager/operator/workshopuserassignment.py
@@ -1,0 +1,203 @@
+import kopf
+import kubernetes_asyncio
+
+from babylon import Babylon
+from cachedkopfobject import CachedKopfObject
+from labuserinterface import LabUserInterface
+
+import resourceclaim
+import workshop as workshop_import
+
+class WorkshopUserAssignment(CachedKopfObject):
+    api_group = Babylon.babylon_domain
+    api_version = Babylon.babylon_api_version
+    kind = 'WorkshopUserAssignment'
+    plural = 'workshopuserassignments'
+
+    cache = {}
+
+    @classmethod
+    def cache_key_from_kwargs(cls, namespace, spec, **kwargs):
+        return (namespace, spec['workshopName'], spec.get('resourceClaimName'), spec.get('userName'))
+
+    @classmethod
+    async def delete_for_resource_claim(cls, namespace, resource_claim_name, logger):
+        async for workshop_user_assignment in cls.list(
+            label_selector = f"{Babylon.resource_claim_label}={resource_claim_name}",
+            namespace = namespace,
+        ):
+            await workshop_user_assignment.delete()
+
+    @classmethod
+    async def find(cls, namespace, workshop_name, resource_claim_name=None, user_name=None):
+        cache_key = (namespace, workshop_name, resource_claim_name, user_name)
+        obj = cls.cache.get(cache_key)
+        if obj:
+            return obj
+
+        label_selector = f"{Babylon.workshop_label}={workshop_name}"
+        if resource_claim_name:
+            label_selector += f",{Babylon.resource_claim_label}={resource_claim_name}"
+        else:
+            label_selector += f",!{Babylon.resource_claim_label}"
+        if user_name:
+            label_selector += f",{Babylon.user_name_label}={user_name}"
+        else:
+            label_selector += f",!{Babylon.user_name_label}"
+        obj_list = await Babylon.custom_objects_api.list_namespaced_custom_object(
+            group = cls.api_group,
+            namespace = namespace,
+            plural = cls.plural,
+            version = cls.api_version,
+            label_selector = label_selector,
+        )
+        items = obj_list.get('items', [])
+        if not items:
+            return None
+
+        obj = cls.from_definition(items[0])
+        cls.cache[cache_key] = obj
+        return obj
+
+    @classmethod
+    async def create(cls, namespace, resource_claim, workshop_name,
+        assignment=None,
+        data={},
+        lab_user_interface=None,
+        messages=None,
+        user_name=None,
+    ):
+        definition = {
+            "apiVersion": f"{cls.api_group}/{cls.api_version}",
+            "kind": cls.kind,
+            "metadata": {
+                "generateName": f"{workshop_name}-",
+                "labels": {
+                    Babylon.workshop_label: workshop_name,
+                    Babylon.resource_claim_label: resource_claim.name,
+                },
+                "ownerReferences": [resource_claim.as_owner_ref()],
+            },
+            "spec": {
+                "data": data,
+                "resourceClaimName": resource_claim.name,
+                "workshopName": workshop_name,
+            }
+        }
+        if assignment:
+            definition['spec']['assignment'] = assignment
+        if lab_user_interface:
+            definition['spec']['labUserInterface'] = lab_user_interface.serialize()
+        if messages:
+            definition['spec']['messages'] = messages
+        if user_name:
+            definition['metadata']['labels'][Babylon.user_name_label] = user_name
+            definition['spec']['userName'] = user_name
+
+        definition = await Babylon.custom_objects_api.create_namespaced_custom_object(
+            group = cls.api_group,
+            namespace = namespace,
+            plural = cls.plural,
+            version = cls.api_version,
+            body = definition,
+        )
+        obj = cls.from_definition(definition)
+        cls.cache[obj.cache_key] = obj
+        return obj
+
+    @property
+    def cache_key(self):
+        return (self.namespace, self.workshop_name, self.resource_claim_name, self.user_name)
+
+    @property
+    def data(self):
+        return self.spec.get('data', {})
+
+    @property
+    def lab_user_interface(self):
+        if 'labUserInterface' in self.spec:
+            return LabUserInterface(definition=self.spec['labUserInterface'])
+
+    @property
+    def messages(self):
+        return self.spec.get('messages')
+
+    @property
+    def resource_claim_name(self):
+        return self.spec.get('resourceClaimName')
+
+    @property
+    def user_name(self):
+        return self.spec.get('userName')
+
+    @property
+    def workshop_name(self):
+        return self.spec.get('workshopName')
+
+    async def copy_to_workshop(self):
+        try:
+            workshop = await self.get_workshop()
+        except kubernetes_asyncio.client.rest.ApiException as exception:
+            if exception.status == 404:
+                raise kopf.TemporaryError(f"Workshop {self.workshop_name} was not found.", delay=60)
+            raise
+
+        async with workshop.lock:
+            index = None
+            for loop_index, user_entry in enumerate(workshop.spec.get('userAssignments', [])):
+                if (
+                    user_entry.get('resourceClaimName') == self.resource_claim_name and
+                    user_entry.get('userName') == self.user_name
+                ):
+                    index = loop_index
+                    break
+
+            json_patch_item = {
+                "value": {
+                    key: value for key, value in self.spec.items() if key != 'workshopName'
+                }
+            }
+            if index != None:
+                json_patch_item['op'] = 'replace'
+                json_patch_item['path'] = f"/spec/userAssignments/{index}"
+            else:
+                json_patch_item['op'] = 'add'
+                json_patch_item['path'] = '/spec/userAssignments/-'
+
+            await workshop.json_patch([json_patch_item])
+
+    async def get_workshop(self):
+        return await workshop_import.Workshop.get(name=self.workshop_name, namespace=self.namespace)
+
+    async def handle_create(self, logger):
+        async with self.lock:
+            logger.info(f"Handling create for {self}")
+            await self.copy_to_workshop()
+
+    async def handle_delete(self, logger):
+        async with self.lock:
+            logger.info(f"Handling create for {self}")
+            await self.remove_from_workshop()
+
+    async def handle_update(self, logger):
+        async with self.lock:
+            logger.info(f"Handling create for {self}")
+            await self.copy_to_workshop()
+
+    async def remove_from_workshop(self):
+        try:
+            workshop = await self.get_workshop()
+            async with workshop.lock:
+                for loop_index, user_entry in reversed(list(enumerate(workshop.spec.get('userAssignments', [])))):
+                    if (
+                        user_entry.get('resourceClaimName') == self.resource_claim_name and
+                        user_entry.get('userName') == self.user_name
+                    ):
+                        await workshop.json_patch([{
+                            "op": "remove",
+                            "path": f"/spec/userAssignments/{loop_index}",
+                        }])
+                        break
+        except kubernetes_asyncio.client.rest.ApiException as exception:
+            if exception.status != 404:
+                raise


### PR DESCRIPTION
This is the first step towards removing the limit on the number of users supported in a workshop by moving the user assignments out of the Workshop. This version makes the WorkshopUserAssignment objects the source of truth while replicating updates from the Workshop `spec.userAssignments` to WorkshopUserAssignment objects for compatibility.