### PR TITLE
feat: Add support for reportingLabels in AgnosticV operator

### DIFF
--- a/agnosticv-operator/operator/babylon.py
+++ b/agnosticv-operator/operator/babylon.py
@@ -1,6 +1,8 @@
 import os
+
 import kubernetes_asyncio
 import yaml
+
 
 class Babylon():
     agnosticv_api_group = os.environ.get('AGNOSTICV_API_GROUP', 'gpte.redhat.com')
@@ -9,6 +11,8 @@ class Babylon():
     anarchy_version = os.environ.get('ANARCHY_VERSION', 'v1')
     catalog_api_group = os.environ.get('CATALOG_API_GROUP', 'babylon.gpte.redhat.com')
     catalog_version = os.environ.get('CATALOG_VERSION', 'v1')
+
+    reporting_domain = os.environ.get('REPORTING_DOMAIN', 'demo.redhat.com')
     resource_broker_api_group = os.environ.get('RESOURCE_BROKER_API_GROUP', 'poolboy.gpte.redhat.com')
     resource_broker_version = os.environ.get('RESOURCE_BROKER_VERSION', 'v1')
     resource_broker_namespace = os.environ.get('RESOURCE_BROKER_NAMESPACE', 'poolboy')


### PR DESCRIPTION
### Summary
This PR adds support for `reportingLabels` in the AgnosticV operator, allowing the inclusion of reporting-specific labels in catalog item metadata. These labels will help with the categorization and filtering of catalog items for reporting and analytics.

### Changes
- Added a new property `reportingLabels` to the `AgnosticVComponent` class, which processes and formats the reporting labels.
- Updated the `Babylon` class to include a new `reporting_domain` used for prefixing reporting labels in metadata.
- Modified the metadata labeling process to append the reporting labels to the catalog item’s metadata.
