### PR TITLE
Auto-scaling for UserAssignments

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -34,6 +34,39 @@ spec:
             description: Specification of Workshop.
             type: object
             properties:
+              autoScaling:
+                type: object
+                description: >-
+                  Auto-scaling configuration for UserAssignments
+                properties:
+                  enabled:
+                    type: boolean
+                    default: false
+                    description: >-
+                      Enable or disable auto-scaling functionality
+                  threshold:
+                    type: number
+                    minimum: 0.0
+                    maximum: 1.0
+                    default: 0.8
+                    description: >-
+                      Utilization threshold (0.0-1.0) that triggers scaling. When
+                      assigned_users/total_users exceeds this value,
+                      auto-scaling is triggered
+                  scaleFactor:
+                    type: number
+                    minimum: 1.0
+                    default: 1.5
+                    description: >-
+                      Multiplier for capacity increase when scaling. For example,
+                      1.5 means increase capacity by 50%
+                  maxProvisions:
+                    type: integer
+                    minimum: 1
+                    default: 100
+                    description: >-
+                      Maximum number of provisions allowed per WorkshopProvision to
+                      prevent runaway scaling
               accessPassword:
                 description: >-
                   Optional password for access to the workshop.

--- a/workshop-manager/README.adoc
+++ b/workshop-manager/README.adoc
@@ -1,3 +1,43 @@
 = Workshop Provisioner
 
 Component to deploy services for workshops.
+
+== Auto-Scaling
+
+The Workshop Provisioner supports automatic scaling of UserAssignments based on allocation demand. When the utilization rate exceeds a configured threshold, the system automatically increases the number of ResourceClaims to provide more UserAssignments.
+
+=== Configuration
+
+Auto-scaling is configured in the Workshop spec under the `autoScaling` section:
+
+[source,yaml]
+----
+spec:
+  autoScaling:
+    enabled: true              # Enable/disable auto-scaling
+    threshold: 0.8             # Scale when 80% of UserAssignments are allocated
+    scaleFactor: 1.5           # Increase capacity by 50% when scaling
+    maxProvisions: 100         # Maximum number of provisions per WorkshopProvision
+----
+
+=== Parameters
+
+* `enabled` (boolean, default: false): Enable or disable auto-scaling functionality
+* `threshold` (float, default: 0.8): Utilization threshold (0.0-1.0) that triggers scaling
+* `scaleFactor` (float, default: 1.5): Multiplier for capacity increase when scaling
+* `maxProvisions` (integer, default: 100): Maximum number of provisions allowed per WorkshopProvision
+
+=== How it Works
+
+1. The Workshop continuously monitors UserAssignment allocation rates
+2. When `assigned_users / total_users >= threshold`, auto-scaling is triggered for each WorkshopProvision
+3. Each WorkshopProvision independently manages its own auto-scaling:
+   - Sets `autoScalingActive: true` in status to prevent concurrent scaling
+   - Increases its `count` by the specified `scaleFactor`
+   - Clears the flag when all ResourceClaims are complete (success/failed)
+4. New ResourceClaims are created automatically, generating additional UserAssignments
+5. Race conditions are prevented by the per-provision `autoScalingActive` flag
+
+=== Example
+
+See link:example-auto-scaling-workshop.yaml[example-auto-scaling-workshop.yaml] for a complete Workshop configuration with auto-scaling enabled.


### PR DESCRIPTION
# Auto-scaling for UserAssignments

## Overview

Implements automatic scaling of UserAssignments based on allocation demand. When utilization exceeds a configurable threshold, the system automatically increases ResourceClaim capacity to provide more available UserAssignments.

## Problem Statement

Workshops with high user demand can run out of available UserAssignments, requiring manual intervention to increase ResourceClaim counts. This creates delays and requires constant monitoring of workshop utilization.

## Solution

Auto-scaling monitors UserAssignment allocation rates and automatically scales WorkshopProvisions when demand is high:

- **Trigger**: When `assigned_users / total_users >= threshold` (default: 80%)
- **Action**: Increase WorkshopProvision `count` by `scaleFactor` (default: 1.5x)
- **Scope**: Each WorkshopProvision scales independently
- **Safety**: Race condition prevention via `autoScalingActive` status flag

## Key Features

-  **Per-Provision Scaling**: Each WorkshopProvision manages its own auto-scaling independently
-  **Race Condition Safe**: `autoScalingActive` flag prevents concurrent scaling operations
-  **Configurable Thresholds**: Customizable trigger threshold and scaling factor
-  **Safety Limits**: `maxProvisions` prevents runaway scaling
-  **Backward Compatible**: Disabled by default, no impact on existing workshops
-  **Completion-Based**: Waits for actual ResourceClaim completion, not arbitrary timers

## Configuration

```yaml
spec:
  autoScaling:
    enabled: true           # Enable auto-scaling
    threshold: 0.8         # Scale at 80% utilization
    scaleFactor: 1.5       # Increase capacity by 50%
    maxProvisions: 100     # Safety limit per provision
```

# Race Condition Prevention

The implementation prevents race conditions that could occur during ResourceClaim provisioning:

1. Problem: Multiple scaling triggers could create excess ResourceClaims
2. Solution: autoScalingActive flag in WorkshopProvision status
3. Workflow:
  - Set flag when scaling starts
  - Skip scaling if flag is active
  - Clear flag when all ResourceClaims are complete/failed

# Testing

To test auto-scaling:

1. Apply example configuration with autoScaling.enabled: true
2. Create user assignments until utilization reaches threshold
3. Verify WorkshopProvision count increases automatically
4. Monitor autoScalingActive flag behavior

# Deployment Requirements

The Workshop and WorkshopProvision CRDs must be updated with new schema before deploying this code.

