### PR TITLE
Intentionally break ability to create workshops

### DIFF
--- a/helm/templates/clusterroles/babylon-user-service-access.yaml
+++ b/helm/templates/clusterroles/babylon-user-service-access.yaml
@@ -31,7 +31,7 @@ rules:
   - workshopuserassignments
   - multiworkshops
   verbs:
-  - create
+  #- create
   - delete
   - get
   - list


### PR DESCRIPTION
- Update babylon-user-service-access role to prevent non-admin users from creating workshops or related resources.