### PR TITLE
Updates for the Workshop provisions tracking

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -162,17 +162,14 @@ spec:
               provisionCount:
                 type: object
                 properties:
-                  ordered:
-                    description: Total number of WorkshopProvisions ordered.
-                    type: integer
-                  provisioning:
-                    description: Number of WorkshopProvisions that are provisioning.
-                    type: integer
                   failed:
                     description: Number of WorkshopProvisions that have failed.
                     type: integer
-                  completed:
-                    description: Number of WorkshopProvisions that have completed.
+                  active:
+                    description: Number of WorkshopProvisions that are active.
+                    type: integer
+                  retries:
+                    description: Number of WorkshopProvisions retries.
                     type: integer
         required:
         - apiVersion

--- a/workshop-manager/operator/resourceclaim.py
+++ b/workshop-manager/operator/resourceclaim.py
@@ -32,7 +32,7 @@ class ResourceClaim(K8sObject):
         event_type = event.get('type')
         logger.debug(f"Handling {resource_claim} {event.get('type') or 'EVENT'}")
 
-        if event.get('type') == 'DELETED':
+        if event.get('type') == 'DELETED' or resource_claim.deletion_timestamp is not None:
             await resource_claim.delete_workshop_user_assignments(logger=logger)
             return
 
@@ -56,6 +56,10 @@ class ResourceClaim(K8sObject):
                 workshop = workshop,
             )
 
+    @property
+    def deletion_timestamp(self):
+        return self.metadata.get('deletionTimestamp')
+    
     @property
     def effective_lifespan_end(self):
         lifespan_end_timestamp = self.definition.get('status', {}).get('lifespan', {}).get('end')

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -208,21 +208,28 @@ class Workshop(CachedKopfObject):
                 assigned_user_count += 1
             else:
                 available_user_count += 1
+        
+        # Collect WorkshopProvision counts
+        total_failed_count = 0
+        total_resource_claim_count = 0
+        total_retry_count = 0
+        
+        for workshop_provision in self.get_workshop_provisions():
+            provision_status = workshop_provision.status or {}
+            total_failed_count += provision_status.get('failedCount', 0)
+            total_resource_claim_count += provision_status.get('resourceClaimCount', 0)
+            total_retry_count += provision_status.get('retryCount', 0)
+
         await self.merge_patch_status({
             "userCount": {
                 "assigned": assigned_user_count,
                 "available": available_user_count,
                 "total": total_user_count,
-            }
-        })
-
-    async def update_provision_count(self, provisioning, failed, completed, ordered):
-
-        await self.merge_patch_status({
+            },
             "provisionCount": {
-                "ordered": ordered,
-                "provisioning": provisioning,
-                "failed": failed,
-                "completed": completed,
+                "failed": total_failed_count,
+                "completed": total_resource_claim_count,
+                "retries": total_retry_count,
             }
         })
+

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -228,7 +228,7 @@ class Workshop(CachedKopfObject):
             },
             "provisionCount": {
                 "failed": total_failed_count,
-                "completed": total_resource_claim_count,
+                "active": total_resource_claim_count,
                 "retries": total_retry_count,
             }
         })

--- a/workshop-manager/operator/workshopprovision.py
+++ b/workshop-manager/operator/workshopprovision.py
@@ -303,6 +303,9 @@ class WorkshopProvision(CachedKopfObject):
             f"{Babylon.workshop_provision_label}={self.name}",
             namespace=self.namespace,
         ):
+            # Ignore ResourceClaims that are being deleted (have deletionTimestamp)
+            if resource_claim.deletion_timestamp is not None:
+                continue
             yield resource_claim
 
     async def manage(self, logger):


### PR DESCRIPTION
This change should fix following items:
- Ignore provisions (ResourceClaims) which stuck in the "deletion" state.
- Updated the `provisionCount` reporting
- Fixing `provisionCount` reporting when Workshop has multiple provisions