### PR TITLE
Update types.ts: Make purpose parameter optional

### DIFF
--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -334,7 +334,7 @@ export interface ResourceClaimSpec {
 export interface ResourceClaimProvider {
   name: string;
   parameterValues: {
-    purpose: string;
+    purpose?: string;
     start_timestamp?: string;
     stop_timestamp?: string;
   };


### PR DESCRIPTION
Currently disabling purpose parameters, makes purpose to be set as null and validations fail.