### PR TITLE
Fix workshop status when all resource claims have a deletionTimestamp

### DIFF
--- a/catalog/ui/src/app/Services/renderWorkshopRow.tsx
+++ b/catalog/ui/src/app/Services/renderWorkshopRow.tsx
@@ -91,10 +91,11 @@ const renderWorkshopRow = ({
     </>
   );
   const guidCell = <span key="workshop-guid">-</span>;
+  const activeResourceClaim = workshop.resourceClaims?.find((r) => !r.metadata.deletionTimestamp);
   const statusCell = (
     <>
-      {workshop.resourceClaims && workshop.resourceClaims.length > 0 ? (
-        <ServiceStatus resourceClaim={workshop.resourceClaims.filter((r) => !r.metadata.deletionTimestamp)[0]} />
+      {activeResourceClaim ? (
+        <ServiceStatus resourceClaim={activeResourceClaim} />
       ) : autoStartTime && autoStartTime > Date.now() ? (
         <span className="services-item__status--scheduled" key="scheduled">
           <CheckCircleIcon key="scheduled-icon" /> Scheduled


### PR DESCRIPTION
When every resource claim on a workshop has a `deletionTimestamp`, the status cell was still attempting to render a `ServiceStatus` component with an `undefined` resource claim (the result of `.filter(...)[0]` on an empty array). This change ensures the component only renders when a genuinely active (non-deleting) resource claim exists.

## Changes
- Extract the active resource claim lookup (`find` instead of `filter(...)[0]`) into a variable before rendering
- Guard the `ServiceStatus` render on the existence of an active claim, falling through to the scheduled/pending states when none is found