### PR TITLE
Bump babylon_anarchy_governor to v0.32.2

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,7 +65,7 @@ anarchy:
     sources:
       babylon_anarchy_governor:
         src: https://github.com/rhpds/babylon_anarchy_governor.git
-        version: v0.32.1
+        version: v0.32.2
   api:
     group: anarchy.gpte.redhat.com
     version: v1


### PR DESCRIPTION
babylon_anarchy_governor v0.32.2 includes support for all the sandboxes, including new SSLSandbox and support  new DNSSandbox using ddns (bind/named)