### PR TITLE
Remove Chart version validation on Ratings

### DIFF
--- a/.github/workflows/ratings-publish.yaml
+++ b/.github/workflows/ratings-publish.yaml
@@ -52,16 +52,6 @@ jobs:
             ( IFS=$','; echo "IMAGE_TAGS=${IMAGE_TAGS[*]}" >> $GITHUB_OUTPUT )
           fi
 
-      - name: Verify Chart version
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          VERSION="${{ steps.image_tags.outputs.VERSION }}"
-          HELM_CHART_VERSION=$(sed -nr 's/^appVersion: (.*)/\1/p' ratings/helm/Chart.yaml)
-          if [[ "v${HELM_CHART_VERSION}" != "${VERSION}" ]]; then
-            echo "Helm chart version does not match tag!"
-            exit 1
-          fi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
Remove these lines from the ratings-workflow 

```
      - name: Verify Chart version
        if: github.event_name != 'workflow_dispatch'
        run: |
          VERSION="${{ steps.image_tags.outputs.VERSION }}"
          HELM_CHART_VERSION=$(sed -nr 's/^appVersion: (.*)/\1/p' ratings/helm/Chart.yaml)
          if [[ "v${HELM_CHART_VERSION}" != "${VERSION}" ]]; then
            echo "Helm chart version does not match tag!"
            exit 1
          fi
```