### PR TITLE
Feat/workshop status url

### DIFF
--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -202,6 +202,7 @@ spec:
                 description: >-
                   URL for accessing this workshop. Constructed from the
                   WORKSHOP_BASE_URL environment variable and the workshop-id label.
+                  If WORKSHOP_BASE_URL is not set, the URL is relative (e.g. /workshop/abc123).
                 type: string
         required:
         - apiVersion

--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -198,6 +198,11 @@ spec:
                   properties:
                     uid:
                       type: string
+              workshopURL:
+                description: >-
+                  URL for accessing this workshop. Constructed from the
+                  WORKSHOP_BASE_URL environment variable and the workshop-id label.
+                type: string
         required:
         - apiVersion
         - kind

--- a/helm/templates/workshopManager/deployment.yaml
+++ b/helm/templates/workshopManager/deployment.yaml
@@ -29,7 +29,11 @@ spec:
           value: "--log-format=json"
         - name: KOPF_PEERING
           value: babylon-workshop-manager
-        image: {{ $workshopManager.image.repository }}:{{ $workshopManager.image.tag }}
+        {{- if $workshopManager.workshopBaseUrl }}
+        - name: WORKSHOP_BASE_URL
+          value: {{ $workshopManager.workshopBaseUrl | quote }}
+        {{- end }}
+        image: "{{ $workshopManager.image.repository }}:{{ $workshopManager.image.tag }}"
         imagePullPolicy: {{ $workshopManager.image.pullPolicy }}
         resources:
           {{- toYaml $workshopManager.resources | nindent 10 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -255,6 +255,7 @@ workshopManager:
     requests:
       cpu: 200m
       memory: 1Gi
+  workshopBaseUrl: ""
 
 admin:
   deploy: true

--- a/workshop-manager/Development.adoc
+++ b/workshop-manager/Development.adoc
@@ -46,5 +46,5 @@ oc start-build babylon-workshop-manager --from-dir=.. --follow
 . Update deployment `babylon-workshop-manager` to use new image:
 +
 ----
-oc patch deployment babylon-workshop-manager --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"'$(oc get imagestream babylon-workshop-manager -o jsonpath={.status.tags[0].items[0].dockerImageReference})'"}]'
+oc patch deployment babylon-workshop-manager --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"'$(oc get imagestream babylon-workshop-manager -o jsonpath='{.status.tags[?(@.tag=="latest")].items[0].dockerImageReference}')'"}]'
 ----

--- a/workshop-manager/helm/templates/deployment.yaml
+++ b/workshop-manager/helm/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
           value: "--log-format=json"
         - name: KOPF_PEERING
           value: {{ include "babylon-workshop-manager.name" . }}
+        {{- if .Values.workshopBaseUrl }}
+        - name: WORKSHOP_BASE_URL
+          value: {{ .Values.workshopBaseUrl | quote }}
+        {{- end }}
         image: {{ include "babylon-workshop-manager.image" . | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:

--- a/workshop-manager/helm/values.yaml
+++ b/workshop-manager/helm/values.yaml
@@ -42,6 +42,8 @@ affinity: {}
 babylon:
   domain: babylon.gpte.redhat.com
 
+workshopBaseUrl: ""
+
 poolboy:
   domain: poolboy.gpte.redhat.com
 

--- a/workshop-manager/operator/babylon.py
+++ b/workshop-manager/operator/babylon.py
@@ -41,6 +41,7 @@ class Babylon():
     user_name_label = f"{babylon_domain}/user-name"
 
     workshop_fail_percentage_threshold = int(os.environ.get('WORKSHOP_FAIL_PERCENTAGE_THRESHOLD', 60))
+    workshop_base_url = os.environ.get('WORKSHOP_BASE_URL', '').rstrip('/')
 
     # Initialized on startup
     api_client = None

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -1,6 +1,7 @@
 import random
 
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 from kubernetes_asyncio.client.models import RbacV1Subject, V1ObjectMeta, V1PolicyRule, V1Role, V1RoleBinding, V1RoleRef
@@ -104,6 +105,16 @@ class Workshop(CachedKopfObject):
     def workshop_url(self):
         return self.status.get('workshopURL')
 
+    @property
+    def _effective_base_url(self):
+        if Babylon.workshop_base_url:
+            return Babylon.workshop_base_url
+        if self.service_url:
+            parsed = urlparse(self.service_url)
+            if parsed.scheme and parsed.netloc:
+                return f"{parsed.scheme}://{parsed.netloc}"
+        return ''
+
     def get_workshop_provisions(self):
         return workshopprovision.WorkshopProvision.get_for_workshop(self)
 
@@ -185,7 +196,7 @@ class Workshop(CachedKopfObject):
         """
         if self.workshop_id:
             if not self.workshop_url:
-                workshop_url = f"{Babylon.workshop_base_url}/workshop/{self.workshop_id}"
+                workshop_url = f"{self._effective_base_url}/workshop/{self.workshop_id}"
                 await self.merge_patch_status({"workshopURL": workshop_url})
                 logger.info(f"Set workshopURL {workshop_url} for {self}")
             return
@@ -206,7 +217,7 @@ class Workshop(CachedKopfObject):
         })
         logger.info(f"Assigned workshop id {workshop_id} to {self}")
 
-        workshop_url = f"{Babylon.workshop_base_url}/workshop/{workshop_id}"
+        workshop_url = f"{self._effective_base_url}/workshop/{workshop_id}"
         await self.merge_patch_status({"workshopURL": workshop_url})
         logger.info(f"Set workshopURL {workshop_url} for {self}")
 

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -197,6 +197,10 @@ class Workshop(CachedKopfObject):
             }
         })
         logger.info(f"Assigned workshop id {workshop_id} to {self}")
+
+        workshop_url = f"{Babylon.workshop_base_url}/workshop/{workshop_id}"
+        await self.merge_patch_status({"workshopURL": workshop_url})
+        logger.info(f"Set workshopURL {workshop_url} for {self}")
         return
 
     async def add_resource_claim_to_status(self, resource_claim, logger):

--- a/workshop-manager/operator/workshop.py
+++ b/workshop-manager/operator/workshop.py
@@ -100,6 +100,10 @@ class Workshop(CachedKopfObject):
     def workshop_id(self):
         return self.labels.get(Babylon.workshop_id_label)
 
+    @property
+    def workshop_url(self):
+        return self.status.get('workshopURL')
+
     def get_workshop_provisions(self):
         return workshopprovision.WorkshopProvision.get_for_workshop(self)
 
@@ -180,6 +184,10 @@ class Workshop(CachedKopfObject):
         Generate a unique workshop id label for workshop to provide a short URL for access.
         """
         if self.workshop_id:
+            if not self.workshop_url:
+                workshop_url = f"{Babylon.workshop_base_url}/workshop/{self.workshop_id}"
+                await self.merge_patch_status({"workshopURL": workshop_url})
+                logger.info(f"Set workshopURL {workshop_url} for {self}")
             return
 
         while True:
@@ -201,7 +209,6 @@ class Workshop(CachedKopfObject):
         workshop_url = f"{Babylon.workshop_base_url}/workshop/{workshop_id}"
         await self.merge_patch_status({"workshopURL": workshop_url})
         logger.info(f"Set workshopURL {workshop_url} for {self}")
-        return
 
     async def add_resource_claim_to_status(self, resource_claim, logger):
         if resource_claim.name in self.status.get('resourceClaims', {}):


### PR DESCRIPTION
- Adds a `workshopURL` field to the Workshop CRD status schema, automatically populated when a workshop ID label is assigned.
- Introduces `WORKSHOP_BASE_URL` environment variable (configurable via Helm `workshopBaseUrl` value) that controls the base URL used to construct workshop access links (e.g. `https://example.com/workshop/<id>`)Adding `workshopURL` to the status.