### PR TITLE
Update Workshop and ResourceClaims reporting

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -152,6 +152,9 @@ spec:
               provisionCount:
                 type: object
                 properties:
+                  ordered:
+                    description: Total number of WorkshopProvisions ordered.
+                    type: integer
                   provisioning:
                     description: Number of WorkshopProvisions that are provisioning.
                     type: integer

--- a/workshop-manager/operator/babylon.py
+++ b/workshop-manager/operator/babylon.py
@@ -8,7 +8,9 @@ class Babylon():
     poolboy_api_version = os.environ.get('POOLBOY_API_VERSION', 'v1')
     poolboy_namespace = os.environ.get('POOLBOY_NAMESPACE', 'poolboy')
     demo_domain = os.environ.get('DEMO_DOMAIN', 'demo.redhat.com')
+    gpte_domain = os.environ.get('GPTE_DOMAIN', 'gpte.redhat.com')
 
+    asset_uuid_label = f"{gpte_domain}/asset-uuid"
     babylon_ignore_label = f"{babylon_domain}/ignore"
     catalog_display_name_annotation = f"{babylon_domain}/catalogDisplayName"
     catalog_item_display_name_annotation = f"{babylon_domain}/catalogItemDisplayName"
@@ -20,9 +22,10 @@ class Babylon():
     lab_ui_url_annotation = f"{babylon_domain}/labUserInterfaceUrl"
     lab_ui_urls_annotation = f"{babylon_domain}/labUserInterfaceUrls"
     notifier_annotation = f"{babylon_domain}/notifier"
+    ordered_by_annotation = f"{demo_domain}/orderedBy"
     purpose_annotation = f"{demo_domain}/purpose"
     purpose_activity_annotation = f"{demo_domain}/purpose-activity"
-    requester_annotation = f"{babylon_domain}/requester"
+    requester_annotation = f"{demo_domain}/requester"
     resource_broker_ignore_label = f"{poolboy_domain}/ignore"
     resource_claim_label = f"{poolboy_domain}/resource-claim"
     resource_pool_annotation = f"{poolboy_domain}/resource-pool-name"

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -204,10 +204,11 @@ class Workshop(CachedKopfObject):
             }
         })
 
-    async def update_provision_count(self, provisioning, failed, completed):
+    async def update_provision_count(self, provisioning, failed, completed, ordered):
 
         await self.merge_patch_status({
             "provisionCount": {
+                "ordered": ordered,
                 "provisioning": provisioning,
                 "failed": failed,
                 "completed": completed,

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -41,6 +41,10 @@ class Workshop(CachedKopfObject):
         ).replace(tzinfo=timezone.utc)
 
     @property
+    def asset_uuid(self):
+        return self.labels.get(Babylon.asset_uuid_label)
+
+    @property
     def ignore(self):
         return Babylon.babylon_ignore_label in self.labels
 
@@ -69,6 +73,10 @@ class Workshop(CachedKopfObject):
     @property
     def requester(self):
         return self.annotations.get(Babylon.requester_annotation)
+
+    @property
+    def ordered_by(self):
+        return self.annotations.get(Babylon.ordered_by_annotation)
 
     @property
     def service_url(self):

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -320,6 +320,7 @@ class WorkshopProvision(CachedKopfObject):
                 failed_count += 1
 
             await workshop.update_provision_count(
+                ordered=self.count,
                 provisioning=provisioning_count,
                 failed=failed_count,
                 completed=resource_claim_count - provisioning_count - failed_count

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -157,8 +157,14 @@ class WorkshopProvision(CachedKopfObject):
         if not self.enable_resource_pools:
             resource_claim_definition['metadata']['annotations'][Babylon.resource_pool_annotation] = "disable"
 
+        if workshop.asset_uuid:
+            resource_claim_definition['metadata']['labels'][Babylon.asset_uuid_label] = workshop.asset_uuid
+
         if workshop.requester:
             resource_claim_definition['metadata']['annotations'][Babylon.requester_annotation] = workshop.requester
+
+        if workshop.ordered_by:
+            resource_claim_definition['metadata']['annotations'][Babylon.ordered_by_annotation] = workshop.ordered_by
 
         if catalog_item.lab_ui_type:
             resource_claim_definition['metadata']['labels'][Babylon.lab_ui_label] = catalog_item.lab_ui_type


### PR DESCRIPTION
This PR includes two changes:

1. Adding the provisionCount.ordered value to the workshop CRD. This value represents the total number of WorkshopProvision resources currently ordered.

Example:
```
apiVersion: babylon.gpte.redhat.com/v1
kind: Workshop
status:
  provisionCount:
    completed: 6
    failed: 0
    ordered: 10
    provisioning: 2
```

2. Replicate orderedBy, requester, and asset-uuid values from the Workshop to the ResourceClaim CR.

Example:
```
apiVersion: poolboy.gpte.redhat.com/v1
kind: ResourceClaim
metadata:
  annotations:
    demo.redhat.com/orderedBy: ordered_by_user@domain.com
    demo.redhat.com/requester: requester_user@domain.com

  labels:
    gpte.redhat.com/asset-uuid: 0cff3662-870e-4f99-ae12-dc5d4esa4532
```