### PR TITLE
feat: Workshop seats on demand definitions

### DIFF
--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -597,6 +597,22 @@ export interface WorkshopProvisionSpec {
   };
 }
 
+export interface WorkshopSpecSeatsOnDemandResourcePool {
+  name?: string;
+  provider: {
+    apiVersion?: string;
+    kind?: string;
+    name: string;
+    namespace: string;
+  };
+  minAvailable?: number;
+}
+
+export interface WorkshopSpecSeatsOnDemand {
+  seatExpiration: string;
+  resourcePool: WorkshopSpecSeatsOnDemandResourcePool;
+}
+
 export interface WorkshopSpec {
   accessPassword?: string;
   description?: string;
@@ -616,6 +632,7 @@ export interface WorkshopSpec {
     maximum?: string;
     relativeMaximum?: string;
   };
+  seatsOnDemand?: WorkshopSpecSeatsOnDemand;
 }
 
 export interface WorkshopUserAssignmentList {

--- a/helm/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -122,6 +122,72 @@ spec:
                   In this case the Workshop should also be set to be owned by the ResourceClaim for the service.
                 type: boolean
                 default: false
+              seatsOnDemand:
+                description: >-
+                  Configuration for on-demand seat provisioning. When configured, no instances are
+                  pre-provisioned at workshop creation. Instead, each seat is provisioned individually
+                  when a user attends the workshop. Seats are short-lived and expire after the
+                  configured duration. A dedicated ResourcePool is created for this workshop and
+                  destroyed when the workshop is deleted.
+                type: object
+                required:
+                - seatExpiration
+                - resourcePool
+                properties:
+                  seatExpiration:
+                    description: >-
+                      Duration for how long each on-demand seat should live after it is provisioned.
+                    type: string
+                    pattern: ^[0-9]+[dhms]$
+                  resourcePool:
+                    description: >-
+                      Configuration for the dedicated ResourcePool to be created for this workshop.
+                      This pool is used exclusively by this workshop and will be destroyed when the
+                      workshop is deleted.
+                    type: object
+                    required:
+                    - provider
+                    properties:
+                      name:
+                        description: >-
+                          Name of the dedicated ResourcePool to create in the poolboy namespace.
+                          If not specified, a name will be generated from the workshop name.
+                        type: string
+                      provider:
+                        description: >-
+                          Reference to the ResourceProvider that will be used to provision resources
+                          for on-demand seats.
+                        type: object
+                        required:
+                        - name
+                        - namespace
+                        properties:
+                          apiVersion:
+                            description: >-
+                              API version of the ResourceProvider.
+                            type: string
+                            default: poolboy.gpte.redhat.com/v1
+                          kind:
+                            description: >-
+                              Kind of the resource provider reference.
+                            type: string
+                            default: ResourceProvider
+                          name:
+                            description: >-
+                              Name of the ResourceProvider.
+                            type: string
+                          namespace:
+                            description: >-
+                              Namespace of the ResourceProvider.
+                            type: string
+                      minAvailable:
+                        description: >-
+                          Minimum number of pre-provisioned resources to keep available in the pool
+                          for faster seat assignment. Default is 0, meaning purely on-demand with no
+                          pre-warming.
+                        type: integer
+                        default: 0
+                        minimum: 0
           status:
             description: Status of Workshop
             type: object
@@ -145,6 +211,24 @@ spec:
                   retries:
                     description: Number of provisions retries.
                     type: integer
+              resourcePool:
+                description: >-
+                  Status of the dedicated ResourcePool created for on-demand seats.
+                  Populated by the operator when seatsOnDemand is configured.
+                type: object
+                properties:
+                  name:
+                    description: >-
+                      Name of the created ResourcePool.
+                    type: string
+                  namespace:
+                    description: >-
+                      Namespace of the created ResourcePool.
+                    type: string
+                  uid:
+                    description: >-
+                      UID of the created ResourcePool resource.
+                    type: string
               resourceClaims:
                 description: >-
                   References to ResourceClaims associated with this Workshop.

--- a/openshift/config/common/helm/babylon-config/crds/workshops.babylon.gpte.redhat.com.yaml
+++ b/openshift/config/common/helm/babylon-config/crds/workshops.babylon.gpte.redhat.com.yaml
@@ -112,6 +112,72 @@ spec:
                   In this case the Workshop should also be set to be owned by the ResourceClaim for the service.
                 type: boolean
                 default: false
+              seatsOnDemand:
+                description: >-
+                  Configuration for on-demand seat provisioning. When configured, no instances are
+                  pre-provisioned at workshop creation. Instead, each seat is provisioned individually
+                  when a user attends the workshop. Seats are short-lived and expire after the
+                  configured duration. A dedicated ResourcePool is created for this workshop and
+                  destroyed when the workshop is deleted.
+                type: object
+                required:
+                - seatExpiration
+                - resourcePool
+                properties:
+                  seatExpiration:
+                    description: >-
+                      Duration for how long each on-demand seat should live after it is provisioned.
+                    type: string
+                    pattern: ^[0-9]+[dhms]$
+                  resourcePool:
+                    description: >-
+                      Configuration for the dedicated ResourcePool to be created for this workshop.
+                      This pool is used exclusively by this workshop and will be destroyed when the
+                      workshop is deleted.
+                    type: object
+                    required:
+                    - provider
+                    properties:
+                      name:
+                        description: >-
+                          Name of the dedicated ResourcePool to create in the poolboy namespace.
+                          If not specified, a name will be generated from the workshop name.
+                        type: string
+                      provider:
+                        description: >-
+                          Reference to the ResourceProvider that will be used to provision resources
+                          for on-demand seats.
+                        type: object
+                        required:
+                        - name
+                        - namespace
+                        properties:
+                          apiVersion:
+                            description: >-
+                              API version of the ResourceProvider.
+                            type: string
+                            default: poolboy.gpte.redhat.com/v1
+                          kind:
+                            description: >-
+                              Kind of the resource provider reference.
+                            type: string
+                            default: ResourceProvider
+                          name:
+                            description: >-
+                              Name of the ResourceProvider.
+                            type: string
+                          namespace:
+                            description: >-
+                              Namespace of the ResourceProvider.
+                            type: string
+                      minAvailable:
+                        description: >-
+                          Minimum number of pre-provisioned resources to keep available in the pool
+                          for faster seat assignment. Default is 0, meaning purely on-demand with no
+                          pre-warming.
+                        type: integer
+                        default: 0
+                        minimum: 0
               userAssignments:
                 description: >-
                   Users for multi-user workshop environments.


### PR DESCRIPTION
Add seatsOnDemand to Workshop CRD schema

_Motivation_
Traditional workshops pre-provision all seats upfront, which is wasteful when attendance is uncertain or environments are expensive. Seats on demand flips this model: resources are only consumed when a user actually joins, and they are automatically reclaimed after the configured expiration. A dedicated resource pool per workshop keeps isolation clean, cost tracking and ensures cleanup on deletion.

_Changes_
- Introduces a new spec.seatsOnDemand property to the Workshop CRD, enabling a provisioning mode where no instances are pre-started at workshop creation. Instead, each seat is provisioned on-the-fly when a user attends the workshop.
- seatExpiration defines the short-lived duration of each seat (e.g. 4h, 1d).
- resourcePool defines a dedicated Poolboy ResourcePool that is created exclusively for this workshop and destroyed when the workshop is deleted, ensuring full lifecycle coupling.
- Adds status.resourcePool to track the created pool (name, namespace, uid) for operator reconciliation.