### PR TITLE
Change notifier to conditionally wrap mjml wrapper

### DIFF
--- a/notifier/operator/catalog_item.py
+++ b/notifier/operator/catalog_item.py
@@ -28,7 +28,7 @@ class CatalogItem:
 
     @property
     def display_name(self):
-        return self.definition['metadata'].get('annotations', {}).get('babylon.gpte.redhat.com/displayName', self.name)
+        return self.definition['spec'].get('displayName', self.name)
 
     @property
     def email_from(self):

--- a/notifier/operator/templates/base.mjml.j2
+++ b/notifier/operator/templates/base.mjml.j2
@@ -40,6 +40,12 @@
       {% block content %}{% endblock %}
     </mj-section>
 
+    {% if template_error_message is defined %}
+    <mj-section padding-top="12px" padding-bottom="12px" padding-left="12px" padding-right="12px" background-color="#f0f0f0">
+      {{ template_error_message }}
+    </mj-section>
+    {% endif %}
+
     <!-- Footer -->
     <mj-section padding-top="12px" padding-bottom="6px" padding-left="12px" padding-right="12px">
       <mj-column>


### PR DESCRIPTION
- Change the notifier to only apply the mjml wrapper if the message body is not a complete html or mjml document.
- Cleanup to get catalog item display name from spec.
- Fix to show error messages in case of template rendering failure.