### PR TITLE
Fix instance_groups issue in babylon_anarchy_governor

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,7 +65,7 @@ anarchy:
     sources:
       babylon_anarchy_governor:
         src: https://github.com/rhpds/babylon_anarchy_governor.git
-        version: v0.32.3
+        version: v0.32.4
   api:
     group: anarchy.gpte.redhat.com
     version: v1


### PR DESCRIPTION
- Relase babylon_anarchy_governor v0.32.4
- Fixes issue with selecting AAP instance groups for specific actions.