### PR TITLE
Failed workshop items rerun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ notifier/values.yaml
 *.key
 *.swp
 __pycache__
+.vscode

--- a/workshop-manager/operator/babylon.py
+++ b/workshop-manager/operator/babylon.py
@@ -32,6 +32,8 @@ class Babylon():
     salesforce_id_annotation = f"{demo_domain}/salesforce-id"
     user_name_label = f"{babylon_domain}/user-name"
 
+    workshop_fail_percentage_threshold = int(os.environ.get('WORKSHOP_FAIL_PERCENTAGE_THRESHOLD', 60))
+
     @classmethod
     async def on_cleanup(cls):
         await cls.core_v1_api.api_client.close()

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -47,6 +47,10 @@ class WorkshopProvision(CachedKopfObject):
         return datetime.strptime(
             stop_timestamp, '%Y-%m-%dT%H:%M:%SZ'
         ).replace(tzinfo=timezone.utc)
+    
+    @property
+    def auto_detach_condition(self):
+        return self.spec.get('autoDetach', {}).get('when')
 
     @property
     def catalog_item_name(self):
@@ -139,6 +143,9 @@ class WorkshopProvision(CachedKopfObject):
                 "resources": deepcopy(catalog_item.resources)
             }
         }
+
+        if self.auto_detach_condition:
+            resource_claim_definition['spec']['autoDetach'] = {"when": self.auto_detach_condition}
 
         if workshop.requester:
             resource_claim_definition['metadata']['annotations'][Babylon.requester_annotation] = workshop.requester

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -303,9 +303,9 @@ class WorkshopProvision(CachedKopfObject):
             return
 
         # Do not start any provisions if failure threshold is exceeded
-        failure_threshold = 60
-        if failure_threshold <= failed_count / self.count * 100:
-            return
+        if self.count != 0:
+            if Babylon.workshop_fail_percentage_threshold <= failed_count / self.count * 100:
+                return
 
         # Start provisions up to count and within concurrency limit
         if resource_claim_count < (self.count + failed_count) and provisioning_count < self.concurrency:


### PR DESCRIPTION
Workshop items will be rerun if some of them fail. This will guarantee that the requested amount matches the provisioned amount.

- Added a ResourceClaim property to check for the failed state.
- A threshold percentage can be set using the WORKSHOP_FAIL_PERCENTAGE_THRESHOLD environment variable (defaults to 60%). This will stop the rerun functionality to avoid an infinite provision loop if the failure rate exceeds the threshold.
- The `autoDetach` property status will be propagated from the `WorkshopProvision` instances to the `ResourceClaim` instances.