### PR TITLE
feat: Add support for catalog item owners in AgnosticV Operator

### DIFF
--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -225,7 +225,7 @@ class AgnosticVComponent(KopfObject):
 
     @property
     def catalog_owners(self):
-        return self.__meta__.get('owners', [])
+        return self.__meta__.get('owners', {})
 
     @property
     def catalog_parameters(self):

--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -224,6 +224,10 @@ class AgnosticVComponent(KopfObject):
         return self.catalog_meta.get('multiuser', False)
 
     @property
+    def catalog_owners(self):
+        return self.__meta__.get('owners', [])
+
+    @property
     def catalog_parameters(self):
         return self.catalog_meta.get('parameters')
 
@@ -588,6 +592,9 @@ class AgnosticVComponent(KopfObject):
 
             if self.catalog_multiuser:
                 definition['spec']['multiuser'] = True
+
+            if len(self.catalog_owners) > 0:
+                definition['spec']['owners'] = self.catalog_owners
 
             if self.catalog_workshop_ui_disabled:
                 definition['spec']['workshopUiDisabled'] = True


### PR DESCRIPTION
- Introduced a new property `catalog_owners` in the `AgnosticVComponent` class to retrieve the owners from the catalog metadata.