### PR TITLE
Catalog audit-trial log

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -41,6 +41,25 @@ session_lifetime = int(os.environ.get('SESSION_LIFETIME', 600))
 
 logging.basicConfig(level=os.environ.get('LOGGING_LEVEL', 'INFO'))
 
+audit_logger = logging.getLogger('audit')
+
+def audit_log(event, user, method=None, path=None, status=None, effective_user=None, **extra):
+    record = {
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'event': event,
+        'user': user,
+    }
+    if effective_user and effective_user != user:
+        record['effective_user'] = effective_user
+    if method:
+        record['method'] = method
+    if path:
+        record['path'] = path
+    if status is not None:
+        record['status'] = status
+    record.update(extra)
+    audit_logger.info(json.dumps(record))
+
 def proxy_api_client(session):
     api_client = HotfixKubeApiClient()
     if os.environ.get('ENVIRONMENT') == 'development':
@@ -408,6 +427,7 @@ async def get_auth_session(request):
         if interface_name:
             ret['interface'] = interface_name
 
+        audit_log('session_created', user=user['metadata']['name'], admin=user_is_admin)
         return web.json_response(ret)
     finally:
         await api_client.close()
@@ -1272,8 +1292,7 @@ async def update_system_status(request):
             else:
                 raise
 
-        # Log the change
-        logging.info(f"System status updated by {user['metadata']['name']}: {data}")
+        audit_log('system_status_updated', user=user['metadata']['name'], data=data)
 
         # Return updated status
         return web.json_response(await get_system_status_from_configmap())
@@ -1434,12 +1453,31 @@ async def openshift_api_proxy(request, api_client=None):
         headers['Content-Encoding'] = 'gzip'
         headers['Content-Type'] = 'application/json'
 
+        if request.method != 'GET':
+            audit_log(
+                'api_action',
+                user=session['user'],
+                effective_user=api_client.default_headers.get('Impersonate-User'),
+                method=request.method,
+                path=request.path,
+                status=response.status,
+            )
+
         return web.Response(
             body=data,
             headers=headers,
             status=response.status,
         )
     except kubernetes_asyncio.client.exceptions.ApiException as exception:
+        if request.method != 'GET':
+            audit_log(
+                'api_action',
+                user=session['user'],
+                effective_user=api_client.default_headers.get('Impersonate-User'),
+                method=request.method,
+                path=request.path,
+                status=exception.status,
+            )
         if exception.body:
             return web.Response(
                 body=exception.body,

--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -43,22 +43,21 @@ logging.basicConfig(level=os.environ.get('LOGGING_LEVEL', 'INFO'))
 
 audit_logger = logging.getLogger('audit')
 
-def audit_log(event, user, method=None, path=None, status=None, effective_user=None, **extra):
-    record = {
-        'timestamp': datetime.now(timezone.utc).isoformat(),
-        'event': event,
-        'user': user,
-    }
+def audit_log(event, user, method=None, path=None, status=None, effective_user=None, body=None, **extra):
+    parts = [datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'), event, f"user={user}"]
     if effective_user and effective_user != user:
-        record['effective_user'] = effective_user
+        parts.append(f"effective_user={effective_user}")
     if method:
-        record['method'] = method
+        parts.append(f"method={method}")
     if path:
-        record['path'] = path
+        parts.append(f"path={path}")
     if status is not None:
-        record['status'] = status
-    record.update(extra)
-    audit_logger.info(json.dumps(record))
+        parts.append(f"status={status}")
+    if body is not None:
+        parts.append(f"body={json.dumps(body, separators=(',', ':'))}")
+    for k, v in extra.items():
+        parts.append(f"{k}={v}")
+    audit_logger.info(' '.join(parts))
 
 def proxy_api_client(session):
     api_client = HotfixKubeApiClient()
@@ -1428,11 +1427,13 @@ async def openshift_api_proxy(request, api_client=None):
         if request.content_type and request.can_read_body:
             header_params['Content-Type'] = request.content_type
 
+        request_body = await request.json() if request.can_read_body else None
+
         response = await api_client.call_api(
             request.path,
             request.method,
             auth_settings = ['BearerToken'],
-            body = await request.json() if request.can_read_body else None,
+            body = request_body,
             header_params = header_params,
             query_params = [(k, v) for k, v in request.query.items()] if request.query else None,
             _preload_content = False,
@@ -1461,6 +1462,7 @@ async def openshift_api_proxy(request, api_client=None):
                 method=request.method,
                 path=request.path,
                 status=response.status,
+                body=request_body,
             )
 
         return web.Response(
@@ -1477,6 +1479,7 @@ async def openshift_api_proxy(request, api_client=None):
                 method=request.method,
                 path=request.path,
                 status=exception.status,
+                body=request_body,
             )
         if exception.body:
             return web.Response(


### PR DESCRIPTION
## Summary

Adds an audit trail to the catalog API so the Ops team can answer questions like "who deleted this provision?" or "did the user actually extend their lifespan?".

All user-initiated mutations flow through the catalog API — the `/apis/*` proxy is the gateway for actions like deleting ResourceClaims, patching lifespan, starting/stopping provisions. System actions (poolboy, anarchy operators) bypass this proxy entirely, so **the absence of a log entry is itself a signal** that the action was system-initiated.

## Changes

- Adds `audit_log()` helper and a dedicated `audit` logger (`logging.getLogger('audit')`)
- Logs all non-GET mutations proxied to Kubernetes (`POST`, `PUT`, `PATCH`, `DELETE`) — both on success and on Kubernetes API errors
- Includes the request body for `PATCH`/`POST`/`PUT` so the actual change is visible (e.g. what lifespan value was set)
- Logs session creation (`/auth/session`) and system status updates
- Upgrades existing `logging.info` for system status to use the same audit format
- No new dependencies

## Log format

Plain text, consistent with existing `aiohttp.access` log style. Filterable with `grep 'INFO:audit:'`.

```
INFO:audit:2026-04-22T17:03:33Z api_action user=kmalgich@redhat.com method=PATCH path=/apis/poolboy.gpte.redhat.com/v1/namespaces/user-kmalgich-redhat-com/resourceclaims/tests.babylon-empty-config.prod-qnk82 status=200 body={"spec":{"lifespan":{"end":"2026-04-23T10:00:00Z"}}}
INFO:audit:2026-04-22T17:03:35Z api_action user=kmalgich@redhat.com method=DELETE path=/apis/poolboy.gpte.redhat.com/v1/namespaces/user-kmalgich-redhat-com/resourceclaims/tests.babylon-empty-config.prod-qnk82 status=200
INFO:audit:2026-04-22T17:03:30Z session_created user=kmalgich@redhat.com admin=False
```

When an admin impersonates a user, both identities are recorded:

```
INFO:audit:2026-04-22T17:03:33Z api_action user=admin@redhat.com effective_user=jdoe@redhat.com method=DELETE path=... status=200
```