### PR TITLE
feat(catalog-ui): Add reorder action on service and workshop 

### DIFF
--- a/catalog/ui/src/app/Catalog/CatalogItemFormAutoStopDestroyModal.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemFormAutoStopDestroyModal.tsx
@@ -5,27 +5,41 @@ import { Alert, AlertGroup, Button, Form, FormGroup, Switch, Tooltip } from '@pa
 import useHelpLink from '@app/utils/useHelpLink';
 import OutlinedClockIcon from '@patternfly/react-icons/dist/js/icons/outlined-clock-icon';
 
-export type TDates = { stopDate: Date; endDate: Date };
-export type TDatesTypes = 'auto-stop' | 'auto-destroy';
+export type TDates = { startDate?: Date; stopDate?: Date; endDate?: Date };
+export type TDatesTypes = 'auto-start' | 'auto-stop' | 'auto-destroy';
 
 const CatalogItemFormAutoStopDestroyModal: React.FC<{
-  type: TDatesTypes;
+  type: TDatesTypes | null;
+  autoStartDate?: Date;
   autoStopDate?: Date;
   autoDestroyDate: Date;
+  maxStartTimestamp?: number;
+  minStartTimestamp?: number;
+  stopMaxDate?: number | null;
+  stopMinDate?: number;
+  stopMaxDateExclusive?: boolean;
   maxRuntimeTimestamp?: number;
   defaultRuntimeTimestamp?: number;
   maxDestroyTimestamp?: number;
+  showNoAutoStopSwitch?: boolean;
   onConfirm: (date: TDates) => void;
   onClose: () => void;
   isAutoStopDisabled?: boolean;
   title: string;
 }> = ({
   type,
+  autoStartDate,
   autoStopDate,
   autoDestroyDate,
+  maxStartTimestamp,
+  minStartTimestamp,
+  stopMaxDate,
+  stopMinDate,
+  stopMaxDateExclusive = false,
   maxRuntimeTimestamp,
   defaultRuntimeTimestamp,
   maxDestroyTimestamp,
+  showNoAutoStopSwitch = false,
   onConfirm,
   onClose,
   isAutoStopDisabled = false,
@@ -33,37 +47,98 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
 }) => {
   const helpLink = useHelpLink();
   const [autoStopDestroyModal, openAutoStopDestroyModal] = useModal();
-  const [now] = useState(() => Date.now());
+  const [now, setNow] = useState(() => Date.now());
+  const [noAutoStopSelected, setNoAutoStopSelected] = useState(false);
   const [dates, setDates] = useState<TDates>({
+    startDate: null,
     stopDate: null,
     endDate: null,
   });
-  const _stopDate = dates.stopDate || autoStopDate;
+  const _startDate = dates.startDate || autoStartDate;
+  const _stopDate =
+    showNoAutoStopSwitch && noAutoStopSelected ? undefined : dates.stopDate || autoStopDate;
   const _endDate = dates.endDate || autoDestroyDate;
-  const noAutoStopChecked = _stopDate && _endDate && _stopDate.getTime() >= _endDate.getTime();
+  const noAutoStopChecked = showNoAutoStopSwitch
+    ? noAutoStopSelected
+    : !_stopDate || (!!_stopDate && !!_endDate && _stopDate.getTime() >= _endDate.getTime());
+  const effectiveStopMaxDate = stopMaxDateExclusive
+    ? stopMaxDate ?? null
+    : stopMaxDate ?? (maxRuntimeTimestamp ? now + maxRuntimeTimestamp : null);
+  let effectiveStopMinDate = stopMinDate ? Math.max(now, stopMinDate) : now;
+  if (effectiveStopMaxDate && effectiveStopMinDate >= effectiveStopMaxDate) {
+    effectiveStopMinDate = effectiveStopMaxDate - 60000;
+  }
+  const noAutoStopSwitchIsVisible =
+    showNoAutoStopSwitch ||
+    effectiveStopMaxDate === null ||
+    (!!effectiveStopMaxDate && effectiveStopMaxDate >= _endDate.getTime());
 
   useEffect(() => {
-    if (type) {
-      openAutoStopDestroyModal();
+    if (!type) {
+      return;
     }
-  }, [openAutoStopDestroyModal, type]);
+    setNow(Date.now());
+    setDates({ startDate: null, stopDate: null, endDate: null });
+    if (type === 'auto-stop' && showNoAutoStopSwitch) {
+      setNoAutoStopSelected(!autoStopDate);
+    }
+    openAutoStopDestroyModal();
+  }, [type]);
 
   return (
-    <Modal ref={autoStopDestroyModal} onConfirm={() => onConfirm(dates)} title={title} onClose={onClose}>
+    <Modal
+      ref={autoStopDestroyModal}
+      onConfirm={() => {
+        if (type === 'auto-stop' && showNoAutoStopSwitch) {
+          onConfirm({
+            ...dates,
+            stopDate: noAutoStopSelected ? undefined : dates.stopDate ?? autoStopDate,
+          });
+          return;
+        }
+        if (type === 'auto-stop' && noAutoStopChecked) {
+          onConfirm({
+            ...dates,
+            stopDate: dates.stopDate ?? new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+          });
+          return;
+        }
+        onConfirm(dates);
+      }}
+      title={title}
+      onClose={onClose}
+    >
       <Form isHorizontal>
+        {type === 'auto-start' ? (
+          <>
+            <FormGroup fieldId="auto-start-modal" label="Start">
+              <DateTimePicker
+                defaultTimestamp={autoStartDate ? autoStartDate.getTime() : now}
+                onSelect={(d) => setDates((prev) => ({ ...prev, startDate: d }))}
+                minDate={minStartTimestamp ?? now}
+                maxDate={maxStartTimestamp ?? null}
+                forceUpdateTimestamp={dates.startDate?.getTime()}
+              />
+            </FormGroup>
+            {_startDate && _startDate.getTime() <= now ? (
+              <Alert variant="warning" isInline title="The selected start date and time is in the past." />
+            ) : null}
+          </>
+        ) : null}
         {type === 'auto-stop' ? (
           !isAutoStopDisabled ? (
             <>
               <FormGroup fieldId="auto-stop-modal" label="Auto-stop">
                 <DateTimePicker
                   defaultTimestamp={autoStopDate ? autoStopDate.getTime() : null}
-                  onSelect={(d) => setDates({ ...dates, stopDate: d })}
-                  minDate={now}
-                  maxDate={now + maxRuntimeTimestamp}
+                  onSelect={(d) => setDates((prev) => ({ ...prev, stopDate: d }))}
+                  minDate={effectiveStopMinDate}
+                  maxDate={effectiveStopMaxDate}
                   isDisabled={noAutoStopChecked}
+                  forceUpdateTimestamp={dates.stopDate?.getTime()}
                 />
               </FormGroup>
-              {now + maxRuntimeTimestamp >= _endDate.getTime() ? (
+              {noAutoStopSwitchIsVisible ? (
                 <Switch
                   id="no-auto-stop-switch"
                   aria-label="No auto-stop"
@@ -71,12 +146,28 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
                   isChecked={noAutoStopChecked}
                   hasCheckIcon
                   onChange={(_event, isChecked) => {
+                    if (showNoAutoStopSwitch) {
+                      setNoAutoStopSelected(isChecked);
+                      if (isChecked) {
+                        setDates((prev) => ({ ...prev, stopDate: null }));
+                      } else {
+                        setDates((prev) => ({
+                          ...prev,
+                          stopDate: new Date(Date.now() + (defaultRuntimeTimestamp || 0)),
+                        }));
+                      }
+                      return;
+                    }
                     if (isChecked) {
-                      setDates({
-                          ...dates,
-                          stopDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
-                        })
-                      }else { setDates({ ...dates, stopDate: new Date(Date.now() + defaultRuntimeTimestamp) });
+                      setDates((prev) => ({
+                        ...prev,
+                        stopDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+                      }));
+                    } else {
+                      setDates((prev) => ({
+                        ...prev,
+                        stopDate: new Date(Date.now() + defaultRuntimeTimestamp),
+                      }));
                     }
                   }}
                 />
@@ -116,7 +207,7 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
             <FormGroup fieldId="auto-destroy-modal" label="Auto-destroy">
               <DateTimePicker
                 defaultTimestamp={autoDestroyDate.getTime()}
-                onSelect={(d) => setDates({ ...dates, endDate: d })}
+                onSelect={(d) => setDates((prev) => ({ ...prev, endDate: d }))}
                 maxDate={maxDestroyTimestamp ? now + maxDestroyTimestamp : null}
                 minDate={now}
                 forceUpdateTimestamp={dates.endDate?.getTime()}

--- a/catalog/ui/src/app/Catalog/CatalogItemFormAutoStopDestroyModal.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemFormAutoStopDestroyModal.tsx
@@ -5,41 +5,27 @@ import { Alert, AlertGroup, Button, Form, FormGroup, Switch, Tooltip } from '@pa
 import useHelpLink from '@app/utils/useHelpLink';
 import OutlinedClockIcon from '@patternfly/react-icons/dist/js/icons/outlined-clock-icon';
 
-export type TDates = { startDate?: Date; stopDate?: Date; endDate?: Date };
-export type TDatesTypes = 'auto-start' | 'auto-stop' | 'auto-destroy';
+export type TDates = { stopDate: Date; endDate: Date };
+export type TDatesTypes = 'auto-stop' | 'auto-destroy';
 
 const CatalogItemFormAutoStopDestroyModal: React.FC<{
-  type: TDatesTypes | null;
-  autoStartDate?: Date;
+  type: TDatesTypes;
   autoStopDate?: Date;
   autoDestroyDate: Date;
-  maxStartTimestamp?: number;
-  minStartTimestamp?: number;
-  stopMaxDate?: number | null;
-  stopMinDate?: number;
-  stopMaxDateExclusive?: boolean;
   maxRuntimeTimestamp?: number;
   defaultRuntimeTimestamp?: number;
   maxDestroyTimestamp?: number;
-  showNoAutoStopSwitch?: boolean;
   onConfirm: (date: TDates) => void;
   onClose: () => void;
   isAutoStopDisabled?: boolean;
   title: string;
 }> = ({
   type,
-  autoStartDate,
   autoStopDate,
   autoDestroyDate,
-  maxStartTimestamp,
-  minStartTimestamp,
-  stopMaxDate,
-  stopMinDate,
-  stopMaxDateExclusive = false,
   maxRuntimeTimestamp,
   defaultRuntimeTimestamp,
   maxDestroyTimestamp,
-  showNoAutoStopSwitch = false,
   onConfirm,
   onClose,
   isAutoStopDisabled = false,
@@ -47,98 +33,37 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
 }) => {
   const helpLink = useHelpLink();
   const [autoStopDestroyModal, openAutoStopDestroyModal] = useModal();
-  const [now, setNow] = useState(() => Date.now());
-  const [noAutoStopSelected, setNoAutoStopSelected] = useState(false);
+  const [now] = useState(() => Date.now());
   const [dates, setDates] = useState<TDates>({
-    startDate: null,
     stopDate: null,
     endDate: null,
   });
-  const _startDate = dates.startDate || autoStartDate;
-  const _stopDate =
-    showNoAutoStopSwitch && noAutoStopSelected ? undefined : dates.stopDate || autoStopDate;
+  const _stopDate = dates.stopDate || autoStopDate;
   const _endDate = dates.endDate || autoDestroyDate;
-  const noAutoStopChecked = showNoAutoStopSwitch
-    ? noAutoStopSelected
-    : !_stopDate || (!!_stopDate && !!_endDate && _stopDate.getTime() >= _endDate.getTime());
-  const effectiveStopMaxDate = stopMaxDateExclusive
-    ? stopMaxDate ?? null
-    : stopMaxDate ?? (maxRuntimeTimestamp ? now + maxRuntimeTimestamp : null);
-  let effectiveStopMinDate = stopMinDate ? Math.max(now, stopMinDate) : now;
-  if (effectiveStopMaxDate && effectiveStopMinDate >= effectiveStopMaxDate) {
-    effectiveStopMinDate = effectiveStopMaxDate - 60000;
-  }
-  const noAutoStopSwitchIsVisible =
-    showNoAutoStopSwitch ||
-    effectiveStopMaxDate === null ||
-    (!!effectiveStopMaxDate && effectiveStopMaxDate >= _endDate.getTime());
+  const noAutoStopChecked = _stopDate && _endDate && _stopDate.getTime() >= _endDate.getTime();
 
   useEffect(() => {
-    if (!type) {
-      return;
+    if (type) {
+      openAutoStopDestroyModal();
     }
-    setNow(Date.now());
-    setDates({ startDate: null, stopDate: null, endDate: null });
-    if (type === 'auto-stop' && showNoAutoStopSwitch) {
-      setNoAutoStopSelected(!autoStopDate);
-    }
-    openAutoStopDestroyModal();
-  }, [type]);
+  }, [openAutoStopDestroyModal, type]);
 
   return (
-    <Modal
-      ref={autoStopDestroyModal}
-      onConfirm={() => {
-        if (type === 'auto-stop' && showNoAutoStopSwitch) {
-          onConfirm({
-            ...dates,
-            stopDate: noAutoStopSelected ? undefined : dates.stopDate ?? autoStopDate,
-          });
-          return;
-        }
-        if (type === 'auto-stop' && noAutoStopChecked) {
-          onConfirm({
-            ...dates,
-            stopDate: dates.stopDate ?? new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
-          });
-          return;
-        }
-        onConfirm(dates);
-      }}
-      title={title}
-      onClose={onClose}
-    >
+    <Modal ref={autoStopDestroyModal} onConfirm={() => onConfirm(dates)} title={title} onClose={onClose}>
       <Form isHorizontal>
-        {type === 'auto-start' ? (
-          <>
-            <FormGroup fieldId="auto-start-modal" label="Start">
-              <DateTimePicker
-                defaultTimestamp={autoStartDate ? autoStartDate.getTime() : now}
-                onSelect={(d) => setDates((prev) => ({ ...prev, startDate: d }))}
-                minDate={minStartTimestamp ?? now}
-                maxDate={maxStartTimestamp ?? null}
-                forceUpdateTimestamp={dates.startDate?.getTime()}
-              />
-            </FormGroup>
-            {_startDate && _startDate.getTime() <= now ? (
-              <Alert variant="warning" isInline title="The selected start date and time is in the past." />
-            ) : null}
-          </>
-        ) : null}
         {type === 'auto-stop' ? (
           !isAutoStopDisabled ? (
             <>
               <FormGroup fieldId="auto-stop-modal" label="Auto-stop">
                 <DateTimePicker
                   defaultTimestamp={autoStopDate ? autoStopDate.getTime() : null}
-                  onSelect={(d) => setDates((prev) => ({ ...prev, stopDate: d }))}
-                  minDate={effectiveStopMinDate}
-                  maxDate={effectiveStopMaxDate}
+                  onSelect={(d) => setDates({ ...dates, stopDate: d })}
+                  minDate={now}
+                  maxDate={now + maxRuntimeTimestamp}
                   isDisabled={noAutoStopChecked}
-                  forceUpdateTimestamp={dates.stopDate?.getTime()}
                 />
               </FormGroup>
-              {noAutoStopSwitchIsVisible ? (
+              {now + maxRuntimeTimestamp >= _endDate.getTime() ? (
                 <Switch
                   id="no-auto-stop-switch"
                   aria-label="No auto-stop"
@@ -146,28 +71,12 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
                   isChecked={noAutoStopChecked}
                   hasCheckIcon
                   onChange={(_event, isChecked) => {
-                    if (showNoAutoStopSwitch) {
-                      setNoAutoStopSelected(isChecked);
-                      if (isChecked) {
-                        setDates((prev) => ({ ...prev, stopDate: null }));
-                      } else {
-                        setDates((prev) => ({
-                          ...prev,
-                          stopDate: new Date(Date.now() + (defaultRuntimeTimestamp || 0)),
-                        }));
-                      }
-                      return;
-                    }
                     if (isChecked) {
-                      setDates((prev) => ({
-                        ...prev,
-                        stopDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
-                      }));
-                    } else {
-                      setDates((prev) => ({
-                        ...prev,
-                        stopDate: new Date(Date.now() + defaultRuntimeTimestamp),
-                      }));
+                      setDates({
+                          ...dates,
+                          stopDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+                        })
+                      }else { setDates({ ...dates, stopDate: new Date(Date.now() + defaultRuntimeTimestamp) });
                     }
                   }}
                 />
@@ -207,7 +116,7 @@ const CatalogItemFormAutoStopDestroyModal: React.FC<{
             <FormGroup fieldId="auto-destroy-modal" label="Auto-destroy">
               <DateTimePicker
                 defaultTimestamp={autoDestroyDate.getTime()}
-                onSelect={(d) => setDates((prev) => ({ ...prev, endDate: d }))}
+                onSelect={(d) => setDates({ ...dates, endDate: d })}
                 maxDate={maxDestroyTimestamp ? now + maxDestroyTimestamp : null}
                 minDate={now}
                 forceUpdateTimestamp={dates.endDate?.getTime()}

--- a/catalog/ui/src/app/Modal/useModal.tsx
+++ b/catalog/ui/src/app/Modal/useModal.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 export default function useModal(): [
   modalInstance: React.Ref<{
@@ -11,13 +10,13 @@ export default function useModal(): [
 ] {
   const modalInstance = useRef(null);
 
-  const openModalFn = () => {
-    modalInstance.current.open();
-  };
+  const openModalFn = useCallback(() => {
+    modalInstance.current?.open();
+  }, []);
 
-  const closeModalFn = () => {
-    modalInstance.current.close();
-  };
+  const closeModalFn = useCallback(() => {
+    modalInstance.current?.close();
+  }, []);
 
   return [modalInstance, openModalFn, closeModalFn];
 }

--- a/catalog/ui/src/app/Services/ServiceActions.tsx
+++ b/catalog/ui/src/app/Services/ServiceActions.tsx
@@ -20,6 +20,7 @@ const ServiceActions: React.FC<{
     stop?: () => void;
     manageWorkshop?: () => void;
     rate?: () => void;
+    reorder?: () => void;
   };
   canManageCollaborators?: boolean;
   className?: string;
@@ -98,6 +99,11 @@ const ServiceActions: React.FC<{
   if (actionHandlers.manageWorkshop) {
     actionDropdownItems.push(
       <ActionDropdownItem key="manageWorkshop" label="Manage Workshop" onSelect={actionHandlers.manageWorkshop} />,
+    );
+  }
+  if (actionHandlers.reorder) {
+    actionDropdownItems.push(
+      <ActionDropdownItem key="reorder" label="Reorder" onSelect={actionHandlers.reorder} />,
     );
   }
   if (!isPartOfWorkshop && actionHandlers.rate) {

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -818,15 +818,18 @@ const ServicesItemComponent: React.FC<{
         }}
       >
         <ReorderModal
+          catalogItem={catalogItem}
           displayName={displayName(resourceClaim)}
+          isAdmin={isAdmin}
           schedule={getResourceClaimReorderSchedule(resourceClaim)}
-          onReorder={async () => {
+          onReorder={async (schedule) => {
             const newResourceClaim = await reorderResourceClaim({
               resourceClaim,
               catalogItem,
               groups,
               isAdmin,
               email,
+              schedule,
             });
             navigate(`/services/${newResourceClaim.metadata.namespace}/${newResourceClaim.metadata.name}`);
           }}

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -120,6 +120,12 @@ import useSWRImmutable from 'swr/immutable';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import useInterfaceConfig from '@app/utils/useInterfaceConfig';
 import UserDisabledModal from '@app/components/UserDisabledModal';
+import ReorderModal from '@app/components/ReorderModal';
+import {
+  canReorderResourceClaim,
+  getResourceClaimReorderSchedule,
+  reorderResourceClaim,
+} from '@app/reorder-utils';
 
 import ResourcePoolSelector from '@app/components/ResourcePoolSelector';
 
@@ -324,7 +330,7 @@ const ServicesItemComponent: React.FC<{
   const navigate = useNavigate();
   const location = useLocation();
   const { sfdc_enabled } = useInterfaceConfig();
-  const { isAdmin, groups, serviceNamespaces: sessionServiceNamespaces } = useSession().getSession();
+  const { isAdmin, groups, serviceNamespaces: sessionServiceNamespaces, email } = useSession().getSession();
   const { mutate: globalMutate, cache } = useSWRConfig();
   const [expanded, setExpanded] = useState([]);
   const {
@@ -366,6 +372,7 @@ const ServicesItemComponent: React.FC<{
   const [modalAction, openModalAction] = useModal();
   const [modalScheduleAction, openModalScheduleAction] = useModal();
   const [modalCreateWorkshop, openModalCreateWorkshop] = useModal();
+  const [modalReorder, openModalReorder] = useModal();
   const [modalEditSalesforce, setModalEditSalesforce] = useState(false);
   const [modalAddServiceAccess, setModalAddServiceAccess] = useState(false);
   const [isUserDisabledModalOpen, setIsUserDisabledModalOpen] = useState(false);
@@ -575,6 +582,7 @@ const ServicesItemComponent: React.FC<{
     stop?: () => void;
     manageWorkshop?: () => void;
     rate?: () => void;
+    reorder?: () => void;
   } = {
     delete: () => showModal({ action: 'delete', modal: 'action', resourceClaim }),
     lifespan: () => showModal({ action: 'retirement', modal: 'scheduleAction', resourceClaim }),
@@ -591,6 +599,9 @@ const ServicesItemComponent: React.FC<{
     actionHandlers.manageWorkshop = () => navigate(`/workshops/${serviceNamespace.name}/${workshopName}`);
   } else {
     actionHandlers.rate = () => showModal({ action: 'rate', modal: 'action', resourceClaim });
+  }
+  if (canReorderResourceClaim(resourceClaim, catalogItem, groups, isAdmin)) {
+    actionHandlers.reorder = () => openModalReorder();
   }
 
   // Find lab user interface information either in the resource claim or inside resources
@@ -795,6 +806,32 @@ const ServicesItemComponent: React.FC<{
         isOpen={isUserDisabledModalOpen}
         onClose={() => setIsUserDisabledModalOpen(false)}
       />
+      <Modal
+        ref={modalReorder}
+        onConfirm={() => undefined}
+        passModifiers={true}
+        confirmText="Reorder"
+        onError={(error: unknown) => {
+          if ((error as Response).status === 403) {
+            setIsUserDisabledModalOpen(true);
+          }
+        }}
+      >
+        <ReorderModal
+          displayName={displayName(resourceClaim)}
+          schedule={getResourceClaimReorderSchedule(resourceClaim)}
+          onReorder={async () => {
+            const newResourceClaim = await reorderResourceClaim({
+              resourceClaim,
+              catalogItem,
+              groups,
+              isAdmin,
+              email,
+            });
+            navigate(`/services/${newResourceClaim.metadata.namespace}/${newResourceClaim.metadata.name}`);
+          }}
+        />
+      </Modal>
       <Modal ref={modalScheduleAction} onConfirm={onModalScheduleAction} passModifiers={true}>
         <ServicesScheduleAction
           action={

--- a/catalog/ui/src/app/Workshops/WorkshopActions.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopActions.tsx
@@ -9,6 +9,7 @@ const WorkshopActions: React.FC<{
     deleteService?: () => void | null;
     start?: () => void | null;
     stop?: () => void | null;
+    reorder?: () => void | null;
   };
   canManageCollaborators?: boolean;
   className?: string;
@@ -64,6 +65,16 @@ const WorkshopActions: React.FC<{
         label="Stop Workshop instances"
         onSelect={actionHandlers.stop}
         icon={isLocked ? <LockedIcon /> : null}
+      />,
+    );
+  }
+  if (actionHandlers.reorder) {
+    actionDropdownItems.push(
+      <ActionDropdownItem
+        key="reorder"
+        isDisabled={!actionHandlers.reorder}
+        label="Reorder"
+        onSelect={actionHandlers.reorder}
       />,
     );
   }

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -36,6 +36,7 @@ import {
 } from '@app/api';
 import {
   NamespaceList,
+  CatalogItem,
   RequestUsageCost,
   ResourceClaim,
   ServiceAccessConfig,
@@ -70,6 +71,14 @@ import Label from '@app/components/Label';
 import LocalTimestamp from '@app/components/LocalTimestamp';
 import ProjectSelector from '@app/components/ProjectSelector';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import UserDisabledModal from '@app/components/UserDisabledModal';
+import ReorderModal from '@app/components/ReorderModal';
+import {
+  canReorderWorkshop,
+  getWorkshopReorderSchedule,
+  reorderWorkshop,
+} from '@app/reorder-utils';
+import useSWRImmutable from 'swr/immutable';
 import parseDuration from 'parse-duration';
 
 import './workshops-item.css';
@@ -98,11 +107,13 @@ const WorkshopsItemComponent: React.FC<{
   const navigate = useNavigate();
   const location = useLocation();
   const { mutate } = useSWRConfig();
-  const { isAdmin, serviceNamespaces: sessionServiceNamespaces } = useSession().getSession();
+  const { isAdmin, groups, serviceNamespaces: sessionServiceNamespaces, email } = useSession().getSession();
   const [modalState, setModalState] = useState<ModalState>({});
   const [modalAction, openModalAction] = useModal();
   const [modalDelete, openModalDelete] = useModal();
   const [modalSchedule, openModalSchedule] = useModal();
+  const [modalReorder, openModalReorder] = useModal();
+  const [isUserDisabledModalOpen, setIsUserDisabledModalOpen] = useState(false);
   const { cache } = useSWRConfig();
   const [selectedResourceClaims, setSelectedResourceClaims] = useState<ResourceClaim[]>([]);
   const [highlightAutoDestroy, setHighlightAutoDestroy] = useState(false);
@@ -163,6 +174,16 @@ const WorkshopsItemComponent: React.FC<{
 
   const stage = getStageFromK8sObject(workshop);
 
+  const { data: catalogItem } = useSWRImmutable<CatalogItem>(
+    workshop?.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemName`]
+      ? apiPaths.CATALOG_ITEM({
+          namespace: workshop.metadata.labels[`${BABYLON_DOMAIN}/catalogItemNamespace`],
+          name: workshop.metadata.labels[`${BABYLON_DOMAIN}/catalogItemName`],
+        })
+      : null,
+    silentFetcher,
+  );
+
   const { data: usageCost } = useSWR<RequestUsageCost>(
     workshop?.metadata.labels?.[`${BABYLON_DOMAIN}/workshop-id`]
       ? apiPaths.USAGE_COST_WORKSHOP({ workshopId: workshop.metadata.labels?.[`${BABYLON_DOMAIN}/workshop-id`] })
@@ -199,6 +220,11 @@ const WorkshopsItemComponent: React.FC<{
       revalidateIfStale: false, // Don't auto-revalidate stale data
       dedupingInterval: 3000, // Dedupe requests
     },
+  );
+
+  const workshopProvision = useMemo(
+    () => workshopProvisions?.find((provision) => provision.metadata.name === workshop?.metadata.name) || workshopProvisions?.[0],
+    [workshop?.metadata.name, workshopProvisions],
   );
 
   const { data: resourceClaims, mutate: mutateRC } = useSWR<ResourceClaim[]>(
@@ -497,6 +523,35 @@ const WorkshopsItemComponent: React.FC<{
           workshopProvisions={workshopProvisions}
         />
       </Modal>
+      <Modal
+        ref={modalReorder}
+        onConfirm={() => undefined}
+        passModifiers={true}
+        confirmText="Reorder"
+        onError={(error: unknown) => {
+          if ((error as Response).status === 403) {
+            setIsUserDisabledModalOpen(true);
+          }
+        }}
+      >
+        <ReorderModal
+          displayName={displayName(workshop)}
+          schedule={getWorkshopReorderSchedule(workshop)}
+          onReorder={async () => {
+            const newWorkshop = await reorderWorkshop({
+              workshop,
+              workshopProvision,
+              catalogItem,
+              email,
+            });
+            navigate(`/workshops/${newWorkshop.metadata.namespace}/${newWorkshop.metadata.name}`);
+          }}
+        />
+      </Modal>
+      <UserDisabledModal
+        isOpen={isUserDisabledModalOpen}
+        onClose={() => setIsUserDisabledModalOpen(false)}
+      />
       {isAdmin || serviceNamespaces.length > 1 ? (
         <PageSection hasBodyWrapper={false} key="topbar" className="workshops-item__topbar">
           <ProjectSelector
@@ -566,6 +621,9 @@ const WorkshopsItemComponent: React.FC<{
                         : null,
                   stop: checkWorkshopCanStop(resourceClaims)
                     ? () => showModal({ action: 'stopServices', resourceClaims })
+                    : null,
+                  reorder: canReorderWorkshop(workshop, catalogItem, workshopProvision, groups, isAdmin)
+                    ? () => openModalReorder()
                     : null,
                 }}
                 canManageCollaborators={canManageCollaborators}

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -535,14 +535,18 @@ const WorkshopsItemComponent: React.FC<{
         }}
       >
         <ReorderModal
+          catalogItem={catalogItem}
           displayName={displayName(workshop)}
+          isAdmin={isAdmin}
+          isWorkshop={true}
           schedule={getWorkshopReorderSchedule(workshop)}
-          onReorder={async () => {
+          onReorder={async (schedule) => {
             const newWorkshop = await reorderWorkshop({
               workshop,
               workshopProvision,
               catalogItem,
               email,
+              schedule,
             });
             navigate(`/workshops/${newWorkshop.metadata.namespace}/${newWorkshop.metadata.name}`);
           }}

--- a/catalog/ui/src/app/components/ReorderModal.tsx
+++ b/catalog/ui/src/app/components/ReorderModal.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import LocalTimestamp from '@app/components/LocalTimestamp';
+import { ReorderSchedule } from '@app/reorder-utils';
+
+const ReorderModal: React.FC<{
+  displayName: string;
+  schedule: ReorderSchedule;
+  onReorder: () => Promise<void>;
+  setOnConfirmCb?: React.Dispatch<React.SetStateAction<() => Promise<void>>>;
+  setTitle?: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ displayName, schedule, onReorder, setOnConfirmCb, setTitle }) => {
+  useEffect(() => {
+    setTitle?.('Reorder');
+    setOnConfirmCb?.(() => onReorder);
+  }, [onReorder, setOnConfirmCb, setTitle]);
+
+  return (
+    <>
+      <p>
+        You are about to reorder <strong>{displayName}</strong> with the same parameters as the original order.
+      </p>
+      <DescriptionList isHorizontal compact>
+        {schedule.startDate ? (
+          <DescriptionListGroup>
+            <DescriptionListTerm>Start</DescriptionListTerm>
+            <DescriptionListDescription>
+              <LocalTimestamp date={schedule.startDate} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        ) : null}
+        {schedule.stopDate ? (
+          <DescriptionListGroup>
+            <DescriptionListTerm>Stop</DescriptionListTerm>
+            <DescriptionListDescription>
+              <LocalTimestamp date={schedule.stopDate} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        ) : null}
+        {schedule.endDate ? (
+          <DescriptionListGroup>
+            <DescriptionListTerm>Destroy</DescriptionListTerm>
+            <DescriptionListDescription>
+              <LocalTimestamp date={schedule.endDate} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        ) : null}
+      </DescriptionList>
+    </>
+  );
+};
+
+export default ReorderModal;

--- a/catalog/ui/src/app/components/ReorderModal.tsx
+++ b/catalog/ui/src/app/components/ReorderModal.tsx
@@ -1,39 +1,132 @@
-import React, { useEffect } from 'react';
-import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
-import LocalTimestamp from '@app/components/LocalTimestamp';
-import { ReorderSchedule } from '@app/reorder-utils';
+import React, { useEffect, useMemo, useState } from 'react';
+import parseDuration from 'parse-duration';
+import {
+  Alert,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+import AutoStopDestroy from '@app/components/AutoStopDestroy';
+import CatalogItemFormAutoStopDestroyModal, {
+  TDatesTypes,
+} from '@app/Catalog/CatalogItemFormAutoStopDestroyModal';
+import { isAutoStopDisabled } from '@app/Catalog/catalog-utils';
+import { CatalogItem } from '@app/types';
+import {
+  getInitialReorderSchedule,
+  getStopMaxDate,
+  getStopMinDate,
+  isValidReorderSchedule,
+  parseCatalogDuration,
+  ReorderSchedule,
+} from '@app/reorder-utils';
 
 const ReorderModal: React.FC<{
+  catalogItem: CatalogItem;
   displayName: string;
+  isAdmin: boolean;
+  isWorkshop?: boolean;
   schedule: ReorderSchedule;
-  onReorder: () => Promise<void>;
+  onReorder: (schedule: ReorderSchedule) => Promise<void>;
   setOnConfirmCb?: React.Dispatch<React.SetStateAction<() => Promise<void>>>;
   setTitle?: React.Dispatch<React.SetStateAction<string>>;
-}> = ({ displayName, schedule, onReorder, setOnConfirmCb, setTitle }) => {
+  setIsDisabled?: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({
+  catalogItem,
+  displayName,
+  isAdmin,
+  isWorkshop = false,
+  schedule,
+  onReorder,
+  setOnConfirmCb,
+  setTitle,
+  setIsDisabled,
+}) => {
+  const [scheduleDates, setScheduleDates] = useState<ReorderSchedule>(() =>
+    getInitialReorderSchedule(schedule, catalogItem),
+  );
+  const [scheduleModal, setScheduleModal] = useState<TDatesTypes | null>(null);
+
+  const maxAutoDestroyTime = Math.min(
+    parseCatalogDuration(catalogItem.spec.lifespan?.maximum) ?? parseDuration('14d'),
+    parseCatalogDuration(catalogItem.spec.lifespan?.relativeMaximum) ?? parseDuration('7d'),
+  );
+  const maxAutoStopTime = parseCatalogDuration(catalogItem.spec.runtime?.maximum);
+  const defaultRuntimeTimestamp =
+    parseCatalogDuration(catalogItem.spec.runtime?.default) ?? parseDuration('4h');
+
+  const validationMessage = useMemo(() => {
+    const now = Date.now();
+    if (!scheduleDates.endDate) {
+      return 'Destroy date is required.';
+    }
+    if (scheduleDates.endDate.getTime() <= now) {
+      return 'Destroy date must be in the future.';
+    }
+    if (scheduleDates.stopDate) {
+      if (scheduleDates.stopDate.getTime() <= now) {
+        return 'Stop date must be in the future.';
+      }
+      if (scheduleDates.startDate.getTime() >= scheduleDates.stopDate.getTime()) {
+        return 'Start date must be before stop date.';
+      }
+    }
+    if (!scheduleDates.startDate) {
+      return 'Start date is required.';
+    }
+    if (scheduleDates.startDate.getTime() >= scheduleDates.endDate.getTime()) {
+      return 'Start date must be before destroy date.';
+    }
+    return null;
+  }, [scheduleDates]);
+
   useEffect(() => {
     setTitle?.('Reorder');
-    setOnConfirmCb?.(() => onReorder);
-  }, [onReorder, setOnConfirmCb, setTitle]);
+    setOnConfirmCb?.(() => () => onReorder(scheduleDates));
+  }, [onReorder, scheduleDates, setOnConfirmCb, setTitle]);
+
+  useEffect(() => {
+    setIsDisabled?.(!isValidReorderSchedule(scheduleDates));
+  }, [scheduleDates, setIsDisabled]);
+
+  const updateSchedule = (field: keyof ReorderSchedule, date: Date) => {
+    setScheduleDates((current) => ({ ...current, [field]: date }));
+  };
 
   return (
     <>
       <p>
-        You are about to reorder <strong>{displayName}</strong> with the same parameters as the original order.
+        You are about to reorder <strong>{displayName}</strong> with the same parameters as the original order. Adjust
+        the schedule below if needed.
       </p>
       <DescriptionList isHorizontal compact>
-        {schedule.startDate ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Start</DescriptionListTerm>
-            <DescriptionListDescription>
-              <LocalTimestamp date={schedule.startDate} />
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {schedule.stopDate ? (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Start</DescriptionListTerm>
+          <DescriptionListDescription>
+            <AutoStopDestroy
+              type="auto-start"
+              onClick={() => setScheduleModal('auto-start')}
+              time={scheduleDates.startDate.getTime()}
+              variant="extended"
+            />
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        {!isAutoStopDisabled(catalogItem) ? (
           <DescriptionListGroup>
             <DescriptionListTerm>Stop</DescriptionListTerm>
             <DescriptionListDescription>
-              <LocalTimestamp date={schedule.stopDate} />
+              <AutoStopDestroy
+                type="auto-stop"
+                onClick={() => setScheduleModal('auto-stop')}
+                time={
+                  scheduleDates.stopDate
+                    ? scheduleDates.stopDate.getTime()
+                    : scheduleDates.endDate.getTime()
+                }
+                variant="extended"
+                destroyTimestamp={scheduleDates.endDate.getTime()}
+              />
             </DescriptionListDescription>
           </DescriptionListGroup>
         ) : null}
@@ -41,11 +134,50 @@ const ReorderModal: React.FC<{
           <DescriptionListGroup>
             <DescriptionListTerm>Destroy</DescriptionListTerm>
             <DescriptionListDescription>
-              <LocalTimestamp date={schedule.endDate} />
+              <AutoStopDestroy
+                type="auto-destroy"
+                onClick={() => setScheduleModal('auto-destroy')}
+                time={scheduleDates.endDate.getTime()}
+                variant="extended"
+                destroyTimestamp={scheduleDates.endDate.getTime()}
+              />
             </DescriptionListDescription>
           </DescriptionListGroup>
         ) : null}
       </DescriptionList>
+      {validationMessage ? <Alert variant="warning" isInline title={validationMessage} /> : null}
+      <CatalogItemFormAutoStopDestroyModal
+        type={scheduleModal}
+        autoStartDate={scheduleDates.startDate}
+        autoStopDate={scheduleDates.stopDate}
+        autoDestroyDate={scheduleDates.endDate}
+        isAutoStopDisabled={isAutoStopDisabled(catalogItem)}
+        stopMaxDate={isAdmin ? null : getStopMaxDate(scheduleDates, maxAutoStopTime)}
+        stopMaxDateExclusive={true}
+        showNoAutoStopSwitch={true}
+        stopMinDate={getStopMinDate(scheduleDates)}
+        maxRuntimeTimestamp={isAdmin ? maxAutoDestroyTime : maxAutoStopTime ?? undefined}
+        defaultRuntimeTimestamp={defaultRuntimeTimestamp}
+        maxDestroyTimestamp={
+          isAdmin
+            ? null
+            : isWorkshop
+              ? scheduleDates.startDate.getTime() - Date.now() + parseDuration('5d')
+              : maxAutoDestroyTime
+        }
+        onConfirm={(dates) => {
+          if (scheduleModal === 'auto-start') {
+            updateSchedule('startDate', dates.startDate || scheduleDates.startDate);
+          } else if (scheduleModal === 'auto-stop') {
+            setScheduleDates((current) => ({ ...current, stopDate: dates.stopDate }));
+          } else if (scheduleModal === 'auto-destroy') {
+            updateSchedule('endDate', dates.endDate || scheduleDates.endDate);
+          }
+          setScheduleModal(null);
+        }}
+        onClose={() => setScheduleModal(null)}
+        title={displayName}
+      />
     </>
   );
 };

--- a/catalog/ui/src/app/components/ReorderModal.tsx
+++ b/catalog/ui/src/app/components/ReorderModal.tsx
@@ -11,16 +11,29 @@ import AutoStopDestroy from '@app/components/AutoStopDestroy';
 import CatalogItemFormAutoStopDestroyModal, {
   TDatesTypes,
 } from '@app/Catalog/CatalogItemFormAutoStopDestroyModal';
+import ReorderScheduleStartModal from '@app/components/ReorderScheduleStartModal';
 import { isAutoStopDisabled } from '@app/Catalog/catalog-utils';
 import { CatalogItem } from '@app/types';
 import {
   getInitialReorderSchedule,
-  getStopMaxDate,
-  getStopMinDate,
   isValidReorderSchedule,
   parseCatalogDuration,
   ReorderSchedule,
 } from '@app/reorder-utils';
+
+type ScheduleModalType = 'start' | TDatesTypes | null;
+
+function getConfirmedStopDate(
+  stopDate: Date | undefined,
+  endDate: Date,
+  previousStopDate?: Date,
+): Date | undefined {
+  const resolvedStopDate = stopDate ?? previousStopDate;
+  if (!resolvedStopDate || resolvedStopDate.getTime() >= endDate.getTime()) {
+    return undefined;
+  }
+  return resolvedStopDate;
+}
 
 const ReorderModal: React.FC<{
   catalogItem: CatalogItem;
@@ -46,7 +59,7 @@ const ReorderModal: React.FC<{
   const [scheduleDates, setScheduleDates] = useState<ReorderSchedule>(() =>
     getInitialReorderSchedule(schedule, catalogItem),
   );
-  const [scheduleModal, setScheduleModal] = useState<TDatesTypes | null>(null);
+  const [scheduleModal, setScheduleModal] = useState<ScheduleModalType>(null);
 
   const maxAutoDestroyTime = Math.min(
     parseCatalogDuration(catalogItem.spec.lifespan?.maximum) ?? parseDuration('14d'),
@@ -94,19 +107,29 @@ const ReorderModal: React.FC<{
     setScheduleDates((current) => ({ ...current, [field]: date }));
   };
 
+  const stopDestroyModalType =
+    scheduleModal === 'auto-stop' || scheduleModal === 'auto-destroy' ? scheduleModal : null;
+
   return (
     <>
       <p>
         You are about to reorder <strong>{displayName}</strong> with the same parameters as the original order. Adjust
         the schedule below if needed.
       </p>
-      <DescriptionList isHorizontal compact>
+      <DescriptionList
+        isHorizontal
+        compact
+        style={{
+          marginTop: 'var(--pf-t--global--spacer--md)',
+          marginBottom: 'var(--pf-t--global--spacer--md)',
+        }}
+      >
         <DescriptionListGroup>
           <DescriptionListTerm>Start</DescriptionListTerm>
           <DescriptionListDescription>
             <AutoStopDestroy
               type="auto-start"
-              onClick={() => setScheduleModal('auto-start')}
+              onClick={() => setScheduleModal('start')}
               time={scheduleDates.startDate.getTime()}
               variant="extended"
             />
@@ -146,16 +169,21 @@ const ReorderModal: React.FC<{
         ) : null}
       </DescriptionList>
       {validationMessage ? <Alert variant="warning" isInline title={validationMessage} /> : null}
+      <ReorderScheduleStartModal
+        isOpen={scheduleModal === 'start'}
+        startDate={scheduleDates.startDate}
+        title={displayName}
+        onConfirm={(startDate) => {
+          updateSchedule('startDate', startDate);
+          setScheduleModal(null);
+        }}
+        onClose={() => setScheduleModal(null)}
+      />
       <CatalogItemFormAutoStopDestroyModal
-        type={scheduleModal}
-        autoStartDate={scheduleDates.startDate}
+        type={stopDestroyModalType}
         autoStopDate={scheduleDates.stopDate}
         autoDestroyDate={scheduleDates.endDate}
         isAutoStopDisabled={isAutoStopDisabled(catalogItem)}
-        stopMaxDate={isAdmin ? null : getStopMaxDate(scheduleDates, maxAutoStopTime)}
-        stopMaxDateExclusive={true}
-        showNoAutoStopSwitch={true}
-        stopMinDate={getStopMinDate(scheduleDates)}
         maxRuntimeTimestamp={isAdmin ? maxAutoDestroyTime : maxAutoStopTime ?? undefined}
         defaultRuntimeTimestamp={defaultRuntimeTimestamp}
         maxDestroyTimestamp={
@@ -166,10 +194,11 @@ const ReorderModal: React.FC<{
               : maxAutoDestroyTime
         }
         onConfirm={(dates) => {
-          if (scheduleModal === 'auto-start') {
-            updateSchedule('startDate', dates.startDate || scheduleDates.startDate);
-          } else if (scheduleModal === 'auto-stop') {
-            setScheduleDates((current) => ({ ...current, stopDate: dates.stopDate }));
+          if (scheduleModal === 'auto-stop') {
+            setScheduleDates((current) => ({
+              ...current,
+              stopDate: getConfirmedStopDate(dates.stopDate, current.endDate, current.stopDate),
+            }));
           } else if (scheduleModal === 'auto-destroy') {
             updateSchedule('endDate', dates.endDate || scheduleDates.endDate);
           }

--- a/catalog/ui/src/app/components/ReorderScheduleStartModal.tsx
+++ b/catalog/ui/src/app/components/ReorderScheduleStartModal.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import DateTimePicker from '@app/components/DateTimePicker';
+import Modal, { useModal } from '@app/Modal/Modal';
+import { Form, FormGroup } from '@patternfly/react-core';
+
+const ReorderScheduleStartModal: React.FC<{
+  isOpen: boolean;
+  startDate: Date;
+  title: string;
+  onConfirm: (startDate: Date) => void;
+  onClose: () => void;
+}> = ({ isOpen, startDate, title, onConfirm, onClose }) => {
+  const [modalRef, openModal] = useModal();
+  const [now, setNow] = useState(() => Date.now());
+  const [selectedDate, setSelectedDate] = useState(startDate);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setNow(Date.now());
+    setSelectedDate(startDate);
+    openModal();
+  }, [isOpen, startDate]);
+
+  return (
+    <Modal ref={modalRef} title={title} onClose={onClose} onConfirm={() => onConfirm(selectedDate)}>
+      <Form isHorizontal>
+        <FormGroup fieldId="reorder-start-modal" label="Start">
+          <DateTimePicker
+            defaultTimestamp={startDate.getTime()}
+            forceUpdateTimestamp={selectedDate.getTime()}
+            minDate={now}
+            maxDate={null}
+            onSelect={setSelectedDate}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default ReorderScheduleStartModal;

--- a/catalog/ui/src/app/reorder-utils.spec.ts
+++ b/catalog/ui/src/app/reorder-utils.spec.ts
@@ -1,5 +1,15 @@
-import { canReorderResourceClaim, getResourceClaimReorderSchedule, getWorkshopReorderSchedule } from './reorder-utils';
+import {
+  canReorderResourceClaim,
+  getResourceClaimReorderSchedule,
+  getWorkshopReorderSchedule,
+  getInitialReorderSchedule,
+  getStopMaxDate,
+  getStopMinDate,
+  isNoAutoStop,
+  isValidReorderSchedule,
+} from './reorder-utils';
 import { CatalogItem, ResourceClaim, Workshop } from '@app/types';
+import parseDuration from 'parse-duration';
 
 const catalogItem: CatalogItem = {
   apiVersion: 'babylon.gpte.redhat.com/v1',
@@ -92,5 +102,89 @@ describe('reorder-utils', () => {
       },
     } as ResourceClaim;
     expect(canReorderResourceClaim(workshopResourceClaim, catalogItem, [], false)).toBe(false);
+  });
+
+  test('getInitialReorderSchedule resets past dates using catalog defaults', () => {
+    const now = Date.now();
+    const schedule = getInitialReorderSchedule(
+      {
+        startDate: new Date('2020-05-20T10:00:00Z'),
+        stopDate: new Date('2020-05-21T18:00:00Z'),
+        endDate: new Date('2020-05-22T10:00:00Z'),
+      },
+      catalogItem,
+    );
+    expect(schedule.startDate.getTime()).toBeGreaterThanOrEqual(now - 5000);
+    expect(schedule.startDate.getTime()).toBeLessThanOrEqual(now + 5000);
+    expect(schedule.endDate.getTime()).toBeGreaterThan(now);
+    expect(schedule.stopDate.getTime()).toBeGreaterThan(now);
+    expect(schedule.stopDate.getTime()).toBeLessThan(schedule.endDate.getTime());
+  });
+
+  test('getStopMaxDate uses start plus runtime capped by destroy', () => {
+    const startDate = new Date('2026-05-28T10:00:00Z');
+    const endDate = new Date('2026-05-31T10:00:00Z');
+    const maxRuntime = parseDuration('4h');
+    expect(getStopMaxDate({ startDate, endDate }, maxRuntime)).toBe(startDate.getTime() + maxRuntime);
+    expect(getStopMaxDate({ startDate, endDate }, parseDuration('7d'))).toBe(endDate.getTime() - 60000);
+  });
+
+  test('getStopMinDate is after start time', () => {
+    const now = Date.parse('2026-05-27T12:00:00Z');
+    const startDate = new Date('2026-05-28T10:00:00Z');
+    expect(getStopMinDate({ startDate }, now)).toBe(startDate.getTime() + 60000);
+  });
+
+  test('isValidReorderSchedule validates date ordering', () => {
+    const now = Date.parse('2026-05-27T12:00:00Z');
+    expect(
+      isValidReorderSchedule(
+        {
+          startDate: new Date('2026-05-28T10:00:00Z'),
+          stopDate: new Date('2026-05-28T18:00:00Z'),
+          endDate: new Date('2026-05-31T10:00:00Z'),
+        },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      isValidReorderSchedule(
+        {
+          startDate: new Date('2026-05-28T20:00:00Z'),
+          stopDate: new Date('2026-05-28T18:00:00Z'),
+          endDate: new Date('2026-05-31T10:00:00Z'),
+        },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      isValidReorderSchedule(
+        {
+          startDate: new Date('2026-05-28T10:00:00Z'),
+          endDate: new Date('2026-05-31T10:00:00Z'),
+        },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      isValidReorderSchedule(
+        {
+          endDate: new Date('2026-05-31T10:00:00Z'),
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test('isNoAutoStop is true only when stop date is missing', () => {
+    const endDate = new Date('2026-05-31T10:00:00Z');
+    expect(isNoAutoStop({ endDate })).toBe(true);
+    expect(isNoAutoStop({ stopDate: endDate, endDate })).toBe(false);
+    expect(
+      isNoAutoStop({
+        stopDate: new Date('2026-05-28T18:00:00Z'),
+        endDate,
+      }),
+    ).toBe(false);
   });
 });

--- a/catalog/ui/src/app/reorder-utils.spec.ts
+++ b/catalog/ui/src/app/reorder-utils.spec.ts
@@ -1,0 +1,96 @@
+import { canReorderResourceClaim, getResourceClaimReorderSchedule, getWorkshopReorderSchedule } from './reorder-utils';
+import { CatalogItem, ResourceClaim, Workshop } from '@app/types';
+
+const catalogItem: CatalogItem = {
+  apiVersion: 'babylon.gpte.redhat.com/v1',
+  kind: 'CatalogItem',
+  metadata: {
+    name: 'test-item',
+    namespace: 'catalog',
+  },
+  spec: {
+    displayName: 'Test Item',
+  },
+} as CatalogItem;
+
+const resourceClaim: ResourceClaim = {
+  apiVersion: 'poolboy.gpte.redhat.com/v1',
+  kind: 'ResourceClaim',
+  metadata: {
+    name: 'test-item-abc12',
+    namespace: 'user-namespace',
+    labels: {
+      'babylon.gpte.redhat.com/catalogItemName': 'test-item',
+      'babylon.gpte.redhat.com/catalogItemNamespace': 'catalog',
+    },
+    annotations: {
+      'demo.redhat.com/purpose': 'QA',
+    },
+  },
+  spec: {
+    lifespan: {
+      start: '2026-05-28T10:00:00Z',
+      end: '2026-05-31T10:00:00Z',
+    },
+    provider: {
+      name: 'test-item',
+      parameterValues: {
+        purpose: 'QA',
+        stop_timestamp: '2026-05-28T18:00:00Z',
+      },
+    },
+  },
+} as ResourceClaim;
+
+const workshop: Workshop = {
+  apiVersion: 'babylon.gpte.redhat.com/v1',
+  kind: 'Workshop',
+  metadata: {
+    name: 'test-workshop-abc12',
+    namespace: 'user-namespace',
+    labels: {
+      'babylon.gpte.redhat.com/catalogItemName': 'test-item',
+      'babylon.gpte.redhat.com/catalogItemNamespace': 'catalog',
+    },
+  },
+  spec: {
+    lifespan: {
+      start: '2026-05-28T10:00:00Z',
+      end: '2026-05-31T10:00:00Z',
+    },
+    actionSchedule: {
+      stop: '2026-05-28T18:00:00Z',
+    },
+  },
+} as Workshop;
+
+describe('reorder-utils', () => {
+  test('getResourceClaimReorderSchedule extracts start, stop, and destroy dates', () => {
+    const schedule = getResourceClaimReorderSchedule(resourceClaim);
+    expect(schedule.startDate?.toISOString()).toBe('2026-05-28T10:00:00.000Z');
+    expect(schedule.stopDate?.toISOString()).toBe('2026-05-28T18:00:00.000Z');
+    expect(schedule.endDate?.toISOString()).toBe('2026-05-31T10:00:00.000Z');
+  });
+
+  test('getWorkshopReorderSchedule extracts start, stop, and destroy dates', () => {
+    const schedule = getWorkshopReorderSchedule(workshop);
+    expect(schedule.startDate?.toISOString()).toBe('2026-05-28T10:00:00.000Z');
+    expect(schedule.stopDate?.toISOString()).toBe('2026-05-28T18:00:00.000Z');
+    expect(schedule.endDate?.toISOString()).toBe('2026-05-31T10:00:00.000Z');
+  });
+
+  test('canReorderResourceClaim returns true when catalog item is available', () => {
+    expect(canReorderResourceClaim(resourceClaim, catalogItem, [], false)).toBe(true);
+  });
+
+  test('canReorderResourceClaim returns false when part of workshop', () => {
+    const workshopResourceClaim = {
+      ...resourceClaim,
+      metadata: {
+        ...resourceClaim.metadata,
+        ownerReferences: [{ kind: 'Workshop', name: 'test-workshop', uid: 'uid' }],
+      },
+    } as ResourceClaim;
+    expect(canReorderResourceClaim(workshopResourceClaim, catalogItem, [], false)).toBe(false);
+  });
+});

--- a/catalog/ui/src/app/reorder-utils.spec.ts
+++ b/catalog/ui/src/app/reorder-utils.spec.ts
@@ -3,13 +3,10 @@ import {
   getResourceClaimReorderSchedule,
   getWorkshopReorderSchedule,
   getInitialReorderSchedule,
-  getStopMaxDate,
-  getStopMinDate,
   isNoAutoStop,
   isValidReorderSchedule,
 } from './reorder-utils';
 import { CatalogItem, ResourceClaim, Workshop } from '@app/types';
-import parseDuration from 'parse-duration';
 
 const catalogItem: CatalogItem = {
   apiVersion: 'babylon.gpte.redhat.com/v1',
@@ -119,20 +116,6 @@ describe('reorder-utils', () => {
     expect(schedule.endDate.getTime()).toBeGreaterThan(now);
     expect(schedule.stopDate.getTime()).toBeGreaterThan(now);
     expect(schedule.stopDate.getTime()).toBeLessThan(schedule.endDate.getTime());
-  });
-
-  test('getStopMaxDate uses start plus runtime capped by destroy', () => {
-    const startDate = new Date('2026-05-28T10:00:00Z');
-    const endDate = new Date('2026-05-31T10:00:00Z');
-    const maxRuntime = parseDuration('4h');
-    expect(getStopMaxDate({ startDate, endDate }, maxRuntime)).toBe(startDate.getTime() + maxRuntime);
-    expect(getStopMaxDate({ startDate, endDate }, parseDuration('7d'))).toBe(endDate.getTime() - 60000);
-  });
-
-  test('getStopMinDate is after start time', () => {
-    const now = Date.parse('2026-05-27T12:00:00Z');
-    const startDate = new Date('2026-05-28T10:00:00Z');
-    expect(getStopMinDate({ startDate }, now)).toBe(startDate.getTime() + 60000);
   });
 
   test('isValidReorderSchedule validates date ordering', () => {

--- a/catalog/ui/src/app/reorder-utils.ts
+++ b/catalog/ui/src/app/reorder-utils.ts
@@ -95,33 +95,12 @@ export function isNoAutoStop(schedule: ReorderSchedule): boolean {
   return !schedule.stopDate;
 }
 
-export function getStopMaxDate(
-  schedule: ReorderSchedule,
-  maxRuntimeMs: number | null | undefined,
-): number | null {
-  if (!schedule.endDate || !schedule.startDate) {
-    return null;
-  }
-  const destroyLimit = schedule.endDate.getTime() - 60000;
-  if (!maxRuntimeMs || Number.isNaN(maxRuntimeMs)) {
-    return destroyLimit;
-  }
-  return Math.min(destroyLimit, schedule.startDate.getTime() + maxRuntimeMs);
-}
-
 export function parseCatalogDuration(value?: string): number | null {
   if (!value) {
     return null;
   }
   const ms = parseDuration(value);
   return ms && !Number.isNaN(ms) ? ms : null;
-}
-
-export function getStopMinDate(schedule: ReorderSchedule, now = Date.now()): number {
-  if (!schedule.startDate) {
-    return now;
-  }
-  return Math.max(now, schedule.startDate.getTime() + 60000);
 }
 
 export function isValidReorderSchedule(schedule: ReorderSchedule, now = Date.now()): boolean {

--- a/catalog/ui/src/app/reorder-utils.ts
+++ b/catalog/ui/src/app/reorder-utils.ts
@@ -1,0 +1,255 @@
+import {
+  createServiceRequest,
+  createWorkshop,
+  createWorkshopProvision,
+  CreateServiceRequestParameterValues,
+} from '@app/api';
+import {
+  CatalogItem,
+  ResourceClaim,
+  ServiceNamespace,
+  Workshop,
+  WorkshopProvision,
+} from '@app/types';
+import {
+  BABYLON_DOMAIN,
+  checkAccessControl,
+  DEMO_DOMAIN,
+  getWhiteGloved,
+  isResourceClaimPartOfWorkshop,
+  parseSalesforceItems,
+} from '@app/util';
+
+export interface ReorderSchedule {
+  startDate?: Date;
+  stopDate?: Date;
+  endDate?: Date;
+}
+
+function parseOptionalDate(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : new Date(parsed);
+}
+
+export function getResourceClaimReorderSchedule(resourceClaim: ResourceClaim): ReorderSchedule {
+  const stopTimestamp = resourceClaim.spec.provider?.parameterValues?.stop_timestamp;
+  return {
+    startDate: parseOptionalDate(resourceClaim.spec.lifespan?.start),
+    stopDate: parseOptionalDate(stopTimestamp),
+    endDate: parseOptionalDate(
+      resourceClaim.spec.lifespan?.end || resourceClaim.status?.lifespan?.end,
+    ),
+  };
+}
+
+export function getWorkshopReorderSchedule(workshop: Workshop): ReorderSchedule {
+  return {
+    startDate: parseOptionalDate(workshop.spec.lifespan?.start || workshop.spec.actionSchedule?.start),
+    stopDate: parseOptionalDate(workshop.spec.actionSchedule?.stop),
+    endDate: parseOptionalDate(workshop.spec.lifespan?.end),
+  };
+}
+
+function getSkippedSfdc(annotations: Record<string, string>): boolean {
+  return annotations[`${DEMO_DOMAIN}/provide_salesforce-id_later`] === 'true';
+}
+
+function getServiceNamespaceFromObject(
+  namespace: string,
+  annotations: Record<string, string>,
+): ServiceNamespace {
+  return {
+    name: namespace,
+    displayName: namespace,
+    requester: annotations[`${DEMO_DOMAIN}/requester`],
+  };
+}
+
+function getParameterValuesFromResourceClaim(resourceClaim: ResourceClaim): CreateServiceRequestParameterValues {
+  const parameterValues: CreateServiceRequestParameterValues = {
+    ...(resourceClaim.spec.provider?.parameterValues || {}),
+  };
+  delete parameterValues.stop_timestamp;
+
+  const annotations = resourceClaim.metadata.annotations || {};
+  if (annotations[`${DEMO_DOMAIN}/purpose`]) {
+    parameterValues.purpose = annotations[`${DEMO_DOMAIN}/purpose`];
+  }
+  if (annotations[`${DEMO_DOMAIN}/purpose-activity`]) {
+    parameterValues.purpose_activity = annotations[`${DEMO_DOMAIN}/purpose-activity`];
+  }
+  if (annotations[`${DEMO_DOMAIN}/purpose-explanation`]) {
+    parameterValues.purpose_explanation = annotations[`${DEMO_DOMAIN}/purpose-explanation`];
+  }
+
+  return parameterValues;
+}
+
+function getParameterValuesFromWorkshopProvision(
+  workshopProvision: WorkshopProvision,
+): CreateServiceRequestParameterValues {
+  const parameters: CreateServiceRequestParameterValues = { ...(workshopProvision.spec.parameters || {}) };
+  delete parameters.salesforce_items;
+  return parameters;
+}
+
+function canReorderCatalogItem(
+  catalogItem: CatalogItem | undefined,
+  groups: string[],
+  isAdmin: boolean,
+): catalogItem is CatalogItem {
+  if (!catalogItem) {
+    return false;
+  }
+  if (catalogItem.spec.externalUrl) {
+    return false;
+  }
+  return checkAccessControl(catalogItem.spec.accessControl, groups, isAdmin) === 'allow';
+}
+
+export function canReorderResourceClaim(
+  resourceClaim: ResourceClaim,
+  catalogItem: CatalogItem | undefined,
+  groups: string[],
+  isAdmin: boolean,
+): boolean {
+  if (isResourceClaimPartOfWorkshop(resourceClaim)) {
+    return false;
+  }
+  if (
+    !resourceClaim.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemName`] ||
+    !resourceClaim.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemNamespace`]
+  ) {
+    return false;
+  }
+  if (
+    resourceClaim.spec.resources?.[0]?.provider?.name === 'babylon-service-request-configmap' &&
+    !isAdmin
+  ) {
+    return false;
+  }
+  const schedule = getResourceClaimReorderSchedule(resourceClaim);
+  if (!schedule.endDate) {
+    return false;
+  }
+  return canReorderCatalogItem(catalogItem, groups, isAdmin);
+}
+
+export function canReorderWorkshop(
+  workshop: Workshop,
+  catalogItem: CatalogItem | undefined,
+  workshopProvision: WorkshopProvision | undefined,
+  groups: string[],
+  isAdmin: boolean,
+): boolean {
+  if (workshop.spec.provisionDisabled) {
+    return false;
+  }
+  if (
+    !workshop.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemName`] ||
+    !workshop.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemNamespace`]
+  ) {
+    return false;
+  }
+  if (!workshopProvision) {
+    return false;
+  }
+  return canReorderCatalogItem(catalogItem, groups, isAdmin);
+}
+
+export async function reorderResourceClaim({
+  resourceClaim,
+  catalogItem,
+  groups,
+  isAdmin,
+  email,
+}: {
+  resourceClaim: ResourceClaim;
+  catalogItem: CatalogItem;
+  groups: string[];
+  isAdmin: boolean;
+  email: string;
+}): Promise<ResourceClaim> {
+  const schedule = getResourceClaimReorderSchedule(resourceClaim);
+  if (!schedule.endDate) {
+    throw new Error('Cannot reorder: auto-destroy date is missing from the original service.');
+  }
+  const annotations = resourceClaim.metadata.annotations || {};
+  const serviceNamespace = getServiceNamespaceFromObject(resourceClaim.metadata.namespace, annotations);
+  const selectedResourcePool = annotations['poolboy.gpte.redhat.com/resource-pool-name'];
+  const catalogNamespaceName =
+    annotations[`${BABYLON_DOMAIN}/catalogDisplayName`] || catalogItem.metadata.namespace;
+
+  return createServiceRequest({
+    catalogItem,
+    catalogNamespaceName,
+    groups,
+    isAdmin,
+    parameterValues: getParameterValuesFromResourceClaim(resourceClaim),
+    serviceNamespace,
+    startDate: schedule.startDate,
+    stopDate: schedule.stopDate,
+    endDate: schedule.endDate,
+    selectedResourcePool,
+    useAutoDetach: !!resourceClaim.spec.autoDetach,
+    email,
+    skippedSfdc: getSkippedSfdc(annotations),
+    whiteGloved: getWhiteGloved(resourceClaim),
+    salesforceItems: parseSalesforceItems(annotations),
+  });
+}
+
+export async function reorderWorkshop({
+  workshop,
+  workshopProvision,
+  catalogItem,
+  email,
+}: {
+  workshop: Workshop;
+  workshopProvision: WorkshopProvision;
+  catalogItem: CatalogItem;
+  email: string;
+}): Promise<Workshop> {
+  const schedule = getWorkshopReorderSchedule(workshop);
+  const annotations = workshop.metadata.annotations || {};
+  const serviceNamespace = getServiceNamespaceFromObject(workshop.metadata.namespace, annotations);
+  const parameterValues = getParameterValuesFromWorkshopProvision(workshopProvision);
+  const readyByDate = parseOptionalDate(workshop.spec.lifespan?.readyBy);
+
+  const newWorkshop = await createWorkshop({
+    accessPassword: workshop.spec.accessPassword,
+    catalogItem,
+    description: workshop.spec.description,
+    displayName: workshop.spec.displayName,
+    openRegistration: workshop.spec.openRegistration ?? true,
+    serviceNamespace,
+    stopDate: schedule.stopDate,
+    endDate: schedule.endDate,
+    startDate: schedule.startDate,
+    readyByDate,
+    email,
+    parameterValues,
+    skippedSfdc: getSkippedSfdc(annotations),
+    whiteGloved: getWhiteGloved(workshop),
+    salesforceItems: parseSalesforceItems(annotations),
+  });
+
+  await createWorkshopProvision({
+    catalogItem,
+    concurrency: workshopProvision.spec.concurrency,
+    count: workshopProvision.spec.count,
+    parameters: {
+      ...parameterValues,
+      salesforce_items: JSON.stringify(parseSalesforceItems(annotations)),
+    },
+    startDelay: workshopProvision.spec.startDelay,
+    workshop: newWorkshop,
+    useAutoDetach: !!workshopProvision.spec.autoDetach,
+    selectedResourcePool: workshopProvision.spec.resourcePool,
+  });
+
+  return newWorkshop;
+}

--- a/catalog/ui/src/app/reorder-utils.ts
+++ b/catalog/ui/src/app/reorder-utils.ts
@@ -1,3 +1,4 @@
+import parseDuration from 'parse-duration';
 import {
   createServiceRequest,
   createWorkshop,
@@ -51,6 +52,97 @@ export function getWorkshopReorderSchedule(workshop: Workshop): ReorderSchedule 
     stopDate: parseOptionalDate(workshop.spec.actionSchedule?.stop),
     endDate: parseOptionalDate(workshop.spec.lifespan?.end),
   };
+}
+
+export function getInitialReorderSchedule(schedule: ReorderSchedule, catalogItem: CatalogItem): ReorderSchedule {
+  const now = Date.now();
+  const defaultRuntime = parseDuration(catalogItem.spec.runtime?.default || '4h');
+  const defaultLifespan = parseDuration(catalogItem.spec.lifespan?.default || '72h');
+
+  let endDate = schedule.endDate;
+  let stopDate = schedule.stopDate;
+  let startDate = schedule.startDate ?? new Date(now);
+
+  if (!endDate || endDate.getTime() <= now) {
+    startDate = new Date(now);
+    endDate = new Date(now + defaultLifespan);
+    if (schedule.stopDate) {
+      stopDate = new Date(Math.min(startDate.getTime() + defaultRuntime, endDate.getTime() - 60000));
+    }
+  } else {
+    if (startDate.getTime() < now) {
+      startDate = new Date(now);
+    }
+    if (stopDate && stopDate.getTime() <= now) {
+      if (endDate && stopDate.getTime() >= endDate.getTime()) {
+        stopDate = undefined;
+      } else {
+        stopDate = new Date(Math.min(startDate.getTime() + defaultRuntime, endDate.getTime() - 60000));
+      }
+    }
+    if (stopDate && endDate && stopDate.getTime() >= endDate.getTime()) {
+      stopDate = undefined;
+    }
+    if (stopDate && stopDate.getTime() <= startDate.getTime()) {
+      stopDate = new Date(Math.min(startDate.getTime() + defaultRuntime, endDate.getTime() - 60000));
+    }
+  }
+
+  return { startDate, stopDate, endDate };
+}
+
+export function isNoAutoStop(schedule: ReorderSchedule): boolean {
+  return !schedule.stopDate;
+}
+
+export function getStopMaxDate(
+  schedule: ReorderSchedule,
+  maxRuntimeMs: number | null | undefined,
+): number | null {
+  if (!schedule.endDate || !schedule.startDate) {
+    return null;
+  }
+  const destroyLimit = schedule.endDate.getTime() - 60000;
+  if (!maxRuntimeMs || Number.isNaN(maxRuntimeMs)) {
+    return destroyLimit;
+  }
+  return Math.min(destroyLimit, schedule.startDate.getTime() + maxRuntimeMs);
+}
+
+export function parseCatalogDuration(value?: string): number | null {
+  if (!value) {
+    return null;
+  }
+  const ms = parseDuration(value);
+  return ms && !Number.isNaN(ms) ? ms : null;
+}
+
+export function getStopMinDate(schedule: ReorderSchedule, now = Date.now()): number {
+  if (!schedule.startDate) {
+    return now;
+  }
+  return Math.max(now, schedule.startDate.getTime() + 60000);
+}
+
+export function isValidReorderSchedule(schedule: ReorderSchedule, now = Date.now()): boolean {
+  if (!schedule.endDate || schedule.endDate.getTime() <= now) {
+    return false;
+  }
+  if (!schedule.startDate) {
+    return false;
+  }
+  if (schedule.stopDate) {
+    if (schedule.stopDate.getTime() <= now) {
+      return false;
+    }
+    if (schedule.startDate.getTime() >= schedule.stopDate.getTime()) {
+      return false;
+    }
+  }
+  if (schedule.startDate.getTime() >= schedule.endDate.getTime()) {
+    return false;
+  }
+  return true;
 }
 
 function getSkippedSfdc(annotations: Record<string, string>): boolean {
@@ -166,16 +258,21 @@ export async function reorderResourceClaim({
   groups,
   isAdmin,
   email,
+  schedule: scheduleOverride,
 }: {
   resourceClaim: ResourceClaim;
   catalogItem: CatalogItem;
   groups: string[];
   isAdmin: boolean;
   email: string;
+  schedule?: ReorderSchedule;
 }): Promise<ResourceClaim> {
-  const schedule = getResourceClaimReorderSchedule(resourceClaim);
+  const schedule = scheduleOverride ?? getResourceClaimReorderSchedule(resourceClaim);
   if (!schedule.endDate) {
     throw new Error('Cannot reorder: auto-destroy date is missing from the original service.');
+  }
+  if (!isValidReorderSchedule(schedule)) {
+    throw new Error('Cannot reorder: schedule dates are invalid.');
   }
   const annotations = resourceClaim.metadata.annotations || {};
   const serviceNamespace = getServiceNamespaceFromObject(resourceClaim.metadata.namespace, annotations);
@@ -207,13 +304,21 @@ export async function reorderWorkshop({
   workshopProvision,
   catalogItem,
   email,
+  schedule: scheduleOverride,
 }: {
   workshop: Workshop;
   workshopProvision: WorkshopProvision;
   catalogItem: CatalogItem;
   email: string;
+  schedule?: ReorderSchedule;
 }): Promise<Workshop> {
-  const schedule = getWorkshopReorderSchedule(workshop);
+  const schedule = scheduleOverride ?? getWorkshopReorderSchedule(workshop);
+  if (!schedule.endDate) {
+    throw new Error('Cannot reorder: auto-destroy date is missing from the original workshop.');
+  }
+  if (!isValidReorderSchedule(schedule)) {
+    throw new Error('Cannot reorder: schedule dates are invalid.');
+  }
   const annotations = workshop.metadata.annotations || {};
   const serviceNamespace = getServiceNamespaceFromObject(workshop.metadata.namespace, annotations);
   const parameterValues = getParameterValuesFromWorkshopProvision(workshopProvision);


### PR DESCRIPTION
Let users duplicate an existing order with the same parameters and schedule from the actions dropdown, with a confirmation modal showing start, stop, and destroy times.