### PR TITLE
Bumping workshop-manager to v0.7.2

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -209,7 +209,7 @@ workshopManager:
   image:
     repository: quay.io/rhpds/babylon-workshop-manager
     pullPolicy: IfNotPresent
-    tag: v0.7.1
+    tag: v0.7.2
   namespace:
     create: true
     name: babylon-workshop-manager


### PR DESCRIPTION
Pushing new version for `workshop-manager` which include:

- Failure/Success reporting
- Fix for `userCount`

See https://github.com/redhat-cop/babylon/pull/2069