### PR TITLE
Adding workshop provisioning reporting

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -149,6 +149,18 @@ spec:
                   total:
                     description: Total user assignments for workshop.
                     type: integer
+              provisionCount:
+                type: object
+                properties:
+                  provisioning:
+                    description: Number of WorkshopProvisions that are provisioning.
+                    type: integer
+                  failed:
+                    description: Number of WorkshopProvisions that have failed.
+                    type: integer
+                  completed:
+                    description: Number of WorkshopProvisions that have completed.
+                    type: integer
         required:
         - apiVersion
         - kind

--- a/workshop-manager/operator/resourceclaim.py
+++ b/workshop-manager/operator/resourceclaim.py
@@ -37,7 +37,7 @@ class ResourceClaim(K8sObject):
             await resource_claim.delete_workshop_user_assignments(logger=logger)
             return
 
-        if not resource_claim.provision_complete:
+        if not resource_claim.provision_complete or resource_claim.is_failed:
             return
 
         try:

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -203,3 +203,13 @@ class Workshop(CachedKopfObject):
                 "total": total_user_count,
             }
         })
+
+    async def update_provision_count(self, provisioning, failed, completed):
+
+        await self.merge_patch_status({
+            "provisionCount": {
+                "provisioning": provisioning,
+                "failed": failed,
+                "completed": completed,
+            }
+        })

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -309,6 +309,12 @@ class WorkshopProvision(CachedKopfObject):
             if resource_claim.is_failed:
                 failed_count += 1
 
+            await workshop.update_provision_count(
+                provisioning=provisioning_count,
+                failed=failed_count,
+                completed=resource_claim_count - provisioning_count - failed_count
+            )
+
         # Do not start any provisions if lifespan start is in the future
         if self.lifespan_start and self.lifespan_start > datetime.now(timezone.utc):
             return


### PR DESCRIPTION
Adding provisioning reporting to the `workshop-manager`. This includes `provisionCount` status value to the  `workshops.babylon.gpte.redhat.com` CRD:

Example:
```
status:
  provisionCount:
    completed: 10
    failed: 3
    provisioning: 0
``` 