### PR TITLE
fix(catalog-ui): Replace raw support URL with friendly link label

### DIFF
--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -112,6 +112,7 @@ import ServiceStatus from './ServiceStatus';
 import ServiceItemStatus from './ServiceItemStatus';
 import InfoTab from './InfoTab';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import useDebounceState from '@app/utils/useDebounceState';
 import SalesforceItemsList from '@app/components/SalesforceItemsList';
@@ -1003,16 +1004,6 @@ const ServicesItemComponent: React.FC<{
                       </DescriptionListDescription>
                     </DescriptionListGroup>
                   ) : null}
-                  {supportLink ? (
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Support</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        <a href={supportLink} target="_blank" rel="noopener noreferrer">
-                          {supportLink}
-                        </a>
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                  ) : null}
                   <DescriptionListGroup>
                     <DescriptionListTerm>GUID</DescriptionListTerm>
                     <DescriptionListDescription>
@@ -1034,6 +1025,25 @@ const ServicesItemComponent: React.FC<{
                       <LocalTimestamp timestamp={resourceClaim.metadata.creationTimestamp} />
                     </DescriptionListDescription>
                   </DescriptionListGroup>
+                  {supportLink ? (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Support</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Button
+                          component="a"
+                          href={supportLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          variant="link"
+                          isInline
+                          icon={<ExternalLinkAltIcon />}
+                          iconPosition="end"
+                        >
+                          {supportLink.includes('slack.com') ? 'Slack Channel' : 'Get Support'}
+                        </Button>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ) : null}
 
                   {startTime && startTime > Date.now() ? (
                     <DescriptionListGroup>

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -1039,7 +1039,7 @@ const ServicesItemComponent: React.FC<{
                           icon={<ExternalLinkAltIcon />}
                           iconPosition="end"
                         >
-                          {supportLink.includes('slack.com') ? 'Slack Channel' : 'Get Support'}
+                          {/^https?:\/\/([^/]+\.)?slack\.com(\/|$)/i.test(supportLink) ? 'Slack Channel' : 'Get Support'}
                         </Button>
                       </DescriptionListDescription>
                     </DescriptionListGroup>

--- a/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
@@ -22,6 +22,7 @@ import {
 } from '@patternfly/react-core';
 import { Select, SelectOption, SelectList, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import {
   apiPaths,
@@ -384,9 +385,18 @@ const WorkshopsItemDetails: React.FC<{
         <DescriptionListGroup>
           <DescriptionListTerm>Support</DescriptionListTerm>
           <DescriptionListDescription>
-            <a href={supportLink} target="_blank" rel="noopener noreferrer">
-              {supportLink}
-            </a>
+            <Button
+              component="a"
+              href={supportLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="link"
+              isInline
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+            >
+              {supportLink.includes('slack.com') ? 'Slack Channel' : 'Get Support'}
+            </Button>
           </DescriptionListDescription>
         </DescriptionListGroup>
       ) : null}

--- a/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
@@ -395,7 +395,7 @@ const WorkshopsItemDetails: React.FC<{
               icon={<ExternalLinkAltIcon />}
               iconPosition="end"
             >
-              {supportLink.includes('slack.com') ? 'Slack Channel' : 'Get Support'}
+              {/^https?:\/\/([^/]+\.)?slack\.com(\/|$)/i.test(supportLink) ? 'Slack Channel' : 'Get Support'}
             </Button>
           </DescriptionListDescription>
         </DescriptionListGroup>


### PR DESCRIPTION
The support field displayed the full URL (e.g. a long Slack link) which was noisy and unclear. Replace it with a PatternFly inline link button showing "Slack Channel" or "Get Support" with an external-link icon, and move it after "Requested On" in the service details for better ordering.