### PR TITLE
Fix/workshop manager reporting

### DIFF
--- a/workshop-manager/.gitignore
+++ b/workshop-manager/.gitignore
@@ -1,3 +1,2 @@
-
-.odo/env
-.odo/odo-file-index.json
+.odo
+typings

--- a/workshop-manager/Development.adoc
+++ b/workshop-manager/Development.adoc
@@ -10,13 +10,41 @@ An Ansible test suite is available for functional testing.
 Use of `odo` is recommended for fast iterative development.
 `odo` simplifies the build/deploy process and avoids creating unnecessary build artifacts during the development process.
 
-. Install the `odo` developer CLI as described in the OpenShift documentation:
+Install the `odo` developer CLI as described in the OpenShift documentation:
 https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html[Installing odo]
+
+### Replace current deployment
+
+The most simple way is to downscale the current deployment and replace it with a development version using `odo`. This
+is useful since not requiring any additional resources (ClusterRole, ServiceAccount, etc.) and allows you to
+quickly iterate on the code.
+
+. Downscale the current deployment to 0 replicas:
++
+---------------------------------------------------
+oc scale deploy babylon-workshop-manager --replicas=0
+---------------------------------------------------
+
+. Run `odo` in the current project (the path where the `devfile.yaml` is located):
++
+---------------------------------------------------
+odo dev
+---------------------------------------------------
+
+. Cleanup. Upscale the current deployment back to 1 replica:
++---------------------------------------------------
+oc scale deploy babylon-workshop-manager --replicas=1
++---------------------------------------------------
+
+### Create a new development project
+This is useful if you want to keep the current deployment running while you develop a new version of the babylon-workshop-manager.
+
+#### Setup
 
 . Create a project for development using `odo`:
 +
 ---------------------------------------------------
-odo project create babylon-workshop-manager-dev
+oc new-project babylon-workshop-manager-dev
 ---------------------------------------------------
 
 . Create Babylon workshop-manager resources from the provided helm chart:
@@ -38,30 +66,28 @@ oc adm policy add-cluster-role-to-user babylon-workshop-manager-dev -z default
 . Setup `odo` from the provided `devfile.yaml`:
 +
 ---------------------------------
-odo create --devfile devfile.yaml
+odo dev
 ---------------------------------
 
-. Use `odo push` to push code into the odo container:
-+
---------
-odo push
---------
+[TIP]
+====
+Most likely required ClusterRole (e.g. `babylon-workshop-manager`) is already created
+by the existing deployment. In this case, you can skip the `helm template` step and just
+add the ClusterRole to the `default` service account.
+---------------------------------------------------
+oc adm policy add-cluster-role-to-user babylon-workshop-manager -z default
+---------------------------------------------------
+====
 
-. Cleanup
-+
-Remove `odo` component
-+
----------------------------------------------------
-odo delete --force babylon-workshop-manager-dev
----------------------------------------------------
-+
-Remove the `babylon-workshop-manager-dev` cluster role binding
+#### Cleanup
+
+. Remove the `babylon-workshop-manager-dev` cluster role binding
 +
 --------------------------------------------------------------------------------
 oc adm policy remove-cluster-role-from-user babylon-workshop-manager-dev -z default
 --------------------------------------------------------------------------------
 +
-Remove resources created from the helm template
+. Remove resources created from the helm template
 +
 -----------------------------------------------------
 helm template helm \

--- a/workshop-manager/helm/templates/rbac.yaml
+++ b/workshop-manager/helm/templates/rbac.yaml
@@ -87,6 +87,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - {{ .Values.poolboy.domain }}
+  resources:
+  - resourceproviders
+  verbs:
+  - get
+  - list
 {{ if .Values.deploy }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/workshop-manager/operator/k8sobject.py
+++ b/workshop-manager/operator/k8sobject.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-import kubernetes_asyncio
+from kubernetes_asyncio.client.rest import ApiException as k8sApiException
 
 from babylon import Babylon
 
@@ -121,7 +121,7 @@ class K8sObject:
                 version = self.api_version,
             )
             self.definition = definition
-        except kubernetes_asyncio.client.rest.ApiException as exception:
+        except k8sApiException as exception:
             if exception.status != 404:
                 raise
 

--- a/workshop-manager/operator/resourceclaim.py
+++ b/workshop-manager/operator/resourceclaim.py
@@ -3,7 +3,7 @@ import json
 from copy import deepcopy
 from datetime import datetime, timezone
 
-import kubernetes_asyncio
+from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
 from babylon import Babylon
 from k8sobject import K8sObject
@@ -41,7 +41,7 @@ class ResourceClaim(K8sObject):
 
         try:
             workshop = await resource_claim.get_workshop()
-        except kubernetes_asyncio.client.rest.ApiException as exception:
+        except k8sApiException as exception:
             if exception.status == 404:
                 logger.warning(
                     f"{resource_claim} references mising Workshop {resource_claim.workshop_name}"

--- a/workshop-manager/operator/resourceclaim.py
+++ b/workshop-manager/operator/resourceclaim.py
@@ -377,5 +377,6 @@ class ResourceClaim(K8sObject):
                     resource_claim = self,
                     user_name = user_assignment.user_name,
                     workshop_name = workshop.name,
+                    workshop_id=workshop.workshop_id,
                 )
                 logger.info(f"Created {workshop_user_assignment} for {workshop} {self}")

--- a/workshop-manager/operator/workshopuserassignment.py
+++ b/workshop-manager/operator/workshopuserassignment.py
@@ -1,11 +1,10 @@
 import kopf
-import kubernetes_asyncio
+from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
 from babylon import Babylon
 from cachedkopfobject import CachedKopfObject
 from labuserinterface import LabUserInterface
 
-import resourceclaim
 import workshop as workshop_import
 
 
@@ -164,7 +163,7 @@ class WorkshopUserAssignment(CachedKopfObject):
     async def copy_to_workshop(self):
         try:
             workshop = await self.get_workshop()
-        except kubernetes_asyncio.client.rest.ApiException as exception:
+        except k8sApiException as exception:
             if exception.status == 404:
                 raise kopf.TemporaryError(
                     f"Workshop {self.workshop_name} was not found.", delay=60
@@ -213,6 +212,6 @@ class WorkshopUserAssignment(CachedKopfObject):
                     {"userAssignments": {self.name: None}}
                 )
                 await workshop.update_status()
-        except kubernetes_asyncio.client.rest.ApiException as exception:
+        except k8sApiException as exception:
             if exception.status != 404:
                 raise

--- a/workshop-manager/requirements.txt
+++ b/workshop-manager/requirements.txt
@@ -1,1 +1,2 @@
 pydantic==1.10.13
+kubernetes_asyncio==32.3.2


### PR DESCRIPTION

* Added a `workshop_id` parameter to the `WorkshopUserAssignments` label. This will simplify `Workshop` and `WorkshopUserAssignments` mapping. 
* Updating `Development.adoc` with details for new `odo` tool version (e.g. using `odo dev`), and also pre-requisite steps to start using development workflow with `odo`.
* Enhanced `rbac.yaml` to include a new rule for `resourceproviders` in the Poolboy domain, allowing `get` and `list` operations.
* Replaced direct imports of `kubernetes_asyncio.client.rest.ApiException` with `kubernetes_asyncio.client.exceptions.ApiException` across multiple files (`k8sobject.py`, `resourceclaim.py`, `workshopprovision.py`) to be on par with the new version of the `kubernetes_asincio` module.
* Applied consistent formatting to long lines using Ruff formatter.
