### PR TITLE
feat(selfpacedlab): Self-paced Lab UI/API Implementation

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1142,6 +1142,169 @@ async def workshop_post(request):
     raise web.HTTPConflict()
 
 
+@routes.get("/api/selfpacedlab/{selfpacedlab_id}")
+async def selfpacedlab_get(request):
+    """
+    Fetch self-paced lab for an attendee in order to present overview.
+    """
+    selfpacedlab_id = request.match_info.get('selfpacedlab_id')
+    selfpacedlab_list = await custom_objects_api.list_cluster_custom_object(
+        group='babylon.gpte.redhat.com',
+        label_selector=f"babylon.gpte.redhat.com/selfpacedlab-id={selfpacedlab_id}",
+        plural='selfpacedlabs',
+        version='v1',
+    )
+    if not selfpacedlab_list.get('items'):
+        raise web.HTTPNotFound()
+    selfpacedlab = selfpacedlab_list['items'][0]
+    ret = {
+        "accessPasswordRequired": True if selfpacedlab['spec'].get('accessPassword') else False,
+        "description": selfpacedlab['spec'].get('description'),
+        "displayName": selfpacedlab['spec'].get('displayName'),
+        "name": selfpacedlab['metadata']['name'],
+        "namespace": selfpacedlab['metadata']['namespace'],
+        "template": selfpacedlab['metadata'].get('annotations', {}).get('demo.redhat.com/user-message-template')
+            or selfpacedlab['metadata'].get('annotations', {}).get('demo.redhat.com/info-message-template')
+    }
+    return web.json_response(ret)
+
+
+@routes.post("/api/selfpacedlab/{selfpacedlab_id}")
+@routes.put("/api/selfpacedlab/{selfpacedlab_id}")
+async def selfpacedlab_post(request):
+    """
+    Access self-paced lab as an attendee with login information.
+    """
+    selfpacedlab_id = request.match_info.get('selfpacedlab_id')
+    if not request.can_read_body:
+        raise web.HTTPBadRequest()
+
+    data = await request.json()
+    if not data:
+        raise web.HTTPBadRequest()
+
+    access_password = data.get('accessPassword')
+    email = data.get('email')
+    if not email:
+        raise web.HTTPBadRequest()
+
+    selfpacedlab_list = await custom_objects_api.list_cluster_custom_object(
+        'babylon.gpte.redhat.com', 'v1', 'selfpacedlabs',
+        label_selector=f"babylon.gpte.redhat.com/selfpacedlab-id={selfpacedlab_id}"
+    )
+    if not selfpacedlab_list.get('items'):
+        raise web.HTTPConflict()
+
+    selfpacedlab = selfpacedlab_list['items'][0]
+    selfpacedlab_access_password = selfpacedlab['spec'].get('accessPassword')
+    selfpacedlab_name = selfpacedlab['metadata']['name']
+    selfpacedlab_namespace = selfpacedlab['metadata']['namespace']
+    selfpacedlab_open_registration = selfpacedlab['spec'].get('openRegistration', True)
+
+    if access_password:
+        if access_password != selfpacedlab_access_password:
+            raise web.HTTPForbidden()
+    elif selfpacedlab_access_password:
+        raise web.HTTPBadRequest()
+
+    resource_claims = await custom_objects_api.list_namespaced_custom_object(
+        group='poolboy.gpte.redhat.com',
+        namespace=selfpacedlab_namespace,
+        plural='resourceclaims',
+        version='v1',
+        label_selector=f"babylon.gpte.redhat.com/selfpacedlab={selfpacedlab_name}",
+    )
+
+    if not resource_claims.get('items'):
+        raise web.HTTPNotFound()
+
+    ret = {
+        "accessPasswordRequired": True if selfpacedlab_access_password else False,
+        "labUserInterfaceRedirect": selfpacedlab['spec'].get('labUserInterface', {}).get('redirect'),
+        "description": selfpacedlab['spec'].get('description'),
+        "displayName": selfpacedlab['spec'].get('displayName'),
+        "name": selfpacedlab_name,
+        "namespace": selfpacedlab_namespace,
+        "template": selfpacedlab['metadata'].get('annotations', {}).get('demo.redhat.com/user-message-template')
+            or selfpacedlab['metadata'].get('annotations', {}).get('demo.redhat.com/info-message-template')
+    }
+
+    def build_assignment_from_rc(rc):
+        annotations = rc.get('metadata', {}).get('annotations', {})
+        status = rc.get('status', {})
+        summary = status.get('summary', {})
+        provision_data = summary.get('provision_data', {}) or {}
+
+        assignment = {
+            "email": rc.get('metadata', {}).get('labels', {}).get(
+                'babylon.gpte.redhat.com/selfpacedlab-assignment', ''),
+        }
+
+        lab_ui_url = (
+            annotations.get('babylon.gpte.redhat.com/labUserInterfaceUrl')
+            or provision_data.get('labUserInterfaceUrl')
+            or provision_data.get('lab_ui_url')
+            or provision_data.get('bookbag_url')
+            or provision_data.get('showroom_primary_view_url')
+        )
+        if lab_ui_url:
+            assignment['labUserInterface'] = {
+                'url': lab_ui_url,
+                'method': annotations.get('babylon.gpte.redhat.com/labUserInterfaceMethod')
+                    or provision_data.get('labUserInterfaceMethod'),
+            }
+
+        messages = annotations.get('demo.redhat.com/info-message') or provision_data.get('messages')
+        if messages:
+            assignment['messages'] = messages
+
+        if provision_data:
+            assignment['data'] = provision_data
+
+        return assignment
+
+    for rc in resource_claims['items']:
+        assignment_label = rc.get('metadata', {}).get('labels', {}).get(
+            'babylon.gpte.redhat.com/selfpacedlab-assignment')
+        if assignment_label == email:
+            ret['assignment'] = build_assignment_from_rc(rc)
+            return web.json_response(ret)
+
+    if not selfpacedlab_open_registration:
+        raise web.HTTPConflict()
+
+    for rc in resource_claims['items']:
+        assignment_label = rc.get('metadata', {}).get('labels', {}).get(
+            'babylon.gpte.redhat.com/selfpacedlab-assignment')
+        if assignment_label:
+            continue
+        state = rc.get('status', {}).get('summary', {}).get('state')
+        if state not in ('started', 'stopped'):
+            continue
+
+        try:
+            await custom_objects_api.patch_namespaced_custom_object(
+                group='poolboy.gpte.redhat.com',
+                version='v1',
+                namespace=rc['metadata']['namespace'],
+                plural='resourceclaims',
+                name=rc['metadata']['name'],
+                body={
+                    'metadata': {
+                        'labels': {
+                            'babylon.gpte.redhat.com/selfpacedlab-assignment': email
+                        }
+                    }
+                },
+            )
+            ret['assignment'] = build_assignment_from_rc(rc)
+            ret['assignment']['email'] = email
+            return web.json_response(ret)
+        except kubernetes_asyncio.client.exceptions.ApiException as exception:
+            if exception.status != 409:
+                raise
+
+    raise web.HTTPConflict()
 
 
 
@@ -1296,7 +1459,7 @@ async def update_system_status(request):
         logging.error(f"Unexpected error updating system status: {e}")
         raise web.HTTPInternalServerError(reason="Failed to update system status")
 
-@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments}")
+@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments|selfpacedlabs|selfpacedlabitems}")
 @routes.get("/apis/{api_group:poolboy\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:resourceclaims}")
 async def openshift_api_list_by_get_rbac(request):
     """List items with special handling so that users can list items in a

--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1207,15 +1207,15 @@ async def selfpacedlab_post(request):
     elif selfpacedlab_access_password:
         raise web.HTTPBadRequest()
 
-    resource_claims = await custom_objects_api.list_namespaced_custom_object(
-        group='poolboy.gpte.redhat.com',
-        namespace=selfpacedlab_namespace,
-        plural='resourceclaims',
-        version='v1',
+    selfpacedlab_user_assignments = await custom_objects_api.list_namespaced_custom_object(
+        group='babylon.gpte.redhat.com',
         label_selector=f"babylon.gpte.redhat.com/selfpacedlab={selfpacedlab_name}",
+        namespace=selfpacedlab_namespace,
+        plural='selfpacedlabuserassignments',
+        version='v1',
     )
 
-    if not resource_claims.get('items'):
+    if not selfpacedlab_user_assignments.get('items'):
         raise web.HTTPNotFound()
 
     ret = {
@@ -1229,80 +1229,31 @@ async def selfpacedlab_post(request):
             or selfpacedlab['metadata'].get('annotations', {}).get('demo.redhat.com/info-message-template')
     }
 
-    def build_assignment_from_rc(rc):
-        annotations = rc.get('metadata', {}).get('annotations', {})
-        status = rc.get('status', {})
-        summary = status.get('summary', {})
-        provision_data = summary.get('provision_data', {}) or {}
-
-        assignment = {
-            "email": rc.get('metadata', {}).get('labels', {}).get(
-                'babylon.gpte.redhat.com/selfpacedlab-assignment', ''),
-        }
-
-        lab_ui_url = (
-            annotations.get('babylon.gpte.redhat.com/labUserInterfaceUrl')
-            or provision_data.get('labUserInterfaceUrl')
-            or provision_data.get('lab_ui_url')
-            or provision_data.get('bookbag_url')
-            or provision_data.get('showroom_primary_view_url')
-        )
-        if lab_ui_url:
-            assignment['labUserInterface'] = {
-                'url': lab_ui_url,
-                'method': annotations.get('babylon.gpte.redhat.com/labUserInterfaceMethod')
-                    or provision_data.get('labUserInterfaceMethod'),
-            }
-
-        messages = annotations.get('demo.redhat.com/info-message') or provision_data.get('messages')
-        if messages:
-            assignment['messages'] = messages
-
-        if provision_data:
-            assignment['data'] = provision_data
-
-        return assignment
-
-    for rc in resource_claims['items']:
-        assignment_label = rc.get('metadata', {}).get('labels', {}).get(
-            'babylon.gpte.redhat.com/selfpacedlab-assignment')
-        if assignment_label == email:
-            ret['assignment'] = build_assignment_from_rc(rc)
+    for user_assignment in selfpacedlab_user_assignments.get('items', []):
+        if email == user_assignment['spec'].get('assignment', {}).get('email'):
+            ret['assignment'] = user_assignment['spec']
             return web.json_response(ret)
 
     if not selfpacedlab_open_registration:
         raise web.HTTPConflict()
 
-    for rc in resource_claims['items']:
-        assignment_label = rc.get('metadata', {}).get('labels', {}).get(
-            'babylon.gpte.redhat.com/selfpacedlab-assignment')
-        if assignment_label:
-            continue
-        state = rc.get('status', {}).get('summary', {}).get('state')
-        if state not in ('started', 'stopped'):
-            continue
-
-        try:
-            await custom_objects_api.patch_namespaced_custom_object(
-                group='poolboy.gpte.redhat.com',
-                version='v1',
-                namespace=rc['metadata']['namespace'],
-                plural='resourceclaims',
-                name=rc['metadata']['name'],
-                body={
-                    'metadata': {
-                        'labels': {
-                            'babylon.gpte.redhat.com/selfpacedlab-assignment': email
-                        }
-                    }
-                },
-            )
-            ret['assignment'] = build_assignment_from_rc(rc)
-            ret['assignment']['email'] = email
-            return web.json_response(ret)
-        except kubernetes_asyncio.client.exceptions.ApiException as exception:
-            if exception.status != 409:
-                raise
+    for user_assignment in selfpacedlab_user_assignments.get('items', []):
+        if not 'assignment' in user_assignment['spec']:
+            try:
+                user_assignment['spec']['assignment'] = {"email": email}
+                await custom_objects_api.replace_namespaced_custom_object(
+                    body=user_assignment,
+                    group='babylon.gpte.redhat.com',
+                    name=user_assignment['metadata']['name'],
+                    namespace=user_assignment['metadata']['namespace'],
+                    plural='selfpacedlabuserassignments',
+                    version='v1',
+                )
+                ret['assignment'] = user_assignment['spec']
+                return web.json_response(ret)
+            except kubernetes_asyncio.client.exceptions.ApiException as exception:
+                if exception.status != 409:
+                    raise
 
     raise web.HTTPConflict()
 
@@ -1459,7 +1410,7 @@ async def update_system_status(request):
         logging.error(f"Unexpected error updating system status: {e}")
         raise web.HTTPInternalServerError(reason="Failed to update system status")
 
-@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments|selfpacedlabs|selfpacedlabitems}")
+@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments|selfpacedlabs|selfpacedlabitems|selfpacedlabuserassignments}")
 @routes.get("/apis/{api_group:poolboy\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:resourceclaims}")
 async def openshift_api_list_by_get_rbac(request):
     """List items with special handling so that users can list items in a

--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1220,7 +1220,7 @@ async def selfpacedlab_post(request):
 
     ret = {
         "accessPasswordRequired": True if selfpacedlab_access_password else False,
-        "labUserInterfaceRedirect": selfpacedlab['spec'].get('labUserInterface', {}).get('redirect'),
+        "labUserInterfaceRedirect": selfpacedlab['spec'].get('labUserInterface', {}).get('redirect', True),
         "description": selfpacedlab['spec'].get('description'),
         "displayName": selfpacedlab['spec'].get('displayName'),
         "name": selfpacedlab_name,

--- a/catalog/helm/templates/oauth-proxy/deployment.yaml
+++ b/catalog/helm/templates/oauth-proxy/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --logout-url=/
         - --provider=openshift
         - --skip-auth-regex=^/(api/)?workshop($|/.*)
+        - --skip-auth-regex=^/(api/)?selfpacedlab($|/.*)
         - --skip-auth-regex=^/(api/)?event($|/.*)
         - --skip-auth-regex=^/support($|/)
         - --skip-auth-regex=^/fonts/.*

--- a/catalog/ui/src/app/Admin/SelfPacedLabs.tsx
+++ b/catalog/ui/src/app/Admin/SelfPacedLabs.tsx
@@ -1,0 +1,326 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useSWRConfig } from 'swr';
+import useSWRInfinite from 'swr/infinite';
+import {
+  EmptyState,
+  EmptyStateBody,
+  PageSection,
+  Split,
+  SplitItem,
+  Title,
+  EmptyStateFooter,
+} from '@patternfly/react-core';
+import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import { apiPaths, deleteSelfPacedLab, fetcher } from '@app/api';
+import { SelfPacedLab, SelfPacedLabList } from '@app/types';
+import { compareK8sObjectsArr, displayName, FETCH_BATCH_LIMIT } from '@app/util';
+import Footer from '@app/components/Footer';
+import KeywordSearchInput from '@app/components/KeywordSearchInput';
+import LocalTimestamp from '@app/components/LocalTimestamp';
+import OpenshiftConsoleLink from '@app/components/OpenshiftConsoleLink';
+import SelectableTable from '@app/components/SelectableTable';
+import TimeInterval from '@app/components/TimeInterval';
+import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
+import Modal, { useModal } from '@app/Modal/Modal';
+import ProjectSelector from '@app/components/ProjectSelector';
+
+import './admin.css';
+
+function keywordMatch(selfPacedLab: SelfPacedLab, keyword: string): boolean {
+  const keywordLowerCased = keyword.toLowerCase();
+  if (
+    selfPacedLab.metadata.name.includes(keywordLowerCased) ||
+    selfPacedLab.metadata.namespace.includes(keywordLowerCased) ||
+    (selfPacedLab.spec.description && selfPacedLab.spec.description.toLowerCase().includes(keywordLowerCased)) ||
+    displayName(selfPacedLab).toLowerCase().includes(keywordLowerCased)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+const SelfPacedLabs: React.FC = () => {
+  const navigate = useNavigate();
+  const { namespace } = useParams();
+  const [modalAction, openModalAction] = useModal();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const keywordFilter = useMemo(
+    () =>
+      searchParams.has('search')
+        ? searchParams
+            .get('search')
+            .trim()
+            .split(/ +/)
+            .filter((w) => w != '')
+        : null,
+    [searchParams.get('search')],
+  );
+  const [modalState, setModalState] = useState<{ action?: string; selfPacedLab?: SelfPacedLab }>({});
+  const [selectedUids, setSelectedUids] = useState([]);
+  const { cache } = useSWRConfig();
+  const showModal = useCallback(
+    ({ action, selfPacedLab }: { action: string; selfPacedLab?: SelfPacedLab }) => {
+      setModalState({ action, selfPacedLab });
+      openModalAction();
+    },
+    [openModalAction],
+  );
+
+  const {
+    data: selfPacedLabsPages,
+    mutate,
+    size,
+    setSize,
+  } = useSWRInfinite<SelfPacedLabList>(
+    (index, previousPageData) => {
+      if (previousPageData && !previousPageData.metadata?.continue) {
+        return null;
+      }
+      const continueId = index === 0 ? '' : previousPageData.metadata?.continue;
+      return apiPaths.SELF_PACED_LABS({ namespace, limit: FETCH_BATCH_LIMIT, continueId });
+    },
+    fetcher,
+    {
+      refreshInterval: 8000,
+      revalidateFirstPage: true,
+      revalidateAll: true,
+      compare: (currentData, newData) => {
+        if (currentData === newData) return true;
+        if (!currentData || currentData.length === 0) return false;
+        if (!newData || newData.length === 0) return false;
+        if (currentData.length !== newData.length) return false;
+        for (let i = 0; i < currentData.length; i++) {
+          if (!compareK8sObjectsArr(currentData[i].items, newData[i].items)) return false;
+        }
+        return true;
+      },
+    },
+  );
+  const isReachingEnd = selfPacedLabsPages && !selfPacedLabsPages[selfPacedLabsPages.length - 1].metadata.continue;
+  const isLoadingInitialData = !selfPacedLabsPages;
+  const isLoadingMore =
+    isLoadingInitialData || (size > 0 && selfPacedLabsPages && typeof selfPacedLabsPages[size - 1] === 'undefined');
+
+  const revalidate = useCallback(
+    ({ updatedItems, action }: { updatedItems: SelfPacedLab[]; action: 'update' | 'delete' }) => {
+      const pagesCpy = JSON.parse(JSON.stringify(selfPacedLabsPages));
+      let p: SelfPacedLabList;
+      let i: number;
+      for ([i, p] of pagesCpy.entries()) {
+        for (const updatedItem of updatedItems) {
+          const foundIndex = p.items.findIndex((r) => r.metadata.uid === updatedItem.metadata.uid);
+          if (foundIndex > -1) {
+            if (action === 'update') {
+              pagesCpy[i].items[foundIndex] = updatedItem;
+            } else if (action === 'delete') {
+              pagesCpy[i].items.splice(foundIndex, 1);
+            }
+            mutate(pagesCpy);
+          }
+        }
+      }
+    },
+    [mutate, selfPacedLabsPages],
+  );
+  const filterSelfPacedLab = useCallback(
+    (selfPacedLab: SelfPacedLab): boolean => {
+      if (selfPacedLab.metadata.deletionTimestamp) {
+        return false;
+      }
+      if (keywordFilter) {
+        for (const keyword of keywordFilter) {
+          if (!keywordMatch(selfPacedLab, keyword)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    },
+    [keywordFilter],
+  );
+
+  const selfPacedLabs: SelfPacedLab[] = useMemo(
+    () => [].concat(...selfPacedLabsPages.map((page) => page.items)).filter(filterSelfPacedLab) || [],
+    [filterSelfPacedLab, selfPacedLabsPages],
+  );
+
+  const scrollHandler = (e: React.UIEvent<HTMLDivElement>) => {
+    const scrollable = e.currentTarget;
+    const scrollRemaining = scrollable.scrollHeight - scrollable.scrollTop - scrollable.clientHeight;
+    if (scrollRemaining < 500 && !isReachingEnd && !isLoadingMore) {
+      setSize(size + 1);
+    }
+  };
+
+  async function onDeleteConfirm(): Promise<void> {
+    const deletedItems: SelfPacedLab[] = [];
+    if (modalState.selfPacedLab) {
+      await deleteSelfPacedLab(modalState.selfPacedLab);
+      deletedItems.push(modalState.selfPacedLab);
+    } else {
+      for (const selfPacedLab of selfPacedLabs) {
+        if (selectedUids.includes(selfPacedLab.metadata.uid)) {
+          await deleteSelfPacedLab(selfPacedLab);
+          cache.delete(
+            apiPaths.SELF_PACED_LAB({
+              namespace: selfPacedLab.metadata.namespace,
+              selfPacedLabName: selfPacedLab.metadata.name,
+            }),
+          );
+          deletedItems.push(selfPacedLab);
+        }
+      }
+    }
+    revalidate({ updatedItems: deletedItems, action: 'delete' });
+  }
+
+  return (
+    <div onScroll={scrollHandler} className="admin-container">
+      <Modal
+        ref={modalAction}
+        onConfirm={onDeleteConfirm}
+        title={
+          modalState.selfPacedLab
+            ? `Delete self-paced lab ${displayName(modalState.selfPacedLab)}?`
+            : 'Delete selected self-paced labs?'
+        }
+      >
+        <p>Provisioned resources will be deleted.</p>
+      </Modal>
+      <PageSection hasBodyWrapper={false} key="header" className="admin-header">
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <Title headingLevel="h4" size="xl">
+              Self-Paced Labs
+            </Title>
+          </SplitItem>
+          <SplitItem>
+            <ProjectSelector
+              currentNamespaceName={namespace}
+              onSelect={(n) => {
+                navigate(`/admin/selfpacedlabs/${n.name}?${searchParams.toString()}`);
+              }}
+            />
+          </SplitItem>
+          <SplitItem>
+            <KeywordSearchInput
+              initialValue={keywordFilter}
+              placeholder="Search..."
+              onSearch={(value) => {
+                if (value) {
+                  searchParams.set('search', value.join(' '));
+                } else if (searchParams.has('search')) {
+                  searchParams.delete('search');
+                }
+                setSearchParams(searchParams);
+              }}
+            />
+          </SplitItem>
+          <SplitItem>
+            <ButtonCircleIcon
+              isDisabled={selectedUids.length === 0}
+              onClick={() => showModal({ action: 'delete' })}
+              description="Delete selected"
+              icon={TrashIcon}
+            />
+          </SplitItem>
+        </Split>
+      </PageSection>
+      {selfPacedLabs.length === 0 ? (
+        <PageSection hasBodyWrapper={false} key="selfpacedlabs-list-empty">
+          <EmptyState headingLevel="h1" icon={ExclamationTriangleIcon} titleText="No self-paced labs found." variant="full">
+            <EmptyStateFooter>
+              {keywordFilter ? (
+                <EmptyStateBody>No self-paced labs matched search.</EmptyStateBody>
+              ) : (
+                <EmptyStateBody>
+                  Request self-paced labs using the <Link to="/catalog">catalog</Link>.
+                </EmptyStateBody>
+              )}
+            </EmptyStateFooter>
+          </EmptyState>
+        </PageSection>
+      ) : (
+        <PageSection hasBodyWrapper={false} key="body" className="admin-body">
+          <SelectableTable
+            columns={['Name', 'Service Namespace', 'Registration', 'Created At', 'Actions']}
+            onSelectAll={(isSelected: boolean) => {
+              if (isSelected) {
+                setSelectedUids(selfPacedLabs.map((s) => s.metadata.uid));
+              } else {
+                setSelectedUids([]);
+              }
+            }}
+            rows={selfPacedLabs.map((selfPacedLab: SelfPacedLab) => {
+              const actionHandlers = {
+                delete: () => showModal({ action: 'delete', selfPacedLab }),
+              };
+
+              const cells: unknown[] = [];
+              cells.push(
+                <>
+                  <Link
+                    key="selfpacedlab"
+                    to={`/selfpacedlabs/${selfPacedLab.metadata.namespace}/${selfPacedLab.metadata.name}`}
+                  >
+                    {displayName(selfPacedLab)}
+                  </Link>
+                  <OpenshiftConsoleLink key="console" resource={selfPacedLab} />
+                </>,
+                <>
+                  <Link key="service-namespace" to={`/services/${selfPacedLab.metadata.namespace}`}>
+                    {selfPacedLab.metadata.namespace}
+                  </Link>
+                  <OpenshiftConsoleLink key="console" resource={selfPacedLab} linkToNamespace={true} />
+                </>,
+                <>{selfPacedLab.spec.openRegistration === false ? 'Pre-registration' : 'Open'}</>,
+                <>
+                  <LocalTimestamp key="timestamp" timestamp={selfPacedLab.metadata.creationTimestamp} />
+                  <br key="break" />
+                  (<TimeInterval key="interval" toTimestamp={selfPacedLab.metadata.creationTimestamp} />)
+                </>,
+                <React.Fragment key="actions">
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      gap: 'var(--pf-t--global--spacer--sm)',
+                    }}
+                  >
+                    <ButtonCircleIcon
+                      key="actions__delete"
+                      onClick={actionHandlers.delete}
+                      description="Delete"
+                      icon={TrashIcon}
+                    />
+                  </div>
+                </React.Fragment>,
+              );
+              return {
+                cells: cells,
+                onSelect: (isSelected) =>
+                  setSelectedUids((uids) => {
+                    if (isSelected) {
+                      if (uids.includes(selfPacedLab.metadata.uid)) {
+                        return uids;
+                      } else {
+                        return [...uids, selfPacedLab.metadata.uid];
+                      }
+                    } else {
+                      return uids.filter((uid) => uid !== selfPacedLab.metadata.uid);
+                    }
+                  }),
+                selected: selectedUids.includes(selfPacedLab.metadata.uid),
+              };
+            })}
+          />
+        </PageSection>
+      )}
+      <Footer />
+    </div>
+  );
+};
+
+export default SelfPacedLabs;

--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -78,7 +78,8 @@ const Navigation: React.FC = () => {
         to={`/services/${userNamespace.name}`}
         className={
           location.pathname.match(/\/services\/[a-zA-Z0-9_.-]/) ||
-          location.pathname.match(/\/workshops\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/)
+          location.pathname.match(/\/workshops\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/) ||
+          location.pathname.match(/\/selfpacedlabs\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/)
             ? 'pf-m-current'
             : ''
         }
@@ -185,6 +186,11 @@ const Navigation: React.FC = () => {
       <NavItem>
         <ExactNavLink className={locationStartsWith('/admin/workshops') ? 'pf-m-current' : ''} to="/admin/workshops">
           Workshops
+        </ExactNavLink>
+      </NavItem>
+      <NavItem>
+        <ExactNavLink className={locationStartsWith('/admin/selfpacedlabs') ? 'pf-m-current' : ''} to="/admin/selfpacedlabs">
+          Self-Paced Labs
         </ExactNavLink>
       </NavItem>
       <NavItem>

--- a/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
@@ -32,6 +32,8 @@ import {
   checkCatalogItemAvailability,
   createServiceRequest,
   CreateServiceRequestParameterValues,
+  createSelfPacedLab,
+  createSelfPacedLabItem,
   createWorkshop,
   createWorkshopProvision,
   fetcher,
@@ -129,6 +131,17 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
       provisionStartDelay: 30,
     }),
     [_displayName, catalogItem.spec.workshopUserMode],
+  );
+
+  const selfPacedLabInitialProps = useMemo(
+    () => ({
+      poolSize: 5,
+      assignedLifespan: '4h',
+      unassignedLifespan: '24h',
+      concurrency: 5,
+      startDelay: 10,
+    }),
+    [],
   );
 
   const onToggleClick = () => {
@@ -327,7 +340,38 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
         return null;
       }
 
-      if (formState.workshop) {
+      if (formState.workshop && formState.selfPacedLab) {
+        const { accessPassword, description, displayName, userRegistration } = formState.workshop;
+        const selfPacedLab = await createSelfPacedLab({
+          accessPassword,
+          description,
+          displayName,
+          catalogItem: catalogItem,
+          openRegistration: userRegistration === 'open',
+          serviceNamespace: formState.serviceNamespace,
+          endDate: formState.endDate,
+          startDate: formState.startDate,
+          email,
+          parameterValues,
+          skippedSfdc: formState.salesforceId.skip,
+          whiteGloved: formState.whiteGloved,
+          salesforceItems: formState.salesforceItems,
+        });
+        await createSelfPacedLabItem({
+          catalogItem: catalogItem,
+          poolSize: formState.selfPacedLab.poolSize,
+          assignedLifespan: formState.selfPacedLab.assignedLifespan,
+          unassignedLifespan: formState.selfPacedLab.unassignedLifespan,
+          concurrency: formState.selfPacedLab.concurrency,
+          startDelay: formState.selfPacedLab.startDelay,
+          parameters: {
+            ...parameterValues,
+            salesforce_items: JSON.stringify(formState.salesforceItems),
+          },
+          selfPacedLab: selfPacedLab,
+        });
+        navigate(`/selfpacedlabs/${selfPacedLab.metadata.namespace}/${selfPacedLab.metadata.name}`);
+      } else if (formState.workshop) {
         const {
           accessPassword,
           description,
@@ -347,8 +391,8 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
           stopDate: formState.stopDate,
           endDate: formState.endDate,
           startDate: formState.startDate,
-          readyByDate: useDirectProvisioningDate && formState.startDate 
-            ? new Date(formState.startDate.getTime() + READY_BY_LEAD_TIME_MS) 
+          readyByDate: useDirectProvisioningDate && formState.startDate
+            ? new Date(formState.startDate.getTime() + READY_BY_LEAD_TIME_MS)
             : undefined,
           email,
           parameterValues,
@@ -671,6 +715,12 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                     type: 'workshop',
                     workshop: isChecked ? workshopInitialProps : null,
                   });
+                  if (!isChecked) {
+                    dispatchFormState({
+                      type: 'selfPacedLab',
+                      selfPacedLab: null,
+                    });
+                  }
                   if (isChecked) {
                     dispatchFormState({
                       type: 'selectedResourcePool',
@@ -680,7 +730,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                   if (!formState.startDate) {
                     dispatchFormState({
                       type: 'dates',
-                      startDate: new Date(Date.now()), // Provisioning start date is current time
+                      startDate: new Date(Date.now()),
                     });
                   }
                 }}
@@ -701,6 +751,39 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
               >
                 <OutlinedQuestionCircleIcon
                   aria-label="Setup a user interface for the attendees to access their credentials"
+                  className="tooltip-icon-only"
+                />
+              </Tooltip>
+            </div>
+          </FormGroup>
+        ) : null}
+
+        {formState.workshop && isAdmin ? (
+          <FormGroup key="self-paced-lab-switch" fieldId="self-paced-lab-switch">
+            <div className="catalog-item-form__group-control--single">
+              <Switch
+                id="self-paced-lab-switch"
+                aria-label="Enable self-paced lab (only visible to admins)"
+                label="Enable self-paced lab (only visible to admins)"
+                isChecked={!!formState.selfPacedLab}
+                hasCheckIcon
+                onChange={(_event, isChecked) => {
+                  dispatchFormState({
+                    type: 'selfPacedLab',
+                    selfPacedLab: isChecked ? selfPacedLabInitialProps : null,
+                  });
+                }}
+              />
+              <Tooltip
+                position="right"
+                content={
+                  <p>
+                    Create a self-paced lab with a warm pool of pre-provisioned instances that users claim on demand.
+                  </p>
+                }
+              >
+                <OutlinedQuestionCircleIcon
+                  aria-label="Create a self-paced lab with a warm pool"
                   className="tooltip-icon-only"
                 />
               </Tooltip>
@@ -732,7 +815,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
           </FormGroup>
         ) : null}
 
-        {!isAutoStopDisabled(catalogItem) && !formState.workshop && !catalogItem.spec.externalUrl ? (
+        {!isAutoStopDisabled(catalogItem) && !formState.workshop && !formState.selfPacedLab && !catalogItem.spec.externalUrl ? (
           <FormGroup key="auto-stop" fieldId="auto-stop" label="Auto-stop">
             <div className="catalog-item-form__group-control--single">
               <AutoStopDestroy
@@ -763,8 +846,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
         ) : null}
 
         {formState.workshop ? (
-          <div className="catalog-item-form__workshop-form">
-            {/* Workshop Dates FormGroup - Start Date and Provisioning Date side by side */}
+          <>
             <div
               style={{
                 display: 'flex',
@@ -773,12 +855,10 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                 alignItems: 'flex-start',
               }}
             >
-              {/* Provisioning Date first, then Ready by */}
               <div style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--pf-t--global--spacer--lg)' }}>
-                {/* Provisioning Date */}
-                <FormGroup 
-                  fieldId="provisioningDate" 
-                  isRequired 
+                <FormGroup
+                  fieldId="provisioningDate"
+                  isRequired
                   label="Provisioning Date"
                 >
                   <div
@@ -830,7 +910,6 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                       />
                     </Tooltip>
                   </div>
-                  {/* Provisioning Mode Toggle */}
                   {isAdmin && (
                     <div
                       style={{
@@ -872,10 +951,9 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                   )}
                 </FormGroup>
 
-                {/* Ready by Date - Only show when switch is enabled and user is admin */}
                 {isAdmin && useDirectProvisioningDate && (
-                  <FormGroup 
-                    fieldId="readyByDate" 
+                  <FormGroup
+                    fieldId="readyByDate"
                     label="Ready by"
                   >
                     <div
@@ -890,16 +968,15 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                         key={`ready-by-${useDirectProvisioningDate}`}
                         defaultTimestamp={
                           formState.startDate
-                            ? formState.startDate.getTime() + READY_BY_LEAD_TIME_MS // Show actual start date (8 hours after provisioning)
+                            ? formState.startDate.getTime() + READY_BY_LEAD_TIME_MS
                             : Date.now() + READY_BY_LEAD_TIME_MS
                         }
                         forceUpdateTimestamp={formState.startDate?.getTime() + READY_BY_LEAD_TIME_MS}
                         onSelect={(d: Date) => {
-                          // Calculate provisioning date as 8 hours BEFORE ready by date
                           const provisioningDate = new Date(d.getTime() - READY_BY_LEAD_TIME_MS);
                           dispatchFormState({
                             type: 'dates',
-                            startDate: provisioningDate, // Internal API still uses provisioning date as startDate
+                            startDate: provisioningDate,
                             stopDate: new Date(
                               d.getTime() +
                                 parseDuration(
@@ -916,7 +993,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                             ),
                           });
                         }}
-                        minDate={Date.now() + READY_BY_LEAD_TIME_MS} // Minimum must account for 8-hour provisioning lead time
+                        minDate={Date.now() + READY_BY_LEAD_TIME_MS}
                       />
                       <Tooltip
                         position="right"
@@ -936,7 +1013,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                 )}
               </div>
             </div>
-            {!isAutoStopDisabled(catalogItem) ? (
+            {!isAutoStopDisabled(catalogItem) && !formState.selfPacedLab ? (
               <FormGroup key="auto-stop" fieldId="auto-stop" isRequired label="Auto-stop">
                 <div className="catalog-item-form__group-control--single">
                   <AutoStopDestroy
@@ -962,6 +1039,9 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                 />
               </div>
             </FormGroup>
+          <div className="catalog-item-form__workshop-section">
+            <div className="catalog-item-form__workshop-section-title">Workshop Settings</div>
+            <div className="catalog-item-form__workshop-form">
             <FormGroup fieldId="workshopDisplayName" isRequired label="Display Name">
               <div className="catalog-item-form__group-control--single">
                 <TextInput
@@ -1063,7 +1143,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                 </Tooltip>
               </div>
             </FormGroup>
-            {catalogItem.spec.workshopUserMode === 'multi' ? null : (
+            {!formState.selfPacedLab && catalogItem.spec.workshopUserMode !== 'multi' ? (
               <>
                 <FormGroup key="provisionCount" fieldId="workshopProvisionCount" label="Workshop User Count">
                   <div className="catalog-item-form__group-control--single">
@@ -1141,15 +1221,128 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                   </>
                 ) : null}
               </>
-            )}
+            ) : null}
+          </div>
+          </div>
+          </>
+        ) : null}
+
+        {formState.selfPacedLab ? (
+          <div className="catalog-item-form__selfpacedlab-section">
+            <div className="catalog-item-form__selfpacedlab-section-title">Self-Paced Lab Settings</div>
+            <FormGroup key="poolSize" fieldId="selfPacedLabPoolSize" isRequired label="Pool Size">
+              <div className="catalog-item-form__group-control--single">
+                <PatientNumberInput
+                  min={1}
+                  max={100}
+                  onChange={(v) =>
+                    dispatchFormState({
+                      type: 'selfPacedLab',
+                      selfPacedLab: { ...formState.selfPacedLab, poolSize: v },
+                    })
+                  }
+                  value={formState.selfPacedLab.poolSize}
+                />
+                <Tooltip position="right" content={<p>Number of pre-provisioned instances to keep ready in the warm pool.</p>}>
+                  <OutlinedQuestionCircleIcon
+                    aria-label="Number of pre-provisioned instances"
+                    className="tooltip-icon-only"
+                  />
+                </Tooltip>
+              </div>
+            </FormGroup>
+            <FormGroup key="assignedLifespan" fieldId="selfPacedLabAssignedLifespan" isRequired label="Assigned Lifespan">
+              <div className="catalog-item-form__group-control--single">
+                <TextInput
+                  id="selfPacedLabAssignedLifespan"
+                  type="text"
+                  value={formState.selfPacedLab.assignedLifespan}
+                  onChange={(_event, value) =>
+                    dispatchFormState({
+                      type: 'selfPacedLab',
+                      selfPacedLab: { ...formState.selfPacedLab, assignedLifespan: value },
+                    })
+                  }
+                  placeholder="e.g. 4h, 1d, 8h"
+                />
+                <Tooltip position="right" content={<p>How long a user keeps their assigned instance (e.g. 4h, 1d).</p>}>
+                  <OutlinedQuestionCircleIcon
+                    aria-label="Assigned lifespan duration"
+                    className="tooltip-icon-only"
+                  />
+                </Tooltip>
+              </div>
+            </FormGroup>
+            <FormGroup key="unassignedLifespan" fieldId="selfPacedLabUnassignedLifespan" isRequired label="Unassigned Lifespan">
+              <div className="catalog-item-form__group-control--single">
+                <TextInput
+                  id="selfPacedLabUnassignedLifespan"
+                  type="text"
+                  value={formState.selfPacedLab.unassignedLifespan}
+                  onChange={(_event, value) =>
+                    dispatchFormState({
+                      type: 'selfPacedLab',
+                      selfPacedLab: { ...formState.selfPacedLab, unassignedLifespan: value },
+                    })
+                  }
+                  placeholder="e.g. 24h, 2d"
+                />
+                <Tooltip position="right" content={<p>How long an unassigned instance lives before being replaced (e.g. 24h).</p>}>
+                  <OutlinedQuestionCircleIcon
+                    aria-label="Unassigned lifespan duration"
+                    className="tooltip-icon-only"
+                  />
+                </Tooltip>
+              </div>
+            </FormGroup>
+            {isAdmin ? (
+              <>
+                <FormGroup
+                  key="selfPacedLabConcurrency"
+                  fieldId="selfPacedLabConcurrency"
+                  label="Provision Concurrency (only visible to admins)"
+                >
+                  <div className="catalog-item-form__group-control--single">
+                    <PatientNumberInput
+                      min={1}
+                      max={30}
+                      onChange={(v) =>
+                        dispatchFormState({
+                          type: 'selfPacedLab',
+                          selfPacedLab: { ...formState.selfPacedLab, concurrency: v },
+                        })
+                      }
+                      value={formState.selfPacedLab.concurrency}
+                    />
+                  </div>
+                </FormGroup>
+                <FormGroup
+                  key="selfPacedLabStartDelay"
+                  fieldId="selfPacedLabStartDelay"
+                  label="Provision Start Interval (only visible to admins)"
+                >
+                  <div className="catalog-item-form__group-control--single">
+                    <PatientNumberInput
+                      min={1}
+                      max={600}
+                      onChange={(v) =>
+                        dispatchFormState({
+                          type: 'selfPacedLab',
+                          selfPacedLab: { ...formState.selfPacedLab, startDelay: v },
+                        })
+                      }
+                      value={formState.selfPacedLab.startDelay}
+                    />
+                  </div>
+                </FormGroup>
+              </>
+            ) : null}
           </div>
         ) : null}
 
         {(isAdmin || isLabDeveloper(groups)) && !catalogItem.spec.externalUrl ? (
           <div className="catalog-item-form__admin-section">
             <div className="catalog-item-form__admin-section-title">Admin Settings</div>
-            <div className="catalog-item-form__admin-section-content">
-              <div className="catalog-item-form__admin-fields">
                 {isAdmin && (
                   <div className="catalog-item-form__group-control--single">
                     <Switch
@@ -1210,8 +1403,6 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
                     }}
                   />
                 </div>
-              </div>
-            </div>
           </div>
         ) : null}
 

--- a/catalog/ui/src/app/Catalog/CatalogItemFormReducer.ts
+++ b/catalog/ui/src/app/Catalog/CatalogItemFormReducer.ts
@@ -21,6 +21,13 @@ type WorkshopProps = {
   provisionConcurrency: number;
   provisionStartDelay: number;
 };
+type SelfPacedLabProps = {
+  poolSize: number;
+  assignedLifespan: string;
+  unassignedLifespan: string;
+  concurrency: number;
+  startDelay: number;
+};
 type FormState = {
   user: UserProps;
   conditionChecks: {
@@ -33,6 +40,7 @@ type FormState = {
   termsOfServiceRequired: boolean;
   whiteGloved: boolean;
   workshop?: WorkshopProps;
+  selfPacedLab?: SelfPacedLabProps;
   error: string;
   useAutoDetach: boolean;
   selectedResourcePool?: string;
@@ -67,6 +75,7 @@ export type FormStateAction = {
     | 'termsOfServiceAgreed'
     | 'dates'
     | 'workshop'
+    | 'selfPacedLab'
     | 'useAutoDetach'
     | 'selectedResourcePool'
     | 'purpose'
@@ -96,6 +105,7 @@ export type FormStateAction = {
   error?: string;
   parameters?: { [name: string]: FormStateParameter };
   workshop?: WorkshopProps;
+  selfPacedLab?: SelfPacedLabProps;
   useAutoDetach?: boolean;
   selectedResourcePool?: string;
   startDate?: Date;
@@ -332,6 +342,7 @@ function reduceFormStateInit(
     termsOfServiceAgreed: false,
     termsOfServiceRequired: catalogItem.spec.termsOfService ? true : false,
     workshop: null,
+    selfPacedLab: null,
     error: '',
     useAutoDetach: true,
     selectedResourcePool: undefined,
@@ -411,6 +422,13 @@ function reduceFormStateWorkshop(initialState: FormState, workshop: WorkshopProp
     salesforceId,
     salesforceItems,
     workshop,
+  };
+}
+
+function reduceFormStateSelfPacedLab(initialState: FormState, selfPacedLab: SelfPacedLabProps = null): FormState {
+  return {
+    ...initialState,
+    selfPacedLab,
   };
 }
 
@@ -536,6 +554,8 @@ export function reduceFormState(state: FormState, action: FormStateAction): Form
       return reduceFormWhiteGloved(state, action.whiteGloved);
     case 'workshop':
       return reduceFormStateWorkshop(state, action.workshop);
+    case 'selfPacedLab':
+      return reduceFormStateSelfPacedLab(state, action.selfPacedLab);
     case 'useAutoDetach':
       return reduceFormStateUseAutoDetach(state, action.useAutoDetach);
     case 'selectedResourcePool':
@@ -591,6 +611,17 @@ export function checkEnableSubmit(state: FormState): boolean {
   }
   if (state.workshop) {
     if (!state.workshop.displayName) {
+      return false;
+    }
+  }
+  if (state.selfPacedLab) {
+    if (state.selfPacedLab.poolSize < 1) {
+      return false;
+    }
+    if (!state.selfPacedLab.assignedLifespan) {
+      return false;
+    }
+    if (!state.selfPacedLab.unassignedLifespan) {
       return false;
     }
   }

--- a/catalog/ui/src/app/Catalog/catalog-item-form.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-form.css
@@ -51,27 +51,36 @@
   margin-left: 0;
 }
 
+.catalog-item-form__workshop-section,
+.catalog-item-form__selfpacedlab-section,
 .catalog-item-form__admin-section {
-  border-top: 2px solid var(--pf-t--chart--color--black--400);
-  margin-top: var(--pf-t--global--spacer--md);
-  padding-top: var(--pf-t--global--spacer--md);
-}
-
-.catalog-item-form__admin-section-content {
-  border-left: 3px solid var(--pf-t--chart--color--black--300);
-  background-color: var(--pf-t--color--background--disabled, #f5f5f5);
+  border-left: 3px solid var(--pf-t--global--color--brand--default, #0066cc);
+  background-color: var(--pf-t--global--background--color--200, #f0f0f0);
   padding: var(--pf-t--global--spacer--md);
   border-radius: var(--pf-t--global--border--radius--sm, 4px);
-}
-
-.catalog-item-form__admin-section-title {
-  margin-bottom: var(--pf-t--global--spacer--md);
-  font-weight: var(--pf-t--global--font--weight--body--bold);
-  color: var(--pf-t--global--text--color--subtle);
-}
-
-.catalog-item-form__admin-fields {
+  margin-top: var(--pf-t--global--spacer--sm);
   display: flex;
   flex-direction: column;
   gap: var(--pf-t--global--spacer--md);
+}
+
+.catalog-item-form__admin-section {
+  border-left-color: var(--pf-t--chart--color--black--300, #6a6e73);
+}
+
+.catalog-item-form__workshop-section-title,
+.catalog-item-form__selfpacedlab-section-title,
+.catalog-item-form__admin-section-title {
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  color: var(--pf-t--global--color--brand--default, #0066cc);
+  margin-bottom: var(--pf-t--global--spacer--xs);
+}
+
+.catalog-item-form__admin-section-title {
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.catalog-item-form__workshop-section .editor__input,
+.catalog-item-form__workshop-section .editor__inner {
+  background-color: var(--pf-t--global--background--color--100, #fff);
 }

--- a/catalog/ui/src/app/SelfPacedLab/SelfPacedLab.tsx
+++ b/catalog/ui/src/app/SelfPacedLab/SelfPacedLab.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import useSWRImmutable from 'swr/immutable';
+import Footer from '@app/components/Footer';
+import summitLogo from '@app/bgimages/Summit-Logo.svg';
+import { publicFetcher } from '@app/api';
+import useDocumentTitle from '@app/utils/useDocumentTitle';
+import { apiPaths } from './selfpacedlab-utils';
+import { selfPacedLabLogin, SelfPacedLabDetails } from './selfPacedLabApi';
+import SelfPacedLabContent from './SelfPacedLabContent';
+import WorkshopHeader from '@app/Workshop/WorkshopHeader';
+import SelfPacedLabLogin from './SelfPacedLabLogin';
+
+import '@app/Workshop/workshop.css';
+
+const SelfPacedLab: React.FC<{ title: string }> = ({ title }) => {
+  useDocumentTitle(title);
+  const { selfPacedLabId } = useParams();
+  const [searchParams] = useSearchParams();
+  const userInterface = searchParams.get('userInterface') || 'rhpds';
+  const [loginFailureMessage, setLoginFailureMessage] = useState('');
+  const { data: selfPacedLab } = useSWRImmutable<SelfPacedLabDetails>(
+    selfPacedLabId ? apiPaths.SELF_PACED_LAB({ selfPacedLabId }) : null,
+    publicFetcher,
+  );
+  const [selfPacedLabPrivateInfo, setSelfPacedLabPrivateInfo] = useState(selfPacedLab);
+
+  async function attemptLogin(email: string, accessPassword: string) {
+    try {
+      const info = await selfPacedLabLogin({
+        accessPassword,
+        email,
+        selfPacedLabId,
+      });
+      setSelfPacedLabPrivateInfo(info);
+      setLoginFailureMessage('');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setLoginFailureMessage(error.message);
+      } else {
+        setLoginFailureMessage('UNKNOWN ERROR');
+      }
+    }
+  }
+
+  return (
+    <div className="workshop">
+      <WorkshopHeader userInterface={userInterface} />
+      <main className="workshop__main">
+        {selfPacedLabPrivateInfo?.assignment ? (
+          <SelfPacedLabContent selfPacedLab={selfPacedLabPrivateInfo} />
+        ) : (
+          <SelfPacedLabLogin
+            loginFailureMessage={loginFailureMessage}
+            onLogin={(email, accessPassword) => attemptLogin(email, accessPassword)}
+            selfPacedLab={selfPacedLab}
+          />
+        )}
+      </main>
+      <Footer
+        rightElement={
+          userInterface === 'summit' ? (
+            <a href="https://www.redhat.com/summit">
+              <img src={summitLogo} alt="Red Hat Summit" width="72px" />
+            </a>
+          ) : null
+        }
+      />
+    </div>
+  );
+};
+
+export default SelfPacedLab;

--- a/catalog/ui/src/app/SelfPacedLab/SelfPacedLabContent.tsx
+++ b/catalog/ui/src/app/SelfPacedLab/SelfPacedLabContent.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import yaml from 'js-yaml';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import { renderContent } from '@app/util';
+import EditorViewer from '@app/components/Editor/EditorViewer';
+import Hero from '@app/components/Hero';
+import heroImg from '@app/bgimages/hero-img.jpeg';
+import { SelfPacedLabDetails } from './selfPacedLabApi';
+import { createAsciiDocAttributes } from '@app/Services/service-utils';
+import { MessageTemplate } from '@app/types';
+import AdocWrapper from '@app/components/AdocWrapper';
+
+import '@app/Workshop/workshop-content.css';
+
+const SelfPacedLabContent: React.FC<{
+  selfPacedLab: SelfPacedLabDetails;
+}> = ({ selfPacedLab }) => {
+  const description = selfPacedLab.description;
+  const displayName = selfPacedLab.displayName || 'Self-Paced Lab';
+  const userAssignment = selfPacedLab.assignment;
+  const labUserInterfaceRedirect = selfPacedLab.labUserInterfaceRedirect;
+  const infoMessageTemplate = selfPacedLab.template ? (JSON.parse(selfPacedLab.template) as MessageTemplate) : null;
+  let renderEditor = true;
+
+  const templateHtml = useMemo(() => {
+    if (!infoMessageTemplate || !userAssignment?.data) return null;
+    const htmlRenderedTemplate = renderContent(infoMessageTemplate.template, {
+      format: infoMessageTemplate.templateFormat,
+      vars: createAsciiDocAttributes(userAssignment.data, '--'),
+    });
+    return (
+      <div style={{ padding: "var(--pf-t--global--spacer--md)" }}>
+        <AdocWrapper html={htmlRenderedTemplate} />
+      </div>
+    );
+  }, [infoMessageTemplate, JSON.stringify(userAssignment.data)]);
+
+  const userAssignmentMessagesHtml = useMemo(
+    () =>
+      userAssignment.messages ? (
+        <div
+          dangerouslySetInnerHTML={{
+            __html: renderContent(userAssignment.messages.replace(/\n/g, '  +\n'), { format: 'asciidoc' }),
+          }}
+        />
+      ) : null,
+    [userAssignment.messages],
+  );
+
+  if (userAssignment.labUserInterface?.url && labUserInterfaceRedirect === true) {
+    window.location.href = userAssignment.labUserInterface.url;
+  }
+
+  try {
+    JSON.parse(description);
+  } catch {
+    renderEditor = false;
+  }
+
+  return (
+    <div className="workshop-content">
+      <Hero image={heroImg} overlay compact>
+        <h1 className="workshop-content__hero-title">{displayName}</h1>
+      </Hero>
+      <section className="workshop-content__body">
+        <div className="workshop-content__wrapper">
+          <h2 className="workshop-content__section-title">
+            Instructions for {displayName}
+          </h2>
+
+          {description ? (
+            <div className="workshop-content__card">
+              {renderEditor ? (
+                <EditorViewer value={description} />
+              ) : (
+                <div dangerouslySetInnerHTML={{ __html: renderContent(description, { format: 'html' }) }} />
+              )}
+            </div>
+          ) : null}
+
+          {userAssignment.labUserInterface ? (
+            <div className="workshop-content__card">
+              <h3 className="workshop-content__card-label">Lab User Interface</h3>
+              <a
+                href={userAssignment.labUserInterface.url}
+                target="_blank"
+                rel="noreferrer"
+                className="workshop-content__link"
+              >
+                {userAssignment.labUserInterface.url} <ExternalLinkAltIcon />
+              </a>
+            </div>
+          ) : null}
+
+          {templateHtml ? (
+            <div className="workshop-content__card">
+              {templateHtml}
+            </div>
+          ) : (
+            <>
+              {userAssignment.messages ? (
+                <div className="workshop-content__card">
+                  <h3 className="workshop-content__card-label">Messages</h3>
+                  {userAssignmentMessagesHtml}
+                </div>
+              ) : null}
+              {userAssignment.data ? (
+                <div className="workshop-content__card">
+                  <h3 className="workshop-content__card-label">Data</h3>
+                  <pre className="workshop-content__pre">
+                    {yaml.dump(
+                      Object.keys(userAssignment.data).length === 1
+                        ? userAssignment.data[Object.keys(userAssignment.data)[0]]
+                        : userAssignment.data,
+                    )}
+                  </pre>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SelfPacedLabContent;

--- a/catalog/ui/src/app/SelfPacedLab/SelfPacedLabLogin.tsx
+++ b/catalog/ui/src/app/SelfPacedLab/SelfPacedLabLogin.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  Popover,
+  TextInput,
+} from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
+import Hero from '@app/components/Hero';
+import heroImg from '@app/bgimages/hero-img.jpeg';
+import EditorViewer from '@app/components/Editor/EditorViewer';
+import { SelfPacedLabDetails } from './selfPacedLabApi';
+import { renderContent } from '@app/util';
+
+import '@app/Workshop/workshop-login.css';
+
+type validateType = 'success' | 'warning' | 'error' | 'default';
+
+const SelfPacedLabLogin: React.FC<{
+  loginFailureMessage: string;
+  onLogin: (email: string, accessPassword: string) => void;
+  selfPacedLab: SelfPacedLabDetails;
+}> = ({ loginFailureMessage, onLogin, selfPacedLab }) => {
+  const displayName = selfPacedLab.displayName || 'Self-Paced Lab';
+  const description = selfPacedLab.description;
+  let renderEditor = true;
+  try {
+    JSON.parse(description);
+  } catch {
+    renderEditor = false;
+  }
+  const [accessPassword, setAccessPassword] = useState('');
+  const [email, setEmail] = useState('');
+  const [emailValidated, setEmailValidated] = useState<validateType>('default');
+  const submitDisabled = (selfPacedLab.accessPasswordRequired && !accessPassword) || emailValidated !== 'success';
+
+  const handleEmail = (v: string) => {
+    const validate = (email: string): validateType => {
+      if (!email || !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(email)) return 'error';
+      return 'success';
+    };
+    const errorType = validate(v);
+    setEmail(v);
+    setEmailValidated(errorType);
+  };
+
+  const hasDescription = description && description.replace(/(<([^>]+)>)/gi, '') !== '';
+
+  return (
+    <div className="workshop-login">
+      <Hero image={heroImg} overlay compact>
+        <h1 className="workshop-login__hero-title">{displayName}</h1>
+      </Hero>
+      <section className="workshop-login__body">
+        <div className={`workshop-login__layout${hasDescription ? ' workshop-login__layout--with-desc' : ''}`}>
+          <div className="workshop-login__card">
+            <h2 className="workshop-login__card-title">Access this lab</h2>
+            <Form className="workshop-login__form">
+              <FormGroup fieldId="email" isRequired label="Email">
+                <InputGroup>
+                  <InputGroupItem isFill>
+                    <TextInput
+                      type="email"
+                      id="email"
+                      placeholder="email@redhat.com"
+                      isRequired
+                      onChange={(_event, v: string) => handleEmail(v)}
+                      value={email}
+                    />
+                  </InputGroupItem>
+                  <InputGroupItem>
+                    <Popover
+                      bodyContent="Only used for identification purposes during this lab. No email messages will be sent to this address."
+                      headerContent="Email Address"
+                    >
+                      <Button icon={<HelpIcon />} variant="control" className="workshop-login__help-btn" />
+                    </Popover>
+                  </InputGroupItem>
+                </InputGroup>
+                {emailValidated === 'error' ? (
+                  <HelperText>
+                    <HelperTextItem variant="error">
+                      Invalid email address
+                    </HelperTextItem>
+                  </HelperText>
+                ) : null}
+              </FormGroup>
+              {selfPacedLab.accessPasswordRequired ? (
+                <FormGroup fieldId="accessPassword" isRequired label="Lab Password">
+                  <InputGroup>
+                    <InputGroupItem isFill>
+                      <TextInput
+                        id="accessPassword"
+                        isRequired
+                        onChange={(_event, val) => setAccessPassword(val)}
+                        type="password"
+                        value={accessPassword}
+                      />
+                    </InputGroupItem>
+                    <InputGroupItem>
+                      <Popover bodyContent="Password will be provided by your lab facilitator.">
+                        <Button icon={<HelpIcon />} variant="control" className="workshop-login__help-btn" />
+                      </Popover>
+                    </InputGroupItem>
+                  </InputGroup>
+                </FormGroup>
+              ) : null}
+              <ActionGroup>
+                <Button
+                  icon={<ArrowRightIcon />}
+                  type="submit"
+                  isDisabled={submitDisabled}
+                  isBlock
+                  onClick={(ev: React.FormEvent<HTMLButtonElement>) => {
+                    ev.preventDefault();
+                    onLogin(email, accessPassword);
+                  }}
+                >
+                  Access this lab
+                </Button>
+              </ActionGroup>
+              {loginFailureMessage ? (
+                <p className="workshop-login__failure">{loginFailureMessage}</p>
+              ) : null}
+            </Form>
+          </div>
+          {hasDescription ? (
+            <aside className="workshop-login__description">
+              <div className="workshop-login__description-card">
+                {renderEditor ? (
+                  <EditorViewer value={description} />
+                ) : (
+                  <div dangerouslySetInnerHTML={{ __html: renderContent(description, { format: 'html' }) }} />
+                )}
+              </div>
+            </aside>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SelfPacedLabLogin;

--- a/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.spec.ts
+++ b/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.spec.ts
@@ -1,0 +1,103 @@
+import fetchMock from 'jest-fetch-mock';
+import { selfPacedLabLogin } from './selfPacedLabApi';
+
+describe('selfPacedLabLogin', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  const selfPacedLabId = 'test-lab-id';
+  const email = 'user@example.com';
+  const accessPassword = 'secret123';
+
+  const mockSuccessResponse = {
+    accessPasswordRequired: true,
+    assignment: {
+      selfPacedLabName: 'test-lab',
+      resourceClaimName: 'rc-001',
+      assignment: { email: 'user@example.com' },
+      labUserInterface: { url: 'https://lab.example.com', redirect: true },
+      messages: 'Welcome to the lab',
+      data: { some_key: 'some_value' },
+    },
+    description: 'A test lab',
+    displayName: 'Test Lab',
+    labUserInterfaceRedirect: true,
+    name: 'test-lab',
+    namespace: 'test-ns',
+    template: 'some-template',
+  };
+
+  test('should send PUT request with email and accessPassword', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockSuccessResponse), { status: 200 });
+
+    await selfPacedLabLogin({ accessPassword, email, selfPacedLabId });
+
+    expect(fetchMock).toHaveBeenCalledWith(`/api/selfpacedlab/${selfPacedLabId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ accessPassword, email }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  test('should return SelfPacedLabDetails on 200 response', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockSuccessResponse), { status: 200 });
+
+    const result = await selfPacedLabLogin({ email, selfPacedLabId });
+
+    expect(result).toEqual(mockSuccessResponse);
+    expect(result.assignment?.selfPacedLabName).toBe('test-lab');
+    expect(result.assignment?.assignment?.email).toBe('user@example.com');
+    expect(result.assignment?.labUserInterface?.url).toBe('https://lab.example.com');
+  });
+
+  test('should throw on 400 (invalid request)', async () => {
+    fetchMock.mockResponseOnce('', { status: 400 });
+
+    await expect(selfPacedLabLogin({ email, selfPacedLabId })).rejects.toThrow('Invalid access request.');
+  });
+
+  test('should throw on 403 (invalid password)', async () => {
+    fetchMock.mockResponseOnce('', { status: 403 });
+
+    await expect(selfPacedLabLogin({ accessPassword: 'wrong', email, selfPacedLabId })).rejects.toThrow(
+      'Invalid access password.',
+    );
+  });
+
+  test('should throw on 409 (no seats available)', async () => {
+    fetchMock.mockResponseOnce('', { status: 409 });
+
+    await expect(selfPacedLabLogin({ email, selfPacedLabId })).rejects.toThrow(
+      'No seats available for this lab.',
+    );
+  });
+
+  test('should throw on 404 (lab not found)', async () => {
+    fetchMock.mockResponseOnce('', { status: 404 });
+
+    await expect(selfPacedLabLogin({ email, selfPacedLabId })).rejects.toThrow(
+      'Self-paced lab no longer exists.',
+    );
+  });
+
+  test('should throw with status code on unexpected error', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 });
+
+    await expect(selfPacedLabLogin({ email, selfPacedLabId })).rejects.toThrow(
+      'API responded with response code 500',
+    );
+  });
+
+  test('should send undefined accessPassword when not provided', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockSuccessResponse), { status: 200 });
+
+    await selfPacedLabLogin({ email, selfPacedLabId });
+
+    expect(fetchMock).toHaveBeenCalledWith(`/api/selfpacedlab/${selfPacedLabId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ accessPassword: undefined, email }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});

--- a/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.ts
+++ b/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.ts
@@ -1,10 +1,10 @@
-import { WorkshopUserAssignmentSpec } from '@app/types';
+import { SelfPacedLabUserAssignmentSpec } from '@app/types';
 
 class SelfPacedLabLoginFailedError extends Error {}
 
 export type SelfPacedLabDetails = {
   accessPasswordRequired: boolean;
-  assignment?: WorkshopUserAssignmentSpec;
+  assignment?: SelfPacedLabUserAssignmentSpec;
   description?: string;
   displayName?: string;
   labUserInterfaceRedirect?: boolean;

--- a/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.ts
+++ b/catalog/ui/src/app/SelfPacedLab/selfPacedLabApi.ts
@@ -1,0 +1,48 @@
+import { WorkshopUserAssignmentSpec } from '@app/types';
+
+class SelfPacedLabLoginFailedError extends Error {}
+
+export type SelfPacedLabDetails = {
+  accessPasswordRequired: boolean;
+  assignment?: WorkshopUserAssignmentSpec;
+  description?: string;
+  displayName?: string;
+  labUserInterfaceRedirect?: boolean;
+  name: string;
+  namespace: string;
+  template?: string;
+};
+
+export async function selfPacedLabLogin({
+  accessPassword,
+  email,
+  selfPacedLabId,
+}: {
+  accessPassword?: string;
+  email: string;
+  selfPacedLabId: string;
+}): Promise<SelfPacedLabDetails> {
+  const resp = await fetch(`/api/selfpacedlab/${selfPacedLabId}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      accessPassword: accessPassword,
+      email: email,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (resp.status === 200) {
+    return (await resp.json()) as SelfPacedLabDetails;
+  }
+  if (resp.status === 400) {
+    throw new SelfPacedLabLoginFailedError('Invalid access request.');
+  } else if (resp.status === 403) {
+    throw new SelfPacedLabLoginFailedError('Invalid access password.');
+  } else if (resp.status === 409) {
+    throw new SelfPacedLabLoginFailedError('No seats available for this lab.');
+  } else if (resp.status === 404) {
+    throw new SelfPacedLabLoginFailedError('Self-paced lab no longer exists.');
+  }
+  throw new SelfPacedLabLoginFailedError(`API responded with response code ${resp.status}`);
+}

--- a/catalog/ui/src/app/SelfPacedLab/selfpacedlab-utils.ts
+++ b/catalog/ui/src/app/SelfPacedLab/selfpacedlab-utils.ts
@@ -1,0 +1,4 @@
+export const apiPaths = {
+  SELF_PACED_LAB: ({ selfPacedLabId }: { selfPacedLabId: string }): string =>
+    `/api/selfpacedlab/${selfPacedLabId}`,
+};

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -1,0 +1,953 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useLocation, Link, useParams } from 'react-router-dom';
+import { EditorState, LexicalEditor } from 'lexical';
+import { $generateHtmlFromNodes } from '@lexical/html';
+import MonacoEditor from '@monaco-editor/react';
+import yaml from 'js-yaml';
+import useSWR, { useSWRConfig } from 'swr';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Bullseye,
+  Button,
+  CodeBlock,
+  CodeBlockCode,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  EmptyState,
+  EmptyStateBody,
+  NumberInput,
+  PageSection,
+  Split,
+  SplitItem,
+  Spinner,
+  Switch,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Title,
+  Tooltip,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import { Select, SelectOption, SelectList } from '@patternfly/react-core';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
+import {
+  apiPaths,
+  dateToApiString,
+  deleteSelfPacedLab,
+  deleteResourceClaim,
+  fetcher,
+  fetcherItemsInAllPages,
+  patchResourceClaim,
+  patchSelfPacedLab,
+  patchSelfPacedLabItem,
+  SERVICES_KEY,
+} from '@app/api';
+import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabItem as SelfPacedLabItemType } from '@app/types';
+import {
+  BABYLON_DOMAIN,
+  DEMO_DOMAIN,
+  compareK8sObjects,
+  compareK8sObjectsArr,
+  displayName,
+  FETCH_BATCH_LIMIT,
+  getStageFromK8sObject,
+  setSalesforceItems as setSalesforceItemsAnno,
+} from '@app/util';
+import useSession from '@app/utils/useSession';
+import useDebounce from '@app/utils/useDebounce';
+import useDebounceState from '@app/utils/useDebounceState';
+import Modal, { useModal } from '@app/Modal/Modal';
+import Label from '@app/components/Label';
+import LocalTimestamp from '@app/components/LocalTimestamp';
+import OpenshiftConsoleLink from '@app/components/OpenshiftConsoleLink';
+import ProjectSelector from '@app/components/ProjectSelector';
+import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import SelectableTable from '@app/components/SelectableTable';
+import ServiceStatus from '@app/Services/ServiceStatus';
+import TimeInterval from '@app/components/TimeInterval';
+import ServiceActions from '@app/Services/ServiceActions';
+import EditableText from '@app/components/EditableText';
+import Editor from '@app/components/Editor/Editor';
+import AutoStopDestroy from '@app/components/AutoStopDestroy';
+import LoadingIcon from '@app/components/LoadingIcon';
+import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
+import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
+import PatientNumberInput from '@app/components/PatientNumberInput';
+import SelfPacedLabStatus from '@app/components/SelfPacedLabStatus';
+import ResourcePoolSelector from '@app/components/ResourcePoolSelector';
+import SalesforceItemsList from '@app/components/SalesforceItemsList';
+import SalesforceItemsEditModal from '@app/components/SalesforceItemsEditModal';
+import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
+import useInterfaceConfig from '@app/utils/useInterfaceConfig';
+import SelfPacedLabScheduleAction from './SelfPacedLabScheduleAction';
+import useSWRImmutable from 'swr/immutable';
+
+import './selfpacedlab-item.css';
+
+type ModalAction = 'scheduleDelete' | 'scheduleStart';
+
+const SelfPacedLabItemComponent: React.FC<{
+  activeTab: string;
+  serviceNamespaceName: string;
+  selfPacedLabName: string;
+}> = ({ activeTab, serviceNamespaceName, selfPacedLabName }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { cache } = useSWRConfig();
+  const { isAdmin, serviceNamespaces: sessionServiceNamespaces } = useSession().getSession();
+  const { sfdc_enabled } = useInterfaceConfig();
+  const [modalDelete, openModalDelete] = useModal();
+  const [modalSchedule, openModalSchedule] = useModal();
+  const [scheduleAction, setScheduleAction] = useState<ModalAction>('scheduleDelete');
+  const [userRegistrationSelectIsOpen, setUserRegistrationSelectIsOpen] = useState(false);
+  const [modalEditSalesforce, setModalEditSalesforce] = useState(false);
+
+  const { data: selfPacedLab, mutate: mutateSelfPacedLab } = useSWR<SelfPacedLab>(
+    apiPaths.SELF_PACED_LAB({ namespace: serviceNamespaceName, selfPacedLabName }),
+    fetcher,
+    {
+      refreshInterval: 8000,
+      compare: compareK8sObjects,
+      revalidateOnMount: true,
+    },
+  );
+
+  const stage = getStageFromK8sObject(selfPacedLab);
+
+  const { data: catalogItem } = useSWRImmutable<CatalogItem>(
+    selfPacedLab?.metadata.labels?.[`${BABYLON_DOMAIN}/catalogItemName`]
+      ? apiPaths.CATALOG_ITEM({
+          namespace: selfPacedLab.metadata.labels[`${BABYLON_DOMAIN}/catalogItemNamespace`],
+          name: selfPacedLab.metadata.labels[`${BABYLON_DOMAIN}/catalogItemName`],
+        })
+      : null,
+    fetcher,
+  );
+
+  const { data: selfPacedLabItems, mutate: mutateSelfPacedLabItems } = useSWR<SelfPacedLabItemType[]>(
+    selfPacedLab
+      ? apiPaths.SELF_PACED_LAB_ITEMS({
+          namespace: serviceNamespaceName,
+          selfPacedLabName: selfPacedLab.metadata.name,
+        })
+      : null,
+    () =>
+      fetcherItemsInAllPages((continueId) =>
+        apiPaths.SELF_PACED_LAB_ITEMS({
+          namespace: serviceNamespaceName,
+          selfPacedLabName: selfPacedLab.metadata.name,
+          limit: FETCH_BATCH_LIMIT,
+          continueId,
+        }),
+      ),
+    {
+      refreshInterval: 8000,
+      compare: compareK8sObjectsArr,
+    },
+  );
+
+  const { data: resourceClaims, mutate: mutateRC } = useSWR<ResourceClaim[]>(
+    selfPacedLab
+      ? apiPaths.RESOURCE_CLAIMS({
+          namespace: serviceNamespaceName,
+          labelSelector: `${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLab.metadata.name}`,
+          limit: 'ALL',
+        })
+      : null,
+    () =>
+      fetcherItemsInAllPages((continueId) =>
+        apiPaths.RESOURCE_CLAIMS({
+          namespace: serviceNamespaceName,
+          labelSelector: `${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLab.metadata.name}`,
+          limit: FETCH_BATCH_LIMIT,
+          continueId,
+        }),
+      ),
+    {
+      refreshInterval: 8000,
+      compare: compareK8sObjectsArr,
+    },
+  );
+
+  const selfPacedLabId = selfPacedLab?.metadata.labels?.[`${BABYLON_DOMAIN}/selfpacedlab-id`];
+  const userRegistrationValue = selfPacedLab?.spec.openRegistration === false ? 'pre' : 'open';
+  const autoDestroyTime = selfPacedLab?.spec.lifespan?.end ? Date.parse(selfPacedLab.spec.lifespan.end) : null;
+  const autoStartTime = selfPacedLab?.spec.lifespan?.start ? Date.parse(selfPacedLab.spec.lifespan.start) : null;
+
+  // Admin settings
+  const opsEffortAnnotation = selfPacedLab?.metadata.annotations?.[`${DEMO_DOMAIN}/ops-effort`];
+  const opsEffortFromAnnotation = useMemo(() => parseInt(opsEffortAnnotation || '0', 10) || 0, [opsEffortAnnotation]);
+  const [opsEffort, setOpsEffort] = useState<number>(opsEffortFromAnnotation);
+  const debouncedOpsEffort = useDebounceState(opsEffort, 1000);
+
+  useEffect(() => {
+    setOpsEffort(opsEffortFromAnnotation);
+  }, [opsEffortFromAnnotation]);
+
+  useEffect(() => {
+    if (!selfPacedLab || debouncedOpsEffort === opsEffortFromAnnotation) return;
+    const opsEffortValue = typeof debouncedOpsEffort === 'number' ? debouncedOpsEffort : Number(debouncedOpsEffort) || 0;
+    patchSelfPacedLab({
+      name: selfPacedLab.metadata.name,
+      namespace: selfPacedLab.metadata.namespace,
+      patch: {
+        metadata: {
+          annotations: {
+            [`${DEMO_DOMAIN}/ops-effort`]: String(opsEffortValue),
+          },
+        },
+      },
+    }).then((updated) => mutateSelfPacedLab(updated));
+  }, [debouncedOpsEffort, opsEffortFromAnnotation, selfPacedLab?.metadata?.name, selfPacedLab?.metadata?.namespace]);
+
+  const whiteGloved = selfPacedLab?.metadata?.labels?.[`${DEMO_DOMAIN}/white-glove`] === 'true';
+  const isLocked = selfPacedLab?.metadata?.labels?.[`${DEMO_DOMAIN}/lock-enabled`] === 'true';
+  const resourcePoolAnnotation = selfPacedLab?.metadata?.annotations?.['poolboy.gpte.redhat.com/resource-pool-name'];
+  const selectedResourcePool = resourcePoolAnnotation;
+
+  async function handleWhiteGloveChange(_: unknown, isChecked: boolean) {
+    if (!selfPacedLab) return;
+    mutateSelfPacedLab(
+      await patchSelfPacedLab({
+        name: selfPacedLab.metadata.name,
+        namespace: selfPacedLab.metadata.namespace,
+        patch: {
+          metadata: {
+            labels: {
+              [`${DEMO_DOMAIN}/white-glove`]: String(isChecked),
+            },
+          },
+        },
+      }),
+    );
+  }
+
+  async function handleLockedChange(_: unknown, isChecked: boolean) {
+    if (!selfPacedLab) return;
+    mutateSelfPacedLab(
+      await patchSelfPacedLab({
+        name: selfPacedLab.metadata.name,
+        namespace: selfPacedLab.metadata.namespace,
+        patch: {
+          metadata: {
+            labels: {
+              [`${DEMO_DOMAIN}/lock-enabled`]: String(isChecked),
+            },
+          },
+        },
+      }),
+    );
+  }
+
+  async function handleResourcePoolChange(poolName: string | undefined) {
+    if (!selfPacedLab) return;
+    mutateSelfPacedLab(
+      await patchSelfPacedLab({
+        name: selfPacedLab.metadata.name,
+        namespace: selfPacedLab.metadata.namespace,
+        patch: {
+          metadata: {
+            annotations: {
+              'poolboy.gpte.redhat.com/resource-pool-name': poolName || null,
+            },
+          },
+        },
+      }),
+    );
+  }
+
+  const debouncedPatchSelfPacedLab = useDebounce(patchSelfPacedLab, 1000) as (...args: unknown[]) => Promise<SelfPacedLab>;
+
+  const patchSelfPacedLabSpec = useCallback(
+    async (patch: {
+      accessPassword?: string;
+      description?: string;
+      displayName?: string;
+      openRegistration?: boolean;
+    }): Promise<void> => {
+      if (!selfPacedLab) return;
+      if (patch.openRegistration !== undefined && selfPacedLab.spec.openRegistration !== patch.openRegistration) {
+        mutateSelfPacedLab(
+          await patchSelfPacedLab({
+            name: selfPacedLab.metadata.name,
+            namespace: selfPacedLab.metadata.namespace,
+            patch: { spec: patch },
+          }),
+        );
+      } else {
+        mutateSelfPacedLab(
+          await debouncedPatchSelfPacedLab({
+            name: selfPacedLab.metadata.name,
+            namespace: selfPacedLab.metadata.namespace,
+            patch: { spec: patch },
+          }),
+        );
+      }
+    },
+    [selfPacedLab, mutateSelfPacedLab, debouncedPatchSelfPacedLab],
+  );
+
+  async function onDeleteConfirm() {
+    await deleteSelfPacedLab(selfPacedLab);
+    cache.delete(SERVICES_KEY({ namespace: selfPacedLab.metadata.namespace }));
+    cache.delete(apiPaths.SELF_PACED_LAB({ namespace: serviceNamespaceName, selfPacedLabName }));
+    navigate(`/services/${serviceNamespaceName}`);
+  }
+
+  async function onModalScheduleConfirm(date: Date) {
+    if (!selfPacedLab) return;
+    if (scheduleAction === 'scheduleDelete') {
+      mutateSelfPacedLab(
+        await patchSelfPacedLab({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+          patch: { spec: { lifespan: { end: dateToApiString(date) } } },
+        }),
+      );
+    } else if (scheduleAction === 'scheduleStart') {
+      mutateSelfPacedLab(
+        await patchSelfPacedLab({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+          patch: { spec: { lifespan: { start: dateToApiString(date) } } },
+        }),
+      );
+    }
+  }
+
+  const onToggleClick = () => {
+    setUserRegistrationSelectIsOpen(!userRegistrationSelectIsOpen);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={userRegistrationSelectIsOpen}>
+      {userRegistrationValue}
+    </MenuToggle>
+  );
+
+  return (
+    <>
+      <Modal
+        ref={modalDelete}
+        onConfirm={onDeleteConfirm}
+        title={`Delete self-paced lab ${displayName(selfPacedLab)}?`}
+      >
+        <p>All pool instances will be deleted.</p>
+      </Modal>
+      <Modal ref={modalSchedule} onConfirm={onModalScheduleConfirm} passModifiers={true} title={displayName(selfPacedLab)}>
+        <SelfPacedLabScheduleAction
+          action={scheduleAction === 'scheduleDelete' ? 'retirement' : 'start'}
+          currentDate={scheduleAction === 'scheduleDelete' ? autoDestroyTime : autoStartTime}
+        />
+      </Modal>
+      {selfPacedLabItems && selfPacedLabItems.length > 0 && (
+        <SalesforceItemsEditModal
+          isOpen={modalEditSalesforce}
+          onClose={() => setModalEditSalesforce(false)}
+          items={JSON.parse(selfPacedLabItems[0].spec.parameters?.['salesforce_items'] || '[]')}
+          onSave={async (next) => {
+            await patchSelfPacedLab({
+              name: selfPacedLab.metadata.name,
+              namespace: selfPacedLab.metadata.namespace,
+              patch: {
+                metadata: {
+                  annotations: {
+                    ...selfPacedLab.metadata.annotations,
+                    'demo.redhat.com/salesforce-items': JSON.stringify(next),
+                  },
+                },
+              },
+            });
+            for (const item of selfPacedLabItems) {
+              await patchSelfPacedLabItem({
+                name: item.metadata.name,
+                namespace: item.metadata.namespace,
+                patch: {
+                  spec: {
+                    parameters: {
+                      ...item.spec.parameters,
+                      salesforce_items: JSON.stringify(next),
+                    },
+                  },
+                },
+              });
+            }
+            if (!resourceClaims || resourceClaims.length === 0) return;
+            for (const rc of resourceClaims) {
+              const annotations = { ...rc.metadata.annotations };
+              setSalesforceItemsAnno(annotations, next);
+              await patchResourceClaim(rc.metadata.namespace, rc.metadata.name, { metadata: { annotations } });
+            }
+          }}
+          isAdmin={isAdmin}
+        />
+      )}
+      {isAdmin || sessionServiceNamespaces.length > 1 ? (
+        <PageSection hasBodyWrapper={false} key="topbar" className="selfpacedlab-item__topbar">
+          <ProjectSelector
+            currentNamespaceName={serviceNamespaceName}
+            onSelect={(namespace) => {
+              if (namespace) {
+                navigate(`/services/${namespace.name}${location.search}`);
+              } else {
+                navigate(`/services${location.search}`);
+              }
+            }}
+          />
+        </PageSection>
+      ) : null}
+      <PageSection hasBodyWrapper={false} key="head" className="selfpacedlab-item__head">
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <Breadcrumb>
+              <BreadcrumbItem
+                render={({ className }) => (
+                  <Link to={`/services/${serviceNamespaceName}`} className={className}>
+                    Services
+                  </Link>
+                )}
+              />
+              <BreadcrumbItem>{selfPacedLabName}</BreadcrumbItem>
+            </Breadcrumb>
+            <Title headingLevel="h4" size="xl" style={{ display: 'flex', alignItems: 'center' }}>
+              {displayName(selfPacedLab)}
+              {stage !== 'prod' ? <Label key="selfpacedlab-item__stage">{stage}</Label> : null}
+              <Label key="selfpacedlab-item__type" tooltipDescription={<div>Self-paced lab with warm pool</div>}>
+                Self-Paced Lab
+              </Label>
+            </Title>
+          </SplitItem>
+          <SplitItem>
+            <Bullseye>
+              <ServiceActions
+                position="right"
+                serviceName={displayName(selfPacedLab)}
+                isLocked={isLocked}
+                actionHandlers={{
+                  delete: () => openModalDelete(),
+                }}
+              />
+            </Bullseye>
+          </SplitItem>
+        </Split>
+      </PageSection>
+      <PageSection hasBodyWrapper={false} key="body" className="selfpacedlab-item__body">
+        <Tabs
+          activeKey={activeTab || 'details'}
+          onSelect={(e, tabIndex) =>
+            navigate(`/selfpacedlabs/${serviceNamespaceName}/${selfPacedLabName}/${tabIndex}`)
+          }
+        >
+          <Tab eventKey="details" title={<TabTitleText>Details</TabTitleText>}>
+            {activeTab === 'details' || !activeTab ? (
+              <DescriptionList isHorizontal className="selfpacedlab-item-details">
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Name</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {selfPacedLab.metadata.name}
+                    {isAdmin ? <OpenshiftConsoleLink resource={selfPacedLab} /> : null}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Lab URL</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {selfPacedLabId ? (
+                      <Link to={`/selfpacedlab/${selfPacedLabId}`} target="_blank" rel="noopener">
+                        {window.location.protocol}
+                        {'//'}
+                        {window.location.host}/selfpacedlab/{selfPacedLabId}
+                      </Link>
+                    ) : (
+                      <LoadingIcon />
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Display Name</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <EditableText
+                      aria-label="Edit Display Name"
+                      onChange={(val: string) => patchSelfPacedLabSpec({ displayName: val })}
+                      placeholder={selfPacedLab.metadata.name}
+                      value={selfPacedLab.spec.displayName}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Status</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {resourceClaims ? (
+                      <SelfPacedLabStatus resourceClaims={resourceClaims} />
+                    ) : (
+                      <Spinner size="md" />
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    Description{' '}
+                    <Tooltip position="right" content={<p>Description text visible in the user access page.</p>}>
+                      <OutlinedQuestionCircleIcon
+                        aria-label="Description text visible in the user access page."
+                        className="tooltip-icon-only"
+                      />
+                    </Tooltip>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Editor
+                      onChange={(_: EditorState, editor: LexicalEditor) => {
+                        editor.update(() => {
+                          const html = $generateHtmlFromNodes(editor, null);
+                          patchSelfPacedLabSpec({ description: html });
+                        });
+                      }}
+                      placeholder="Add description"
+                      defaultValue={selfPacedLab.spec.description}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    Access Password{' '}
+                    <Tooltip position="right" content={<p>Password users need to enter to access the lab.</p>}>
+                      <OutlinedQuestionCircleIcon
+                        aria-label="Password users need to enter to access the lab."
+                        className="tooltip-icon-only"
+                      />
+                    </Tooltip>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <EditableText
+                      aria-label="Edit Access Password"
+                      componentType="Password"
+                      onChange={(val: string) => patchSelfPacedLabSpec({ accessPassword: val })}
+                      placeholder="- no password -"
+                      value={selfPacedLab.spec.accessPassword}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>User Registration</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Select
+                      isOpen={userRegistrationSelectIsOpen}
+                      onSelect={(_event, selected) => {
+                        const selectedValue = typeof selected === 'string' ? selected : selected.toString();
+                        patchSelfPacedLabSpec({ openRegistration: selectedValue === 'open' }).then(() =>
+                          setUserRegistrationSelectIsOpen(false),
+                        );
+                      }}
+                      selected={userRegistrationValue}
+                      onOpenChange={(isOpen) => setUserRegistrationSelectIsOpen(isOpen)}
+                      toggle={toggle}
+                    >
+                      <SelectList>
+                        <SelectOption value="open">open registration</SelectOption>
+                        <SelectOption value="pre">pre-registration</SelectOption>
+                      </SelectList>
+                    </Select>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {autoStartTime && autoStartTime > Date.now() ? (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Start Date</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <AutoStopDestroy
+                        type="auto-start"
+                        variant="extended"
+                        isDisabled={isLocked}
+                        onClick={() => {
+                          if (!isLocked) {
+                            setScheduleAction('scheduleStart');
+                            openModalSchedule();
+                          }
+                        }}
+                        time={autoStartTime}
+                        className="selfpacedlab-item__schedule-btn"
+                      />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Auto-Destroy</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <AutoStopDestroy
+                      type="auto-destroy"
+                      isDisabled={isLocked}
+                      onClick={() => {
+                        if (!isLocked) {
+                          setScheduleAction('scheduleDelete');
+                          openModalSchedule();
+                        }
+                      }}
+                      time={autoDestroyTime}
+                      variant="extended"
+                      className="selfpacedlab-item__schedule-btn"
+                      notDefinedMessage="- Not defined -"
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Created</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <LocalTimestamp timestamp={selfPacedLab.metadata.creationTimestamp} /> (
+                    <TimeInterval toTimestamp={selfPacedLab.metadata.creationTimestamp} />)
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+
+                {selfPacedLabItems && selfPacedLabItems.length > 0 && sfdc_enabled ? (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Salesforce IDs</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <SalesforceItemsList
+                        items={JSON.parse(selfPacedLabItems[0].spec.parameters?.['salesforce_items'] || '[]')}
+                      />
+                      <Button
+                        variant="link"
+                        icon={<PlusCircleIcon />}
+                        onClick={() => setModalEditSalesforce(true)}
+                        style={{ alignSelf: 'flex-start' }}
+                      >
+                        Add Salesforce IDs
+                      </Button>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
+
+                {isAdmin ? (
+                  <DescriptionListGroup className="selfpacedlab-item-details__admin-section">
+                    <DescriptionListTerm>Admin Settings</DescriptionListTerm>
+                    <DescriptionListDescription className="selfpacedlab-item-details__admin-description">
+                      <div className="selfpacedlab-item-details__admin-fields">
+                        <div className="selfpacedlab-item-details__admin-field">
+                          <Switch
+                            id="white-glove-switch"
+                            aria-label="White-Glove Support"
+                            label="White-Glove Support (for admins to tick when giving a white gloved experience)"
+                            isChecked={whiteGloved}
+                            hasCheckIcon
+                            onChange={handleWhiteGloveChange}
+                          />
+                        </div>
+                        <div className="selfpacedlab-item-details__admin-field">
+                          <div className="selfpacedlab-item-details__group-control--single" style={{ maxWidth: 350 }}>
+                            <label htmlFor="ops-effort-input">Ops Effort</label>
+                            <NumberInput
+                              id="ops-effort-input"
+                              aria-label="Ops Effort"
+                              min={0}
+                              value={opsEffort}
+                              onMinus={() => {
+                                const newValue = Math.max(0, (typeof opsEffort === 'number' ? opsEffort : 0) - 1);
+                                setOpsEffort(newValue);
+                              }}
+                              onPlus={() => {
+                                const newValue = (typeof opsEffort === 'number' ? opsEffort : 0) + 1;
+                                setOpsEffort(newValue);
+                              }}
+                              onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                                const inputValue = event.currentTarget.value;
+                                const value = inputValue === '' ? 0 : parseInt(inputValue, 10);
+                                if (!isNaN(value) && value >= 0) {
+                                  setOpsEffort(value);
+                                }
+                              }}
+                            />
+                            <Tooltip position="right" content={<div>Operations effort value for this self-paced lab.</div>}>
+                              <OutlinedQuestionCircleIcon
+                                aria-label="Operations effort value for this self-paced lab."
+                                className="tooltip-icon-only"
+                              />
+                            </Tooltip>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="selfpacedlab-item-details__admin-field"
+                        style={{ marginTop: 'var(--pf-t--global--spacer--md)' }}
+                      >
+                        <Switch
+                          id="lock-switch"
+                          aria-label="Locked"
+                          label="Locked"
+                          isChecked={isLocked}
+                          hasCheckIcon
+                          onChange={handleLockedChange}
+                        />
+                      </div>
+                      <div
+                        className="selfpacedlab-item-details__admin-field"
+                        style={{ marginTop: 'var(--pf-t--global--spacer--md)' }}
+                      >
+                        <div className="selfpacedlab-item-details__group-control--single" style={{ maxWidth: 350 }}>
+                          <label htmlFor="resource-pool-selector">Resource Pool</label>
+                          <ResourcePoolSelector
+                            disableAutoSelect
+                            selectedPool={selectedResourcePool}
+                            onSelect={handleResourcePoolChange}
+                          />
+                          <Tooltip position="right" content={<p>Select a specific resource pool for this lab.</p>}>
+                            <OutlinedQuestionCircleIcon
+                              aria-label="Select a specific resource pool for this lab"
+                              className="tooltip-icon-only"
+                            />
+                          </Tooltip>
+                        </div>
+                      </div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
+              </DescriptionList>
+            ) : null}
+          </Tab>
+          <Tab eventKey="provision" title={<TabTitleText>Provisioning</TabTitleText>}>
+            {activeTab === 'provision' ? (
+              selfPacedLabItems && selfPacedLabItems.length > 0 ? (
+                selfPacedLabItems.map((item) => (
+                  <DescriptionList isHorizontal key={item.metadata.uid}>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Name</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {item.metadata.name}
+                        {isAdmin ? <OpenshiftConsoleLink resource={item} /> : null}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Catalog Item</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {catalogItem ? (
+                          <>
+                            <Link to={`/catalog/${catalogItem.metadata.namespace}?item=${catalogItem.metadata.namespace}/${catalogItem.metadata.name}`}>
+                              {displayName(catalogItem)}
+                            </Link>
+                            {isAdmin ? <OpenshiftConsoleLink resource={catalogItem} /> : null}
+                          </>
+                        ) : (
+                          <p>
+                            Missing catalog item {item.spec.catalogItem.name} in {item.spec.catalogItem.namespace}
+                          </p>
+                        )}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Parameters</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <CodeBlock>
+                          <CodeBlockCode>{yaml.dump(item.spec.parameters || {})}</CodeBlockCode>
+                        </CodeBlock>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Pool Size</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <PatientNumberInput
+                          min={0}
+                          max={200}
+                          adminModifier={true}
+                          onChange={(value: number) =>
+                            patchSelfPacedLabItem({
+                              name: item.metadata.name,
+                              namespace: item.metadata.namespace,
+                              patch: { spec: { poolSize: value } },
+                            }).then(() => mutateSelfPacedLabItems())
+                          }
+                          value={item.spec.poolSize}
+                          style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
+                        />
+                        <Tooltip position="right" content={<p>Number of pre-provisioned instances in the warm pool.</p>}>
+                          <OutlinedQuestionCircleIcon
+                            aria-label="Number of pre-provisioned instances in the warm pool."
+                            className="tooltip-icon-only"
+                          />
+                        </Tooltip>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {isAdmin ? (
+                      <>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Concurrency</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <PatientNumberInput
+                              min={1}
+                              max={30}
+                              onChange={(value: number) =>
+                                patchSelfPacedLabItem({
+                                  name: item.metadata.name,
+                                  namespace: item.metadata.namespace,
+                                  patch: { spec: { concurrency: value } },
+                                }).then(() => mutateSelfPacedLabItems())
+                              }
+                              value={item.spec.concurrency}
+                              style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
+                            />
+                            (only visible to admins)
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Start Delay</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <PatientNumberInput
+                              min={10}
+                              max={999}
+                              onChange={(value: number) =>
+                                patchSelfPacedLabItem({
+                                  name: item.metadata.name,
+                                  namespace: item.metadata.namespace,
+                                  patch: { spec: { startDelay: value } },
+                                }).then(() => mutateSelfPacedLabItems())
+                              }
+                              value={item.spec.startDelay}
+                              style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
+                            />
+                            (only visible to admins)
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      </>
+                    ) : null}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        Assigned Lifespan{' '}
+                        <Tooltip position="right" content={<p>How long an instance stays active after being assigned to a user.</p>}>
+                          <OutlinedQuestionCircleIcon
+                            aria-label="Assigned lifespan duration"
+                            className="tooltip-icon-only"
+                          />
+                        </Tooltip>
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <EditableText
+                          aria-label="Edit Assigned Lifespan"
+                          onChange={(val: string) =>
+                            patchSelfPacedLabItem({
+                              name: item.metadata.name,
+                              namespace: item.metadata.namespace,
+                              patch: { spec: { assignedLifespan: val } },
+                            }).then(() => mutateSelfPacedLabItems())
+                          }
+                          placeholder="e.g. 4h"
+                          value={item.spec.assignedLifespan}
+                        />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        Unassigned Lifespan{' '}
+                        <Tooltip position="right" content={<p>How long an unassigned instance stays in the pool before being recycled.</p>}>
+                          <OutlinedQuestionCircleIcon
+                            aria-label="Unassigned lifespan duration"
+                            className="tooltip-icon-only"
+                          />
+                        </Tooltip>
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <EditableText
+                          aria-label="Edit Unassigned Lifespan"
+                          onChange={(val: string) =>
+                            patchSelfPacedLabItem({
+                              name: item.metadata.name,
+                              namespace: item.metadata.namespace,
+                              patch: { spec: { unassignedLifespan: val } },
+                            }).then(() => mutateSelfPacedLabItems())
+                          }
+                          placeholder="e.g. 24h"
+                          value={item.spec.unassignedLifespan}
+                        />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                ))
+              ) : selfPacedLabItems ? (
+                <EmptyState headingLevel="h4" titleText="No SelfPacedLabItems found" variant="sm">
+                  <EmptyStateBody>
+                    This indicates an error has occurred. A SelfPacedLabItem should have been created when this lab was created.
+                  </EmptyStateBody>
+                </EmptyState>
+              ) : (
+                <Spinner size="lg" />
+              )
+            ) : null}
+          </Tab>
+          <Tab eventKey="instances" title={<TabTitleText>Instances ({resourceClaims?.length ?? '...'})</TabTitleText>}>
+            {activeTab === 'instances' ? (
+              resourceClaims && resourceClaims.length > 0 ? (
+                <SelectableTable
+                  columns={
+                    isAdmin
+                      ? ['Name', 'Status', 'Assignment', 'Created At', 'Actions']
+                      : ['Name', 'Status', 'Assignment', 'Created At']
+                  }
+                  onSelectAll={() => {}}
+                  rows={resourceClaims.map((rc) => {
+                    const assignment = rc.metadata.labels?.[`${BABYLON_DOMAIN}/selfpacedlab-assignment`];
+                    return {
+                      cells: [
+                        <>
+                          <Link key="link" to={`/services/${rc.metadata.namespace}/${rc.metadata.name}`}>
+                            {displayName(rc)}
+                          </Link>
+                          {isAdmin ? <OpenshiftConsoleLink key="console" resource={rc} /> : null}
+                        </>,
+                        <ServiceStatus key="status" resourceClaim={rc} />,
+                        assignment || '-',
+                        <>
+                          <LocalTimestamp key="ts" timestamp={rc.metadata.creationTimestamp} /> (
+                          <TimeInterval key="iv" toTimestamp={rc.metadata.creationTimestamp} />)
+                        </>,
+                        ...(isAdmin
+                          ? [
+                              <ButtonCircleIcon
+                                key="actions"
+                                onClick={() => deleteResourceClaim(rc).then(() => mutateRC())}
+                                description="Delete"
+                                icon={TrashIcon}
+                              />,
+                            ]
+                          : []),
+                      ],
+                    };
+                  })}
+                />
+              ) : resourceClaims ? (
+                <EmptyState headingLevel="h4" titleText="No instances" variant="sm">
+                  <EmptyStateBody>No pool instances found for this self-paced lab.</EmptyStateBody>
+                </EmptyState>
+              ) : (
+                <Spinner size="lg" />
+              )
+            ) : null}
+          </Tab>
+          <Tab eventKey="yaml" title={<TabTitleText>YAML</TabTitleText>}>
+            {activeTab === 'yaml' ? (
+              <MonacoEditor
+                height="500px"
+                language="yaml"
+                options={{ readOnly: true }}
+                theme="vs-dark"
+                value={yaml.dump(selfPacedLab)}
+              />
+            ) : null}
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};
+
+const SelfPacedLabItem: React.FC = () => {
+  const { name: selfPacedLabName, namespace: serviceNamespaceName, tab: activeTab = 'details' } = useParams();
+  return (
+    <ErrorBoundaryPage namespace={serviceNamespaceName} name={selfPacedLabName} type="Self-Paced Lab">
+      <SelfPacedLabItemComponent
+        activeTab={activeTab}
+        selfPacedLabName={selfPacedLabName}
+        serviceNamespaceName={serviceNamespaceName}
+      />
+    </ErrorBoundaryPage>
+  );
+};
+
+export default SelfPacedLabItem;

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabScheduleAction.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabScheduleAction.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Form, FormGroup } from '@patternfly/react-core';
+import DateTimePicker from '@app/components/DateTimePicker';
+import useSession from '@app/utils/useSession';
+
+const SelfPacedLabScheduleAction: React.FC<{
+  action: 'retirement' | 'start';
+  currentDate?: number;
+  setState?: React.Dispatch<React.SetStateAction<Date>>;
+  setIsDisabled?: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({ action, currentDate, setState, setIsDisabled }) => {
+  const { isAdmin } = useSession().getSession();
+  const defaultDate = currentDate ? new Date(currentDate) : new Date(Date.now() + 14400000);
+  const [selectedDate, setSelectedDate] = useState(defaultDate);
+
+  useEffect(() => {
+    setState(selectedDate);
+  }, [setState, selectedDate]);
+
+  useEffect(() => {
+    if (setIsDisabled) {
+      if (action === 'start') {
+        setIsDisabled(selectedDate.getTime() < Date.now());
+      } else {
+        setIsDisabled(false);
+      }
+    }
+  }, [setIsDisabled, selectedDate, action]);
+
+  const actionLabel = action === 'retirement' ? 'Auto-destroy' : 'Start Date';
+
+  const minMaxProps: { minDate: number; maxDate?: number } = {
+    minDate: Date.now(),
+  };
+  if (!isAdmin) {
+    minMaxProps.maxDate = Date.now() + 365 * 24 * 60 * 60 * 1000;
+  }
+
+  return (
+    <Form isHorizontal>
+      <FormGroup fieldId="selfpacedlab-schedule-action" label={actionLabel}>
+        <DateTimePicker
+          defaultTimestamp={selectedDate.getTime()}
+          onSelect={(date) => setSelectedDate(date)}
+          {...minMaxProps}
+        />
+      </FormGroup>
+      {selectedDate.getTime() <= Date.now() ? (
+        <Alert
+          variant="warning"
+          isInline
+          title={`The selected ${action === 'retirement' ? 'auto-destroy' : 'start'} date and time is in the past.`}
+        />
+      ) : null}
+    </Form>
+  );
+};
+
+export default SelfPacedLabScheduleAction;

--- a/catalog/ui/src/app/SelfPacedLabs/selfpacedlab-item.css
+++ b/catalog/ui/src/app/SelfPacedLabs/selfpacedlab-item.css
@@ -1,0 +1,79 @@
+.selfpacedlab-item__body.pf-v6-c-page__main-section {
+  padding-top: 0px;
+  flex-grow: 1;
+}
+
+.selfpacedlab-item__body.pf-v6-c-page__main-section .pf-v6-c-tabs {
+  margin-left: -100px;
+  padding-left: 100px;
+  margin-right: -100px;
+  padding-right: 100px;
+  margin-bottom: var(--pf-t--global--spacer--sm);
+}
+
+.selfpacedlab-item__body .pf-v6-c-tab-content {
+  padding: var(--pf-t--global--spacer--sm) 0;
+}
+
+.selfpacedlab-item__body.pf-v6-c-page__main-section .pf-v6-c-description-list {
+  row-gap: var(--pf-t--global--spacer--sm);
+  margin-bottom: var(--pf-t--global--spacer--sm);
+}
+
+.selfpacedlab-item__body .pf-v6-c-description-list__group {
+  align-items: center;
+}
+
+.selfpacedlab-item__head.pf-v6-c-page__main-section {
+  padding-top: var(--pf-t--global--spacer--md);
+  padding-bottom: var(--pf-t--global--spacer--md);
+  border-bottom: 1px solid var(--pf-t--chart--color--black--300);
+}
+
+.selfpacedlab-item__head.pf-v6-c-page__main-section .pf-v6-c-title {
+  margin-top: var(--pf-t--global--spacer--lg);
+}
+
+.selfpacedlab-item__topbar.pf-v6-c-page__main-section .pf-c-dropdown__menu {
+  max-height: 25em;
+  overflow-y: scroll;
+}
+
+.selfpacedlab-item__body .pf-v6-c-table tbody > tr > * {
+  vertical-align: middle !important;
+}
+
+.selfpacedlab-item-details.pf-v6-c-description-list[class*='pf-m-horizontal'] {
+  --pf-v6-c-description-list__term--width: 142px !important;
+}
+
+.selfpacedlab-item-details__admin-section.pf-v6-c-description-list__group {
+  border-top: 2px solid var(--pf-t--chart--color--black--400) !important;
+  margin-top: var(--pf-t--global--spacer--md) !important;
+  margin-bottom: var(--pf-t--global--spacer--md) !important;
+}
+
+.selfpacedlab-item-details__admin-description.pf-v6-c-description-list__description {
+  border-left: 3px solid var(--pf-t--chart--color--black--300) !important;
+  background-color: var(--pf-t--color--background--disabled, #f5f5f5) !important;
+  padding: var(--pf-t--global--spacer--md) !important;
+  border-radius: var(--pf-t--global--border--radius--sm, 4px) !important;
+}
+
+.selfpacedlab-item-details__admin-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--md);
+}
+
+.selfpacedlab-item-details__admin-field {
+  display: flex;
+  align-items: center;
+}
+
+.selfpacedlab-item-details__group-control--single {
+  display: flex;
+  flex-direction: row;
+  gap: var(--pf-t--global--spacer--md);
+  align-items: center;
+}

--- a/catalog/ui/src/app/Services/ServicesList.tsx
+++ b/catalog/ui/src/app/Services/ServicesList.tsx
@@ -15,6 +15,7 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import {
   apiPaths,
   deleteResourceClaim,
+  deleteSelfPacedLab,
   deleteWorkshop,
   fetcherItemsInAllPages,
   scheduleStartResourceClaim,
@@ -29,7 +30,7 @@ import {
   stopAllResourcesInResourceClaim,
   stopWorkshop,
 } from '@app/api';
-import { ResourceClaim, ResourceClaimWithCollaborator, Service, ServiceAccess, ServiceActionActions, Workshop, WorkshopWithResourceClaims } from '@app/types';
+import { ResourceClaim, ResourceClaimWithCollaborator, SelfPacedLab, SelfPacedLabWithResourceClaims, Service, ServiceAccess, ServiceActionActions, Workshop, WorkshopWithResourceClaims } from '@app/types';
 import { fetcher } from '@app/api';
 import KeywordSearchInput from '@app/components/KeywordSearchInput';
 import {
@@ -40,6 +41,7 @@ import {
   compareK8sObjectsArr,
   FETCH_BATCH_LIMIT,
   isResourceClaimPartOfWorkshop,
+  isResourceClaimPartOfSelfPacedLab,
 } from '@app/util';
 import SelectableTable from '@app/components/SelectableTable';
 import Modal, { useModal } from '@app/Modal/Modal';
@@ -50,6 +52,7 @@ import ServicesAction from './ServicesAction';
 import ServiceActions from './ServiceActions';
 import ServicesScheduleAction from './ServicesScheduleAction';
 import renderResourceClaimRow from './renderResourceClaimRow';
+import renderSelfPacedLabRow from './renderSelfPacedLabRow';
 import renderWorkshopRow from './renderWorkshopRow';
 import { isWorkshopLocked } from '@app/Workshops/workshops-utils';
 import { isResourceClaimLocked } from './service-utils';
@@ -70,7 +73,7 @@ async function fetchServices(namespace: string): Promise<Service[]> {
         namespace,
         limit: FETCH_BATCH_LIMIT,
         continueId,
-        labelSelector: `!${BABYLON_DOMAIN}/workshop`,
+        labelSelector: `!${BABYLON_DOMAIN}/workshop,!${BABYLON_DOMAIN}/selfpacedlab`,
       }),
     )) as ResourceClaim[];
   }
@@ -78,6 +81,11 @@ async function fetchServices(namespace: string): Promise<Service[]> {
     return (await fetcherItemsInAllPages((continueId) =>
       apiPaths.WORKSHOPS({ namespace, limit: FETCH_BATCH_LIMIT, continueId }),
     )) as Workshop[];
+  }
+  async function fetchSelfPacedLabs(namespace: string) {
+    return (await fetcherItemsInAllPages((continueId) =>
+      apiPaths.SELF_PACED_LABS({ namespace, limit: FETCH_BATCH_LIMIT, continueId }),
+    )) as SelfPacedLab[];
   }
   async function fetchSharedServices(namespace: string) {
     const serviceAccesses = (await fetcherItemsInAllPages((continueId) =>
@@ -143,10 +151,12 @@ async function fetchServices(namespace: string): Promise<Service[]> {
 
   const resourceClaims: ResourceClaim[] = [];
   const workshops: Workshop[] = [];
+  const selfPacedLabs: SelfPacedLab[] = [];
   const sharedServices: Service[] = [];
   await Promise.all([
     fetchResourceClaims(namespace).then((r) => resourceClaims.push(...r)),
     fetchWorkshops(namespace).then((w) => workshops.push(...w)),
+    fetchSelfPacedLabs(namespace).then((s) => selfPacedLabs.push(...s)),
     fetchSharedServices(namespace).then((s) => sharedServices.push(...s)),
   ]);
 
@@ -154,7 +164,7 @@ async function fetchServices(namespace: string): Promise<Service[]> {
 
   const seen = new Set<string>();
   const services: Service[] = [];
-  for (const service of [...resourceClaims, ...resolvedWorkshops, ...sharedServices]) {
+  for (const service of [...resourceClaims, ...resolvedWorkshops, ...selfPacedLabs, ...sharedServices]) {
     const uid = service.metadata.uid;
     if (!seen.has(uid)) {
       seen.add(uid);
@@ -190,6 +200,32 @@ async function fetchWorkshopResourceClaims(
   return result;
 }
 
+async function fetchSelfPacedLabResourceClaims(
+  namespaces: string[],
+): Promise<Record<string, ResourceClaim[]>> {
+  const result: Record<string, ResourceClaim[]> = {};
+  const promises = namespaces.map(async (namespace) => {
+    const rcs = (await fetcherItemsInAllPages((continueId) =>
+      apiPaths.RESOURCE_CLAIMS({
+        namespace,
+        limit: FETCH_BATCH_LIMIT,
+        continueId,
+        labelSelector: `${BABYLON_DOMAIN}/selfpacedlab`,
+      }),
+    )) as ResourceClaim[];
+    for (const rc of rcs) {
+      const splName = rc.metadata.labels?.[`${BABYLON_DOMAIN}/selfpacedlab`];
+      if (splName) {
+        const key = `${namespace}/${splName}`;
+        if (!result[key]) result[key] = [];
+        result[key].push(rc);
+      }
+    }
+  });
+  await Promise.all(promises);
+  return result;
+}
+
 const ServicesList: React.FC<{
   serviceNamespaceName: string;
 }> = ({ serviceNamespaceName }) => {
@@ -214,6 +250,7 @@ const ServicesList: React.FC<{
     action: ServiceActionActions;
     resourceClaim?: ResourceClaim;
     workshop?: WorkshopWithResourceClaims;
+    selfPacedLab?: SelfPacedLab;
     rating?: { rate: number; useful: 'yes' | 'no' | 'not applicable'; comment: string };
     submitDisabled: boolean;
   }>({ action: null, submitDisabled: false });
@@ -255,6 +292,31 @@ const ServicesList: React.FC<{
     },
   );
 
+  const selfPacedLabNamespaces = useMemo(() => {
+    if (!_services) return [];
+    return [...new Set(
+      _services
+        .filter((s) => s.kind === 'SelfPacedLab')
+        .map((s) => s.metadata.namespace),
+    )].sort();
+  }, [_services]);
+
+  const { data: selfPacedLabRCsMap } = useSWR<Record<string, ResourceClaim[]>>(
+    selfPacedLabNamespaces.length > 0 ? `selfpacedlab-rcs/${selfPacedLabNamespaces.join(',')}` : null,
+    () => fetchSelfPacedLabResourceClaims(selfPacedLabNamespaces),
+    {
+      suspense: false,
+      refreshInterval: 8000,
+      revalidateOnMount: true,
+      compare: (currentData, newData) => {
+        if (!currentData || !newData) return currentData === newData;
+        const allCurrentRCs = Object.values(currentData).flat();
+        const allNewRCs = Object.values(newData).flat();
+        return compareK8sObjectsArr(allCurrentRCs, allNewRCs);
+      },
+    },
+  );
+
   const filterFn = useCallback(
     (service: Service) => {
       if (service.kind === 'ResourceClaim') {
@@ -262,8 +324,7 @@ const ServicesList: React.FC<{
           return false;
         }
         const resourceClaim = service as ResourceClaim;
-        const isPartOfWorkshop = isResourceClaimPartOfWorkshop(resourceClaim);
-        if (isPartOfWorkshop) {
+        if (isResourceClaimPartOfWorkshop(resourceClaim) || isResourceClaimPartOfSelfPacedLab(resourceClaim)) {
           return false;
         }
         if (!isAdmin && resourceClaim.spec.provider?.name === 'babylon-service-request-configmap') {
@@ -293,6 +354,20 @@ const ServicesList: React.FC<{
         }
         return true;
       }
+      if (service.kind === 'SelfPacedLab') {
+        const selfPacedLab = service as SelfPacedLab;
+        if (selfPacedLab.metadata.deletionTimestamp) {
+          return false;
+        }
+        if (keywordFilter) {
+          for (const keyword of keywordFilter) {
+            if (!keywordMatch(selfPacedLab, keyword)) {
+              return false;
+            }
+          }
+        }
+        return true;
+      }
       return false;
     },
     [keywordFilter, isAdmin],
@@ -310,6 +385,15 @@ const ServicesList: React.FC<{
           }
           return ws;
         }
+        if (service.kind === 'SelfPacedLab') {
+          const spl = service as SelfPacedLabWithResourceClaims;
+          const key = `${spl.metadata.namespace}/${spl.metadata.name}`;
+          const rcs = selfPacedLabRCsMap?.[key];
+          if (rcs !== undefined) {
+            return { ...spl, resourceClaims: rcs } as SelfPacedLabWithResourceClaims;
+          }
+          return spl;
+        }
         return service;
       });
       return enriched
@@ -318,7 +402,7 @@ const ServicesList: React.FC<{
           (a, b) => new Date(b.metadata.creationTimestamp).valueOf() - new Date(a.metadata.creationTimestamp).valueOf(),
         );
     },
-    [filterFn, _services, workshopRCsMap],
+    [filterFn, _services, workshopRCsMap, selfPacedLabRCsMap],
   );
 
   const revalidate = useCallback(
@@ -427,6 +511,23 @@ const ServicesList: React.FC<{
     [cache, modalState.action, modalState.workshop, revalidate, mutate],
   );
 
+  const performModalActionForSelfPacedLab = useCallback(
+    async (selfPacedLab: SelfPacedLab): Promise<SelfPacedLab> => {
+      if (modalState.action === 'delete') {
+        try {
+          return await deleteSelfPacedLab(selfPacedLab);
+        } catch (error: unknown) {
+          if ((error as { status?: number })?.status === 404) {
+            return selfPacedLab;
+          }
+          throw error;
+        }
+      }
+      return selfPacedLab;
+    },
+    [modalState.action],
+  );
+
   const onModalAction = useCallback(async (): Promise<void> => {
     const serviceUpdates: Service[] = [];
     if (modalState.resourceClaim) {
@@ -435,6 +536,8 @@ const ServicesList: React.FC<{
       serviceUpdates.push(
         setResourceClaims(await performModalActionForWorkshop(modalState.workshop), modalState.workshop.resourceClaims),
       );
+    } else if (modalState.selfPacedLab) {
+      serviceUpdates.push(await performModalActionForSelfPacedLab(modalState.selfPacedLab));
     } else if (selectedUids.length > 0) {
       for (const service of services) {
         if (selectedUids.includes(service.metadata.uid)) {
@@ -446,6 +549,9 @@ const ServicesList: React.FC<{
             serviceUpdates.push(
               setResourceClaims(await performModalActionForWorkshop(_workshop), _workshop.resourceClaims),
             );
+          }
+          if (service.kind === 'SelfPacedLab') {
+            serviceUpdates.push(await performModalActionForSelfPacedLab(service as SelfPacedLab));
           }
         }
       }
@@ -473,11 +579,13 @@ const ServicesList: React.FC<{
   }, [
     modalState.resourceClaim,
     modalState.workshop,
+    modalState.selfPacedLab,
     modalState.action,
     modalState.rating,
     selectedUids,
     performModalActionForResourceClaim,
     performModalActionForWorkshop,
+    performModalActionForSelfPacedLab,
     services,
     globalMutate,
     revalidate,
@@ -489,18 +597,20 @@ const ServicesList: React.FC<{
       action,
       resourceClaim,
       workshop,
+      selfPacedLab,
     }: {
       modal: string;
       action?: ServiceActionActions;
       resourceClaim?: ResourceClaim;
       workshop?: Workshop;
+      selfPacedLab?: SelfPacedLab;
     }) => {
       if (modal === 'action') {
-        setModalState({ ...modalState, action, resourceClaim, workshop });
+        setModalState({ ...modalState, action, resourceClaim, workshop, selfPacedLab });
         openModalAction();
       }
       if (modal === 'scheduleAction') {
-        setModalState({ ...modalState, action, resourceClaim, workshop });
+        setModalState({ ...modalState, action, resourceClaim, workshop, selfPacedLab });
         openModalScheduleAction();
       }
     },
@@ -528,7 +638,7 @@ const ServicesList: React.FC<{
 
   // Check if any selected service is a collaborator service (can't delete those)
   const selectedHasCollaborator = selectedUids.length > 0 && services.some(
-    (service) => selectedUids.includes(service.metadata.uid) && service.isCollaborator
+    (service) => selectedUids.includes(service.metadata.uid) && 'isCollaborator' in service && service.isCollaborator
   );
 
   return (
@@ -663,6 +773,12 @@ const ServicesList: React.FC<{
                 return Object.assign(
                   selectObj,
                   renderWorkshopRow({ workshop: service as Workshop, showModal, isAdmin }),
+                );
+              }
+              if (service.kind === 'SelfPacedLab') {
+                return Object.assign(
+                  selectObj,
+                  renderSelfPacedLabRow({ selfPacedLab: service as SelfPacedLab, showModal, isAdmin }),
                 );
               }
               return null;

--- a/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
+++ b/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { SelfPacedLab, ServiceActionActions } from '@app/types';
+import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
+import { displayName, getStageFromK8sObject } from '@app/util';
+import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
+import TimeInterval from '@app/components/TimeInterval';
+import { Link } from 'react-router-dom';
+import OpenshiftConsoleLink from '@app/components/OpenshiftConsoleLink';
+import AutoStopDestroy from '@app/components/AutoStopDestroy';
+import Label from '@app/components/Label';
+import SelfPacedLabStatus from '@app/components/SelfPacedLabStatus';
+
+const renderSelfPacedLabRow = ({
+  selfPacedLab,
+  showModal,
+  isAdmin,
+}: {
+  selfPacedLab: SelfPacedLab;
+  showModal: ({
+    modal,
+    action,
+    selfPacedLab,
+  }: {
+    modal: string;
+    action?: ServiceActionActions;
+    selfPacedLab?: SelfPacedLab;
+  }) => void;
+  isAdmin: boolean;
+}) => {
+  const actionHandlers = {
+    delete: () => showModal({ modal: 'action', action: 'delete', selfPacedLab }),
+    lifespan: () => showModal({ action: 'retirement', modal: 'scheduleAction', selfPacedLab }),
+  };
+  const stage = getStageFromK8sObject(selfPacedLab);
+  const autoDestroyTime = selfPacedLab.spec.lifespan?.end ? Date.parse(selfPacedLab.spec.lifespan.end) : null;
+
+  const poolCount = selfPacedLab.status?.poolCount;
+
+  const nameCell = (
+    <>
+      <Link
+        key="selfpacedlab-name"
+        to={`/selfpacedlabs/${selfPacedLab.metadata.namespace}/${selfPacedLab.metadata.name}`}
+      >
+        {displayName(selfPacedLab)}
+      </Link>
+      {stage !== 'prod' ? <Label key="selfpacedlab-name__stage">{stage}</Label> : null}
+      <Label key="selfpacedlab-name__type" tooltipDescription={<div>Self-paced lab with warm pool of pre-provisioned instances</div>}>
+        Self-Paced Lab
+      </Label>
+      {isAdmin ? <OpenshiftConsoleLink key="selfpacedlab-name__console" resource={selfPacedLab} /> : null}
+    </>
+  );
+  const guidCell = <span key="selfpacedlab-guid">-</span>;
+  const statusCell = poolCount ? (
+    <SelfPacedLabStatus key="selfpacedlab-status" poolCount={poolCount} />
+  ) : (
+    <span key="selfpacedlab-status">Initializing...</span>
+  );
+  const createdAtCell = (
+    <>
+      <TimeInterval key="interval" toTimestamp={selfPacedLab.metadata.creationTimestamp} />
+    </>
+  );
+  const autoStopCell = <span key="selfpacedlab-autostop">-</span>;
+  const autoDestroyCell = (
+    <>
+      <AutoStopDestroy
+        type="auto-destroy"
+        onClick={actionHandlers.lifespan}
+        time={autoDestroyTime}
+        isDisabled={!showModal}
+        notDefinedMessage="- Not defined -"
+        key="selfpacedlab-auto-destroy"
+      />
+    </>
+  );
+  const actionsCell = (
+    <React.Fragment key="selfpacedlab-actions">
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 'var(--pf-t--global--spacer--sm)',
+        }}
+      >
+        <ButtonCircleIcon
+          key="actions__delete"
+          onClick={actionHandlers.delete}
+          description="Delete"
+          icon={TrashIcon}
+        />
+      </div>
+    </React.Fragment>
+  );
+
+  return {
+    cells: isAdmin
+      ? [nameCell, guidCell, statusCell, createdAtCell, autoStopCell, autoDestroyCell, actionsCell]
+      : [nameCell, statusCell, createdAtCell, autoStopCell, autoDestroyCell, actionsCell],
+  };
+};
+
+export default renderSelfPacedLabRow;

--- a/catalog/ui/src/app/api.spec.ts
+++ b/catalog/ui/src/app/api.spec.ts
@@ -1,13 +1,6 @@
-import { FORBIDDEN_RESPONSE } from './api';
-
-// Mock the fetcher and apiFetch
-jest.mock('./api', () => {
-  const originalModule = jest.requireActual('./api');
-  return {
-    ...originalModule,
-    fetcher: jest.fn(),
-  };
-});
+import { FORBIDDEN_RESPONSE, assignSelfPacedLabUser } from './api';
+import { SelfPacedLabUserAssignment } from './types';
+import fetchMock from 'jest-fetch-mock';
 
 describe('optionalFetcher', () => {
   beforeEach(() => {
@@ -79,5 +72,160 @@ describe('Resource Pool Annotation Logic', () => {
       const result = getResourcePoolSpec();
       expect(result).toEqual({});
     });
+  });
+});
+
+describe('assignSelfPacedLabUser', () => {
+  const makeSelfPacedLabUserAssignment = (
+    overrides: Partial<{
+      name: string;
+      resourceClaimName: string;
+      userName: string;
+      email: string;
+      selfPacedLabName: string;
+    }> = {},
+  ): SelfPacedLabUserAssignment => ({
+    apiVersion: 'babylon.gpte.redhat.com/v1',
+    kind: 'SelfPacedLabUserAssignment',
+    metadata: {
+      name: overrides.name || 'splua-001',
+      namespace: 'test-ns',
+      uid: 'uid-001',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+    },
+    spec: {
+      selfPacedLabName: overrides.selfPacedLabName || 'test-lab',
+      resourceClaimName: overrides.resourceClaimName || 'rc-001',
+      userName: overrides.userName || 'user1',
+      ...(overrides.email !== undefined ? { assignment: { email: overrides.email } } : {}),
+    },
+  });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (window as any).sessionPromiseInstance = Promise.resolve({ token: 'test-token' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (window as any).sessionPromiseInstance;
+  });
+
+  test('should return original array when assignment is not found', async () => {
+    const assignments = [makeSelfPacedLabUserAssignment()];
+
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'non-existent',
+      userName: 'user1',
+      email: 'new@example.com',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result).toBe(assignments);
+    expect(console.error).toHaveBeenCalledWith('Unable to assign, non-existent user1 not found.');
+  });
+
+  test('should return original array when email already matches', async () => {
+    const assignments = [makeSelfPacedLabUserAssignment({ email: 'same@example.com' })];
+
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: 'same@example.com',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result).toBe(assignments);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('should return original array when both current and new email are empty', async () => {
+    const assignments = [makeSelfPacedLabUserAssignment()];
+
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: '',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result).toBe(assignments);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('should add assignment when no existing assignment and email provided', async () => {
+    const updatedAssignment = makeSelfPacedLabUserAssignment({ email: 'new@example.com' });
+    fetchMock.mockResponseOnce(JSON.stringify(updatedAssignment));
+
+    const assignments = [makeSelfPacedLabUserAssignment()];
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: 'new@example.com',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result[0]).toEqual(updatedAssignment);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain('selfpacedlabuserassignments');
+    const body = JSON.parse(options?.body as string);
+    expect(body).toContainEqual({ op: 'add', path: '/spec/assignment', value: { email: 'new@example.com' } });
+  });
+
+  test('should replace assignment email when existing assignment present', async () => {
+    const updatedAssignment = makeSelfPacedLabUserAssignment({ email: 'new@example.com' });
+    fetchMock.mockResponseOnce(JSON.stringify(updatedAssignment));
+
+    const assignments = [makeSelfPacedLabUserAssignment({ email: 'old@example.com' })];
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: 'new@example.com',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result[0]).toEqual(updatedAssignment);
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options?.body as string);
+    expect(body).toContainEqual({ op: 'test', path: '/spec/assignment/email', value: 'old@example.com' });
+    expect(body).toContainEqual({ op: 'replace', path: '/spec/assignment/email', value: 'new@example.com' });
+  });
+
+  test('should remove assignment when existing assignment and empty email', async () => {
+    const updatedAssignment = makeSelfPacedLabUserAssignment();
+    fetchMock.mockResponseOnce(JSON.stringify(updatedAssignment));
+
+    const assignments = [makeSelfPacedLabUserAssignment({ email: 'old@example.com' })];
+    const result = await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: '',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    expect(result[0]).toEqual(updatedAssignment);
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options?.body as string);
+    expect(body).toContainEqual({ op: 'remove', path: '/spec/assignment' });
+  });
+
+  test('should include test ops for resourceClaimName and userName', async () => {
+    const updatedAssignment = makeSelfPacedLabUserAssignment({ email: 'new@example.com' });
+    fetchMock.mockResponseOnce(JSON.stringify(updatedAssignment));
+
+    const assignments = [makeSelfPacedLabUserAssignment()];
+    await assignSelfPacedLabUser({
+      resourceClaimName: 'rc-001',
+      userName: 'user1',
+      email: 'new@example.com',
+      selfPacedLabUserAssignments: assignments,
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options?.body as string);
+    expect(body).toContainEqual({ op: 'test', path: '/spec/resourceClaimName', value: 'rc-001' });
+    expect(body).toContainEqual({ op: 'test', path: '/spec/userName', value: 'user1' });
   });
 });

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -26,6 +26,7 @@ import {
   Session,
   Nullable,
   WorkshopUserAssignment,
+  SelfPacedLabUserAssignment,
 } from '@app/types';
 import { store, selectImpersonationUser } from '@app/store';
 import {
@@ -322,6 +323,103 @@ export async function assignWorkshopUser({
   });
   workshopUserAssignments[userAssignmentIdx] = updatedWorkshopUserAssignment;
   return workshopUserAssignments;
+}
+
+export async function assignSelfPacedLabUser({
+  resourceClaimName,
+  userName,
+  email,
+  selfPacedLabUserAssignments,
+}: {
+  resourceClaimName: string;
+  userName: string;
+  email: string;
+  selfPacedLabUserAssignments: SelfPacedLabUserAssignment[];
+}) {
+  const userAssignmentIdx: number = selfPacedLabUserAssignments.findIndex(
+    (item) => resourceClaimName === item.spec.resourceClaimName && userName === item.spec.userName,
+  );
+  const userAssignment = selfPacedLabUserAssignments[userAssignmentIdx];
+  if (!userAssignment) {
+    console.error(`Unable to assign, ${resourceClaimName} ${userName} not found.`);
+    return selfPacedLabUserAssignments;
+  } else if (userAssignment.spec.assignment?.email === email || (!userAssignment.spec.assignment?.email && !email)) {
+    return selfPacedLabUserAssignments;
+  }
+
+  const jsonPatch: JSONPatch = [];
+  if (resourceClaimName) {
+    jsonPatch.push({
+      op: 'test',
+      path: `/spec/resourceClaimName`,
+      value: resourceClaimName,
+    });
+  }
+  if (userName) {
+    jsonPatch.push({
+      op: 'test',
+      path: `/spec/userName`,
+      value: userName,
+    });
+  }
+  if (userAssignment.spec.assignment) {
+    jsonPatch.push({
+      op: 'test',
+      path: `/spec/assignment/email`,
+      value: userAssignment.spec.assignment.email,
+    });
+    if (email) {
+      jsonPatch.push({
+        op: 'replace',
+        path: `/spec/assignment/email`,
+        value: email,
+      });
+    } else {
+      jsonPatch.push({
+        op: 'remove',
+        path: `/spec/assignment`,
+      });
+    }
+  } else if (email) {
+    jsonPatch.push({
+      op: 'add',
+      path: `/spec/assignment`,
+      value: { email: email },
+    });
+  } else {
+    return selfPacedLabUserAssignments;
+  }
+
+  const updatedSelfPacedLabUserAssignment = await patchK8sObject<SelfPacedLabUserAssignment>({
+    name: userAssignment.metadata.name,
+    namespace: userAssignment.metadata.namespace,
+    jsonPatch: jsonPatch,
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    plural: 'selfpacedlabuserassignments',
+  });
+  selfPacedLabUserAssignments[userAssignmentIdx] = updatedSelfPacedLabUserAssignment;
+  return selfPacedLabUserAssignments;
+}
+
+export async function patchSelfPacedLabUserAssignment({
+  name,
+  namespace,
+  jsonPatch,
+  patch,
+}: {
+  name: string;
+  namespace: string;
+  jsonPatch?: JSONPatch;
+  patch?: Record<string, unknown>;
+}) {
+  return await patchK8sObject<SelfPacedLabUserAssignment>({
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    jsonPatch,
+    name,
+    namespace,
+    plural: 'selfpacedlabuserassignments',
+    patch,
+  });
 }
 
 export function dateToApiString(date: Date) {
@@ -2525,6 +2623,8 @@ export const apiPaths = {
     `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabitems?labelSelector=${encodeURIComponent(`${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLabName}`)}${
       limit ? `&limit=${limit}` : ''
     }${continueId ? `&continue=${continueId}` : ''}`,
+  SELF_PACED_LAB_USER_ASSIGNMENTS: ({ namespace, selfPacedLabName }: { namespace: string; selfPacedLabName: string }) =>
+    `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabuserassignments?labelSelector=${encodeURIComponent(`${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLabName}`)}`,
   WORKSHOP: ({ namespace, workshopName }: { namespace: string; workshopName: string }) =>
     `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/workshops/${workshopName}`,
   WORKSHOPS: ({ namespace, limit, continueId }: { namespace?: string; limit?: number | string; continueId?: string }) =>

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -17,6 +17,8 @@ import {
   ResourceProvider,
   ServiceAccessConfig,
   ServiceNamespace,
+  SelfPacedLab,
+  SelfPacedLabItem,
   Workshop,
   WorkshopProvision,
   MultiWorkshop,
@@ -222,13 +224,13 @@ export async function fetcherItemsInAllPages(pathFn: (continueId: string) => str
   return items;
 }
 
-function addPurposeAndSfdc(
-  _definition: K8sObject,
+function addPurposeAndSfdc<T extends K8sObject>(
+  _definition: T,
   parameterValues: Record<string, unknown>,
   skippedSfdc: boolean,
   salesforceItems?: Array<{ id: string; type: 'campaign' | 'project' | 'opportunity' }>,
-) {
-  const d = Object.assign({}, _definition) as ResourceClaim | Workshop;
+): T {
+  const d = Object.assign({}, _definition) as T;
   // Purpose & SFDC
   if (parameterValues.purpose) {
     d.metadata.annotations[`${DEMO_DOMAIN}/purpose`] = parameterValues.purpose as string;
@@ -1090,6 +1092,206 @@ export async function deleteResourceProvider(resourceProvider: ResourceProvider)
 
 export async function deleteWorkshop(workshop: Workshop) {
   return await deleteK8sObject(workshop);
+}
+
+export async function createSelfPacedLab({
+  accessPassword,
+  catalogItem,
+  description,
+  displayName,
+  openRegistration,
+  serviceNamespace,
+  endDate,
+  startDate,
+  email,
+  parameterValues,
+  skippedSfdc,
+  whiteGloved,
+  salesforceItems,
+}: {
+  accessPassword?: string;
+  catalogItem: CatalogItem;
+  description?: string;
+  displayName?: string;
+  openRegistration: boolean;
+  serviceNamespace: ServiceNamespace;
+  endDate?: Date;
+  startDate?: Date;
+  email: string;
+  parameterValues: Record<string, unknown>;
+  skippedSfdc: boolean;
+  whiteGloved: boolean;
+  salesforceItems?: Array<{ id: string; type: 'campaign' | 'project' | 'opportunity' }>;
+}): Promise<SelfPacedLab> {
+  const session = await getApiSession();
+  const selfPacedLabName = generateK8sNameWithSuffix(catalogItem.metadata.name);
+  const _definition: SelfPacedLab = {
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    kind: 'SelfPacedLab',
+    metadata: {
+      name: selfPacedLabName,
+      namespace: serviceNamespace.name,
+      labels: {
+        [`${BABYLON_DOMAIN}/catalogItemName`]: catalogItem.metadata.name,
+        [`${BABYLON_DOMAIN}/catalogItemNamespace`]: catalogItem.metadata.namespace,
+        ...(catalogItem.metadata.labels?.['gpte.redhat.com/asset-uuid']
+          ? { 'gpte.redhat.com/asset-uuid': catalogItem.metadata.labels['gpte.redhat.com/asset-uuid'] }
+          : {}),
+        [`${DEMO_DOMAIN}/white-glove`]: String(whiteGloved),
+      },
+      annotations: {
+        [`${BABYLON_DOMAIN}/category`]: catalogItem.spec.category,
+        [`${DEMO_DOMAIN}/requester`]: serviceNamespace.requester || email,
+        [`${DEMO_DOMAIN}/orderedBy`]: session.user,
+        ...(catalogItem.spec.supportLink ? { [`${BABYLON_DOMAIN}/support-link`]: catalogItem.spec.supportLink } : {}),
+      },
+    },
+    spec: {
+      openRegistration: openRegistration,
+      lifespan: {
+        ...(startDate ? { start: dateToApiString(startDate) } : {}),
+        ...(endDate ? { end: dateToApiString(endDate) } : {}),
+      },
+    },
+  };
+  if (accessPassword) {
+    _definition.spec.accessPassword = accessPassword;
+  }
+  if (description) {
+    _definition.spec.description = description;
+  }
+  if (displayName) {
+    _definition.spec.displayName = displayName;
+  }
+
+  const definition = addPurposeAndSfdc(_definition, parameterValues, skippedSfdc, salesforceItems);
+
+  let retryCount = 0;
+  const maxRetries = 3;
+
+  while (retryCount <= maxRetries) {
+    try {
+      return await createK8sObject(definition);
+    } catch (error: unknown) {
+      if ((error as Response).status === 409 && retryCount < maxRetries) {
+        retryCount++;
+        definition.metadata.name = generateK8sNameWithSuffix(catalogItem.metadata.name);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error('Failed to create self-paced lab after maximum retries');
+}
+
+export async function createSelfPacedLabItem({
+  catalogItem,
+  poolSize,
+  assignedLifespan,
+  unassignedLifespan,
+  concurrency,
+  startDelay,
+  parameters,
+  selfPacedLab,
+}: {
+  catalogItem: CatalogItem;
+  poolSize: number;
+  assignedLifespan: string;
+  unassignedLifespan: string;
+  concurrency?: number;
+  startDelay?: number;
+  parameters: Record<string, unknown>;
+  selfPacedLab: SelfPacedLab;
+}) {
+  const definition: SelfPacedLabItem = {
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    kind: 'SelfPacedLabItem',
+    metadata: {
+      name: selfPacedLab.metadata.name,
+      namespace: selfPacedLab.metadata.namespace,
+      labels: {
+        [`${BABYLON_DOMAIN}/catalogItemName`]: catalogItem.metadata.name,
+        [`${BABYLON_DOMAIN}/catalogItemNamespace`]: catalogItem.metadata.namespace,
+        ...(catalogItem.metadata.labels?.['gpte.redhat.com/asset-uuid']
+          ? { 'gpte.redhat.com/asset-uuid': catalogItem.metadata.labels['gpte.redhat.com/asset-uuid'] }
+          : {}),
+      },
+      annotations: {
+        [`${BABYLON_DOMAIN}/category`]: catalogItem.spec.category,
+      },
+      ownerReferences: [
+        {
+          apiVersion: `${BABYLON_DOMAIN}/v1`,
+          controller: true,
+          kind: 'SelfPacedLab',
+          name: selfPacedLab.metadata.name,
+          uid: selfPacedLab.metadata.uid,
+        },
+      ],
+    },
+    spec: {
+      assignedLifespan,
+      catalogItem: {
+        name: catalogItem.metadata.name,
+        namespace: catalogItem.metadata.namespace,
+      },
+      poolSize,
+      selfPacedLabName: selfPacedLab.metadata.name,
+      unassignedLifespan,
+      ...(concurrency ? { concurrency } : {}),
+      ...(startDelay ? { startDelay } : {}),
+      parameters,
+    },
+  };
+
+  return await createK8sObject(definition);
+}
+
+export async function deleteSelfPacedLab(selfPacedLab: SelfPacedLab) {
+  return await deleteK8sObject(selfPacedLab);
+}
+
+export async function patchSelfPacedLab({
+  name,
+  namespace,
+  jsonPatch,
+  patch,
+}: {
+  name: string;
+  namespace: string;
+  jsonPatch?: JSONPatch;
+  patch?: Record<string, unknown>;
+}): Promise<SelfPacedLab> {
+  return await patchK8sObject({
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    jsonPatch,
+    name,
+    namespace,
+    plural: 'selfpacedlabs',
+    patch,
+  });
+}
+
+export async function patchSelfPacedLabItem({
+  name,
+  namespace,
+  jsonPatch,
+  patch,
+}: {
+  name: string;
+  namespace: string;
+  jsonPatch?: JSONPatch;
+  patch?: Record<string, unknown>;
+}): Promise<SelfPacedLabItem> {
+  return await patchK8sObject({
+    apiVersion: `${BABYLON_DOMAIN}/v1`,
+    jsonPatch,
+    name,
+    namespace,
+    plural: 'selfpacedlabitems',
+    patch,
+  });
 }
 
 export async function deleteAssetFromMultiWorkshop({
@@ -2303,6 +2505,26 @@ export const apiPaths = {
     `/api/v1/namespaces?${labelSelector ? `labelSelector=${labelSelector}` : ''}${limit ? `&limit=${limit}` : ''}${
       continueId ? `&continue=${continueId}` : ''
     }`,
+  SELF_PACED_LAB: ({ namespace, selfPacedLabName }: { namespace: string; selfPacedLabName: string }) =>
+    `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabs/${selfPacedLabName}`,
+  SELF_PACED_LABS: ({ namespace, limit, continueId }: { namespace?: string; limit?: number | string; continueId?: string }) =>
+    `/apis/${BABYLON_DOMAIN}/v1${namespace ? `/namespaces/${namespace}` : ''}/selfpacedlabs?${
+      limit ? `limit=${limit}` : ''
+    }${continueId ? `&continue=${continueId}` : ''}`,
+  SELF_PACED_LAB_ITEMS: ({
+    namespace,
+    selfPacedLabName,
+    limit,
+    continueId,
+  }: {
+    namespace: string;
+    selfPacedLabName: string;
+    limit?: number | string;
+    continueId?: string;
+  }) =>
+    `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabitems?labelSelector=${encodeURIComponent(`${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLabName}`)}${
+      limit ? `&limit=${limit}` : ''
+    }${continueId ? `&continue=${continueId}` : ''}`,
   WORKSHOP: ({ namespace, workshopName }: { namespace: string; workshopName: string }) =>
     `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/workshops/${workshopName}`,
   WORKSHOPS: ({ namespace, limit, continueId }: { namespace?: string; limit?: number | string; continueId?: string }) =>

--- a/catalog/ui/src/app/components/ReorderModal.tsx
+++ b/catalog/ui/src/app/components/ReorderModal.tsx
@@ -118,7 +118,7 @@ const ReorderModal: React.FC<{
       </p>
       <DescriptionList
         isHorizontal
-        compact
+        isCompact
         style={{
           marginTop: 'var(--pf-t--global--spacer--md)',
           marginBottom: 'var(--pf-t--global--spacer--md)',

--- a/catalog/ui/src/app/components/SelfPacedLabStatus.spec.tsx
+++ b/catalog/ui/src/app/components/SelfPacedLabStatus.spec.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SelfPacedLabStatus from './SelfPacedLabStatus';
+import { ResourceClaim } from '@app/types';
+
+describe('SelfPacedLabStatus', () => {
+  describe('with poolCount prop', () => {
+    test('should display ready, assigned, and provisioning counts', () => {
+      render(<SelfPacedLabStatus poolCount={{ ready: 5, assigned: 3, provisioning: 2 }} />);
+
+      expect(screen.getByText('5 ready')).toBeInTheDocument();
+      expect(screen.getByText('3 assigned')).toBeInTheDocument();
+      expect(screen.getByText('2 provisioning')).toBeInTheDocument();
+    });
+
+    test('should default missing counts to 0', () => {
+      render(<SelfPacedLabStatus poolCount={{}} />);
+
+      expect(screen.getByText('0 ready')).toBeInTheDocument();
+      expect(screen.getByText('0 assigned')).toBeInTheDocument();
+      expect(screen.getByText('0 provisioning')).toBeInTheDocument();
+    });
+
+    test('should handle partial poolCount', () => {
+      render(<SelfPacedLabStatus poolCount={{ ready: 3 }} />);
+
+      expect(screen.getByText('3 ready')).toBeInTheDocument();
+      expect(screen.getByText('0 assigned')).toBeInTheDocument();
+      expect(screen.getByText('0 provisioning')).toBeInTheDocument();
+    });
+  });
+
+  describe('with resourceClaims prop', () => {
+    const assignmentLabel = 'babylon.gpte.redhat.com/selfpacedlab-assignment';
+
+    const makeResourceClaim = (overrides: {
+      labels?: Record<string, string>;
+      state?: string;
+    }): ResourceClaim =>
+      ({
+        apiVersion: 'poolboy.gpte.redhat.com/v1',
+        kind: 'ResourceClaim',
+        metadata: {
+          name: 'rc-test',
+          namespace: 'test-ns',
+          labels: overrides.labels || {},
+        },
+        status: {
+          summary: {
+            state: overrides.state || 'provisioning',
+          },
+        },
+      }) as unknown as ResourceClaim;
+
+    test('should count assigned claims by label', () => {
+      const resourceClaims = [
+        makeResourceClaim({ labels: { [assignmentLabel]: 'user@example.com' }, state: 'started' }),
+        makeResourceClaim({ labels: { [assignmentLabel]: 'user2@example.com' }, state: 'started' }),
+        makeResourceClaim({ state: 'started' }),
+      ];
+
+      render(<SelfPacedLabStatus resourceClaims={resourceClaims} />);
+
+      expect(screen.getByText('1 ready')).toBeInTheDocument();
+      expect(screen.getByText('2 assigned')).toBeInTheDocument();
+      expect(screen.getByText('0 provisioning')).toBeInTheDocument();
+    });
+
+    test('should count ready claims (started/stopped without assignment)', () => {
+      const resourceClaims = [
+        makeResourceClaim({ state: 'started' }),
+        makeResourceClaim({ state: 'stopped' }),
+        makeResourceClaim({ state: 'provisioning' }),
+      ];
+
+      render(<SelfPacedLabStatus resourceClaims={resourceClaims} />);
+
+      expect(screen.getByText('2 ready')).toBeInTheDocument();
+      expect(screen.getByText('0 assigned')).toBeInTheDocument();
+      expect(screen.getByText('1 provisioning')).toBeInTheDocument();
+    });
+
+    test('should show all zeros with empty resourceClaims', () => {
+      render(<SelfPacedLabStatus resourceClaims={[]} />);
+
+      expect(screen.getByText('0 ready')).toBeInTheDocument();
+      expect(screen.getByText('0 assigned')).toBeInTheDocument();
+      expect(screen.getByText('0 provisioning')).toBeInTheDocument();
+    });
+
+    test('should show all zeros when resourceClaims is undefined', () => {
+      render(<SelfPacedLabStatus />);
+
+      expect(screen.getByText('0 ready')).toBeInTheDocument();
+      expect(screen.getByText('0 assigned')).toBeInTheDocument();
+      expect(screen.getByText('0 provisioning')).toBeInTheDocument();
+    });
+  });
+
+  describe('poolCount takes priority over resourceClaims', () => {
+    test('should use poolCount when both props are provided', () => {
+      const resourceClaims = [
+        {
+          apiVersion: 'poolboy.gpte.redhat.com/v1',
+          kind: 'ResourceClaim',
+          metadata: { name: 'rc-1', namespace: 'ns', labels: {} },
+          status: { summary: { state: 'started' } },
+        } as unknown as ResourceClaim,
+      ];
+
+      render(
+        <SelfPacedLabStatus poolCount={{ ready: 10, assigned: 5, provisioning: 3 }} resourceClaims={resourceClaims} />,
+      );
+
+      expect(screen.getByText('10 ready')).toBeInTheDocument();
+      expect(screen.getByText('5 assigned')).toBeInTheDocument();
+      expect(screen.getByText('3 provisioning')).toBeInTheDocument();
+    });
+  });
+});

--- a/catalog/ui/src/app/components/SelfPacedLabStatus.tsx
+++ b/catalog/ui/src/app/components/SelfPacedLabStatus.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import HourglassHalfIcon from '@patternfly/react-icons/dist/js/icons/hourglass-half-icon';
+import UserIcon from '@patternfly/react-icons/dist/js/icons/user-icon';
+import { ResourceClaim } from '@app/types';
+import { BABYLON_DOMAIN } from '@app/util';
+
+const SelfPacedLabStatus: React.FC<{
+  resourceClaims?: ResourceClaim[];
+  poolCount?: { ready?: number; assigned?: number; provisioning?: number };
+  assignmentLabel?: string;
+}> = ({ resourceClaims, poolCount, assignmentLabel = `${BABYLON_DOMAIN}/selfpacedlab-assignment` }) => {
+  const status = useMemo(() => {
+    if (poolCount) {
+      return {
+        ready: poolCount.ready ?? 0,
+        assigned: poolCount.assigned ?? 0,
+        provisioning: poolCount.provisioning ?? 0,
+      };
+    }
+    if (!resourceClaims) return { ready: 0, assigned: 0, provisioning: 0 };
+    let ready = 0;
+    let assigned = 0;
+    let provisioning = 0;
+    for (const rc of resourceClaims) {
+      if (rc.metadata.labels?.[assignmentLabel]) {
+        assigned++;
+      } else if (rc.status?.summary?.state === 'started' || rc.status?.summary?.state === 'stopped') {
+        ready++;
+      } else {
+        provisioning++;
+      }
+    }
+    return { ready, assigned, provisioning };
+  }, [resourceClaims, poolCount, assignmentLabel]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--xs)' }}>
+      <span style={{ color: 'var(--pf-t--global--border--color--status--success--default)' }}>
+        <CheckCircleIcon /> {status.ready} ready
+      </span>
+      <span style={{ color: 'var(--pf-t--global--border--color--status--success--default)' }}>
+        <UserIcon /> {status.assigned} assigned
+      </span>
+      <span style={{ color: 'var(--pf-t--global--icon--color--status--info--default)' }}>
+        <HourglassHalfIcon /> {status.provisioning} provisioning
+      </span>
+    </div>
+  );
+};
+
+export default SelfPacedLabStatus;

--- a/catalog/ui/src/app/routes.tsx
+++ b/catalog/ui/src/app/routes.tsx
@@ -11,6 +11,7 @@ const CatalogItemForm = React.lazy(() => import('@app/Catalog/CatalogItemForm'))
 const Services = React.lazy(() => import('@app/Services/Services'));
 const ResourceClaims = React.lazy(() => import('@app/Admin/ResourceClaims'));
 const WorkshopsList = React.lazy(() => import('@app/Admin/Workshops'));
+const SelfPacedLabsList = React.lazy(() => import('@app/Admin/SelfPacedLabs'));
 const MultiWorkshopsList = React.lazy(() => import('@app/Admin/MultiWorkshops'));
 const MultiWorkshopList = React.lazy(() => import('@app/MultiWorkshops/MultiWorkshopList'));
 
@@ -18,7 +19,9 @@ const MultiWorkshopCreate = React.lazy(() => import('@app/MultiWorkshops/MultiWo
 const MultiWorkshopDetail = React.lazy(() => import('@app/MultiWorkshops/MultiWorkshopDetail'));
 const MultiWorkshopLanding = React.lazy(() => import('@app/MultiWorkshops/MultiWorkshopLanding'));
 const WorkshopsItem = React.lazy(() => import('@app/Workshops/WorkshopsItem'));
+const SelfPacedLabItem = React.lazy(() => import('@app/SelfPacedLabs/SelfPacedLabItem'));
 const Workshop = React.lazy(() => import('@app/Workshop/Workshop'));
+const SelfPacedLab = React.lazy(() => import('@app/SelfPacedLab/SelfPacedLab'));
 const SupportPage = React.lazy(() => import('@app/Support/SupportPage'));
 const NotFound = React.lazy(() => import('@app/NotFound/NotFound'));
 const IncidentsPage = React.lazy(() => import('@app/Admin/IncidentsPage'));
@@ -129,6 +132,16 @@ const appRoutes: IAppRoute[] = [
     title: 'Babylon | Workshops',
   },
   {
+    component: SelfPacedLabItem,
+    path: '/selfpacedlabs/:namespace/:name/:tab',
+    title: 'Babylon | Self-Paced Labs',
+  },
+  {
+    component: SelfPacedLabItem,
+    path: '/selfpacedlabs/:namespace/:name',
+    title: 'Babylon | Self-Paced Labs',
+  },
+  {
     component: ResourceClaims,
     path: '/admin/resourceclaims/:namespace',
     title: 'Babylon | ResourceClaims',
@@ -149,6 +162,18 @@ const appRoutes: IAppRoute[] = [
     title: 'Babylon | Workshops',
   },
 
+  {
+    component: SelfPacedLabsList,
+    path: '/admin/selfpacedlabs/:namespace',
+    title: 'Babylon | Self-Paced Labs',
+    accessControl: 'admin',
+  },
+  {
+    component: SelfPacedLabsList,
+    path: '/admin/selfpacedlabs',
+    title: 'Babylon | Self-Paced Labs',
+    accessControl: 'admin',
+  },
   {
     component: MultiWorkshopsList,
     path: '/admin/multiworkshops/:namespace',
@@ -354,6 +379,11 @@ const publicRoutes: IAppRoute[] = [
     component: Workshop,
     path: '/workshop/:workshopId',
     title: 'Workshop | Babylon',
+  },
+  {
+    component: SelfPacedLab,
+    path: '/selfpacedlab/:selfPacedLabId',
+    title: 'Self-Paced Lab | Babylon',
   },
   {
     component: MultiWorkshopLanding,

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -628,6 +628,58 @@ export interface WorkshopSpec {
   };
 }
 
+export interface SelfPacedLab extends K8sObject {
+  spec: SelfPacedLabSpec;
+  status?: {
+    poolCount?: {
+      ready?: number;
+      provisioning?: number;
+      assigned?: number;
+    };
+    selfPacedLabURL?: string;
+  };
+}
+
+export interface SelfPacedLabList {
+  items: SelfPacedLab[];
+  metadata: K8sObjectListMeta;
+}
+
+export interface SelfPacedLabSpec {
+  accessPassword?: string;
+  description?: string;
+  displayName?: string;
+  lifespan?: {
+    start?: string;
+    end?: string;
+  };
+  openRegistration?: boolean;
+}
+
+export interface SelfPacedLabItem extends K8sObject {
+  spec: SelfPacedLabItemSpec;
+  status?: {
+    readyCount?: number;
+    provisioningCount?: number;
+    assignedCount?: number;
+    failedCount?: number;
+  };
+}
+
+export interface SelfPacedLabItemSpec {
+  assignedLifespan: string;
+  catalogItem: {
+    name: string;
+    namespace: string;
+  };
+  concurrency?: number;
+  parameters?: any;
+  poolSize: number;
+  selfPacedLabName: string;
+  startDelay?: number;
+  unassignedLifespan: string;
+}
+
 export interface WorkshopUserAssignmentList {
   metadata: K8sObjectListMeta;
   items: WorkshopUserAssignment[];
@@ -818,7 +870,10 @@ export type WorkshopWithResourceClaims = Workshop & {
   resourceClaims?: ResourceClaim[];
   isCollaborator?: boolean;
 };
-export type Service = ResourceClaimWithCollaborator | WorkshopWithResourceClaims;
+export type SelfPacedLabWithResourceClaims = SelfPacedLab & {
+  resourceClaims?: ResourceClaim[];
+};
+export type Service = ResourceClaimWithCollaborator | WorkshopWithResourceClaims | SelfPacedLabWithResourceClaims;
 
 export type Incident = {
   id: number;

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -680,6 +680,33 @@ export interface SelfPacedLabItemSpec {
   unassignedLifespan: string;
 }
 
+export interface SelfPacedLabUserAssignmentSpec {
+  data?: any;
+  messages?: string;
+  resourceClaimName?: string;
+  userName?: string;
+  selfPacedLabName: string;
+  labUserInterface?: {
+    data?: object;
+    method?: string;
+    url: string;
+    redirect?: boolean;
+  };
+  assignment?: {
+    email: string;
+  };
+}
+
+export interface SelfPacedLabUserAssignment extends K8sObject {
+  spec: SelfPacedLabUserAssignmentSpec;
+  status?: any;
+}
+
+export interface SelfPacedLabUserAssignmentList {
+  metadata: K8sObjectListMeta;
+  items: SelfPacedLabUserAssignment[];
+}
+
 export interface WorkshopUserAssignmentList {
   metadata: K8sObjectListMeta;
   items: WorkshopUserAssignment[];

--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -10,6 +10,7 @@ import {
   Nullable,
   ResourceClaim,
   SalesforceItem,
+  SelfPacedLab,
   Service,
   ServiceNamespace,
   Workshop,
@@ -83,6 +84,9 @@ export function displayName(item: K8sObject | CatalogNamespace | ServiceNamespac
   } else if (k8sObject.kind === 'CatalogItem') {
     const _item = k8sObject as CatalogItem;
     return _item.spec.displayName;
+  } else if (k8sObject.kind === 'SelfPacedLab') {
+    const _item = k8sObject as SelfPacedLab;
+    return _item.spec?.displayName || _item.metadata.name;
   } else {
     return (
       k8sObject.metadata?.annotations?.[`${BABYLON_DOMAIN}/displayName`] ||
@@ -238,6 +242,11 @@ export function isResourceClaimPartOfWorkshop(resourceClaim: ResourceClaim) {
   if (!resourceClaim || !resourceClaim.metadata?.ownerReferences) return false;
   return resourceClaim.metadata.ownerReferences.filter((x) => x.kind === 'WorkshopProvision' || x.kind === 'Workshop')
     .length > 0;
+}
+
+export function isResourceClaimPartOfSelfPacedLab(resourceClaim: ResourceClaim) {
+  if (!resourceClaim || !resourceClaim.metadata?.labels) return false;
+  return !!resourceClaim.metadata.labels[`${BABYLON_DOMAIN}/selfpacedlab`];
 }
 
 export function isWorkshopPartOfResourceClaim(workshop: Workshop) {

--- a/helm/crds/selfpacedlabuserassignments.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/selfpacedlabuserassignments.babylon.gpte.redhat.com.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: selfpacedlabuserassignments.babylon.gpte.redhat.com
+spec:
+  conversion:
+    strategy: None
+  group: babylon.gpte.redhat.com
+  names:
+    kind: SelfPacedLabUserAssignment
+    listKind: SelfPacedLabUserAssignmentList
+    plural: selfpacedlabuserassignments
+    singular: selfpacedlabuserassignment
+  scope: Namespaced
+  versions:
+  - name: v1
+    additionalPrinterColumns:
+    - name: SelfPacedLab
+      type: string
+      jsonPath: .spec.selfPacedLabName
+    - name: ResourceClaim
+      type: string
+      jsonPath: .spec.resourceClaimName
+    - name: User
+      type: string
+      jsonPath: .spec.userName
+    - name: Assignment
+      type: string
+      jsonPath: .spec.assignment.email
+    schema:
+      openAPIV3Schema:
+        description: >-
+          Self-paced lab user assignment which may represent an assigned seat to a user or an available, unassigned, seat.
+        required:
+        - resourceClaimName
+        - selfPacedLabName
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            properties:
+              name:
+                maxLength: 63
+                pattern: ^[a-z0-9A-Z]([a-z0-9A-Z\-._]*[a-z0-9A-Z])?$
+                type: string
+            type: object
+          spec:
+            description: Specification of SelfPacedLabUserAssignment.
+            type: object
+            properties:
+              assignment:
+                description: >-
+                  Assignment for self-paced lab participant.
+                type: object
+                required:
+                - email
+                properties:
+                  email:
+                    description: >-
+                      Email address used to identify self-paced lab participant.
+                    type: string
+              data:
+                description: >-
+                  Any data items reported for the user from the service provisioning.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              labUserInterface:
+                description: >-
+                  Lab user interface information for user access.
+                type: object
+                properties:
+                  redirect:
+                    description: >-
+                      Configure that users should be automatically redirected to the lab user interface.
+                    type: boolean
+                  url:
+                    description: >-
+                      URL for the lab user interface.
+                    type: string
+              messages:
+                description: >-
+                  Any messages reported for the user from the service provisioning.
+                type: string
+              resourceClaimName:
+                description: >-
+                  ResourceClaim name.
+                type: string
+              userName:
+                description: >-
+                  User name for lab as reported from the service provisioning.
+                type: string
+              selfPacedLabName:
+                description: >-
+                  SelfPacedLab name reference.
+                type: string
+          status:
+            description: Status of SelfPacedLabUserAssignment
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              diffBase:
+                description: Kopf diffbase
+                type: string
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/catalog/interfaces/oauth-proxy/deployment.yaml
+++ b/helm/templates/catalog/interfaces/oauth-proxy/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --openshift-service-account=babylon-catalog-oauth-proxy
         - --provider=openshift
         - --skip-auth-regex=^/(api/)?workshop($|/.*)
+        - --skip-auth-regex=^/(api/)?selfpacedlab($|/.*)
         - --skip-auth-regex=^/(api/)?event($|/.*)
         - --skip-auth-regex=^/support($|/)
         - --skip-auth-regex=^/fonts/.*

--- a/selfpacedlab-manager/helm/templates/rbac.yaml
+++ b/selfpacedlab-manager/helm/templates/rbac.yaml
@@ -9,6 +9,14 @@ metadata:
     {{- include "babylon-selfpacedlab-manager.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/selfpacedlab-manager/helm/values.yaml
+++ b/selfpacedlab-manager/helm/values.yaml
@@ -37,6 +37,6 @@ poolboy:
   domain: poolboy.gpte.redhat.com
 
 image:
-  repository: quay.io/redhat-gpte/babylon-selfpacedlab-manager
+  repository: quay.io/rhpds/babylon-selfpacedlab-manager
   pullPolicy: Always
   tagOverride: ""

--- a/selfpacedlab-manager/operator/labuserinterface.py
+++ b/selfpacedlab-manager/operator/labuserinterface.py
@@ -1,0 +1,10 @@
+class LabUserInterface:
+    def __init__(self, definition=None, url=None):
+        if definition:
+            self.url = definition.get('url')
+        else:
+            self.url = url
+
+    def serialize(self):
+        ret = dict(url=self.url)
+        return ret

--- a/selfpacedlab-manager/operator/operator.py
+++ b/selfpacedlab-manager/operator/operator.py
@@ -11,6 +11,7 @@ from babylon import Babylon
 from resourceclaim import ResourceClaim
 from selfpacedlab import SelfPacedLab
 from selfpacedlabitem import SelfPacedLabItem
+from selfpacedlabuserassignment import SelfPacedLabUserAssignment
 from configure_kopf_logging import configure_kopf_logging
 from infinite_relative_backoff import InfiniteRelativeBackoff
 
@@ -29,6 +30,7 @@ async def on_startup(settings: kopf.OperatorSettings, logger, **_):
     await Babylon.on_startup()
     await SelfPacedLab.preload()
     await SelfPacedLabItem.preload()
+    await SelfPacedLabUserAssignment.preload()
 
 
 @kopf.on.cleanup()
@@ -151,3 +153,30 @@ async def selfpacedlab_item_daemon(logger, stopped, **kwargs):
             await asyncio.sleep(item.start_delay)
     except asyncio.CancelledError:
         pass
+
+
+@kopf.on.create(
+    SelfPacedLabUserAssignment.api_group, SelfPacedLabUserAssignment.api_version, SelfPacedLabUserAssignment.plural,
+    labels={Babylon.babylon_ignore_label: kopf.ABSENT},
+)
+async def selfpacedlab_user_assignment_create(logger, **kwargs):
+    assignment = SelfPacedLabUserAssignment.load(**kwargs)
+    await assignment.handle_create(logger=logger)
+
+
+@kopf.on.delete(
+    SelfPacedLabUserAssignment.api_group, SelfPacedLabUserAssignment.api_version, SelfPacedLabUserAssignment.plural,
+    labels={Babylon.babylon_ignore_label: kopf.ABSENT},
+)
+async def selfpacedlab_user_assignment_delete(logger, **kwargs):
+    assignment = SelfPacedLabUserAssignment.load(**kwargs)
+    await assignment.handle_delete(logger=logger)
+
+
+@kopf.on.update(
+    SelfPacedLabUserAssignment.api_group, SelfPacedLabUserAssignment.api_version, SelfPacedLabUserAssignment.plural,
+    labels={Babylon.babylon_ignore_label: kopf.ABSENT},
+)
+async def selfpacedlab_user_assignment_update(logger, **kwargs):
+    assignment = SelfPacedLabUserAssignment.load(**kwargs)
+    await assignment.handle_update(logger=logger)

--- a/selfpacedlab-manager/operator/resourceclaim.py
+++ b/selfpacedlab-manager/operator/resourceclaim.py
@@ -4,8 +4,11 @@ from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
 from babylon import Babylon
 from k8sobject import K8sObject
+from labuserinterface import LabUserInterface
+from userassignment import UserAssignment
 
 import selfpacedlab as selfpacedlab_import
+import selfpacedlabuserassignment
 
 
 class ResourceClaim(K8sObject):
@@ -13,6 +16,8 @@ class ResourceClaim(K8sObject):
     api_version = Babylon.poolboy_api_version
     kind = 'ResourceClaim'
     plural = 'resourceclaims'
+
+    lab_ui_url_keys = ('bookbag_url', 'lab_ui_url', 'labUserInterfaceUrl', 'showroom_primary_view_url')
 
     @classmethod
     async def handle_event(cls, event, logger):
@@ -34,6 +39,7 @@ class ResourceClaim(K8sObject):
         if event.get('type') == 'DELETED' or resource_claim.deletion_timestamp is not None:
             if lab is not None:
                 await lab.remove_resource_claim_from_status(resource_claim, logger=logger)
+            await resource_claim.delete_selfpacedlab_user_assignments(logger=logger)
             return
 
         if lab is None:
@@ -43,6 +49,11 @@ class ResourceClaim(K8sObject):
             return
 
         await lab.add_resource_claim_to_status(resource_claim, logger=logger)
+
+        if resource_claim.provision_complete and not resource_claim.is_failed:
+            await resource_claim.manage_selfpacedlab_user_assignments(
+                logger=logger, lab=lab,
+            )
 
     @property
     def deletion_timestamp(self):
@@ -89,7 +100,87 @@ class ResourceClaim(K8sObject):
     def selfpacedlab_name(self):
         return self.labels.get(Babylon.selfpacedlab_label)
 
+    def as_user_assignment(self):
+        annotations = self.definition['metadata'].get('annotations', {})
+        lab_user_interface = None
+        provision_data = {}
+        provision_messages = []
+
+        for resource in self.definition.get('status', {}).get('resources', []):
+            name = resource.get('name')
+            state = resource.get('state')
+            if not state or not state['kind'] == 'AnarchySubject':
+                continue
+            state_vars = state['spec']['vars']
+            if 'provision_data' in state_vars:
+                provision_data[name] = {}
+                provision_data[name].update({
+                    k: v for k, v in state_vars['provision_data'].items() if k not in self.lab_ui_url_keys
+                })
+                for lab_ui_url_key in self.lab_ui_url_keys:
+                    if lab_ui_url_key in state_vars['provision_data']:
+                        lab_user_interface = LabUserInterface(
+                            url=state_vars['provision_data'][lab_ui_url_key]
+                        )
+                        break
+            if 'provision_messages' in state_vars:
+                provision_messages.extend(state_vars['provision_messages'])
+
+        if Babylon.lab_ui_url_annotation in annotations:
+            lab_user_interface = LabUserInterface(
+                url=annotations[Babylon.lab_ui_url_annotation]
+            )
+
+        return UserAssignment(
+            data=provision_data,
+            lab_user_interface=lab_user_interface,
+            messages="\n".join(provision_messages) if provision_messages else None,
+            resource_claim_name=self.name,
+        )
+
+    async def delete_selfpacedlab_user_assignments(self, logger):
+        await selfpacedlabuserassignment.SelfPacedLabUserAssignment.delete_for_resource_claim(
+            logger=logger,
+            namespace=self.namespace,
+            resource_claim_name=self.name,
+        )
+
     async def get_selfpacedlab(self):
         return await selfpacedlab_import.SelfPacedLab.get(
             name=self.selfpacedlab_name, namespace=self.namespace
         )
+
+    async def manage_selfpacedlab_user_assignments(self, logger, lab):
+        user_assignment = self.as_user_assignment()
+
+        existing = await selfpacedlabuserassignment.SelfPacedLabUserAssignment.find(
+            namespace=self.namespace,
+            resource_claim_name=self.name,
+            selfpacedlab_name=lab.name,
+        )
+        lab_user_interface = (
+            user_assignment.lab_user_interface.serialize()
+            if user_assignment.lab_user_interface else None
+        )
+        if existing:
+            if (
+                existing.data != user_assignment.data or
+                existing.spec.get('labUserInterface') != lab_user_interface or
+                existing.messages != user_assignment.messages
+            ):
+                await existing.merge_patch({
+                    "data": user_assignment.data,
+                    "labUserInterface": lab_user_interface,
+                    "messages": user_assignment.messages,
+                })
+        else:
+            new_assignment = await selfpacedlabuserassignment.SelfPacedLabUserAssignment.create(
+                data=user_assignment.data,
+                lab_user_interface=user_assignment.lab_user_interface,
+                messages=user_assignment.messages,
+                namespace=self.namespace,
+                resource_claim=self,
+                selfpacedlab_name=lab.name,
+                selfpacedlab_id=lab.selfpacedlab_id or '',
+            )
+            logger.info(f"Created {new_assignment} for {lab} {self}")

--- a/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
+++ b/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
@@ -1,0 +1,215 @@
+import kopf
+from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
+
+from babylon import Babylon
+from cachedkopfobject import CachedKopfObject
+from labuserinterface import LabUserInterface
+
+import selfpacedlab as selfpacedlab_import
+
+
+class SelfPacedLabUserAssignment(CachedKopfObject):
+    api_group = Babylon.babylon_domain
+    api_version = Babylon.babylon_api_version
+    kind = 'SelfPacedLabUserAssignment'
+    plural = 'selfpacedlabuserassignments'
+
+    cache = {}
+
+    @classmethod
+    def cache_key_from_kwargs(cls, namespace, spec, **kwargs):
+        return (
+            namespace,
+            spec['selfPacedLabName'],
+            spec.get('resourceClaimName'),
+            spec.get('userName'),
+        )
+
+    @classmethod
+    async def delete_for_resource_claim(cls, namespace, resource_claim_name, logger):
+        async for selfpacedlab_user_assignment in cls.list(
+            label_selector=f"{Babylon.resource_claim_label}={resource_claim_name}",
+            namespace=namespace,
+        ):
+            await selfpacedlab_user_assignment.delete()
+
+    @classmethod
+    async def find(
+        cls, namespace, selfpacedlab_name, resource_claim_name=None, user_name=None
+    ):
+        cache_key = (namespace, selfpacedlab_name, resource_claim_name, user_name)
+        obj = cls.cache.get(cache_key)
+        if obj:
+            return obj
+
+        label_selector = f"{Babylon.selfpacedlab_label}={selfpacedlab_name}"
+        if resource_claim_name:
+            label_selector += f",{Babylon.resource_claim_label}={resource_claim_name}"
+        else:
+            label_selector += f",!{Babylon.resource_claim_label}"
+        if user_name:
+            label_selector += f",{Babylon.user_name_label}={user_name}"
+        else:
+            label_selector += f",!{Babylon.user_name_label}"
+        obj_list = await Babylon.custom_objects_api.list_namespaced_custom_object(
+            group=cls.api_group,
+            namespace=namespace,
+            plural=cls.plural,
+            version=cls.api_version,
+            label_selector=label_selector,
+        )
+        items = obj_list.get('items', [])
+        if not items:
+            return None
+
+        obj = cls.from_definition(items[0])
+        cls.cache[cache_key] = obj
+        return obj
+
+    @classmethod
+    async def create(
+        cls,
+        namespace,
+        resource_claim,
+        selfpacedlab_name,
+        selfpacedlab_id,
+        assignment=None,
+        data={},
+        lab_user_interface=None,
+        messages=None,
+        user_name=None,
+    ):
+        definition = {
+            "apiVersion": f"{cls.api_group}/{cls.api_version}",
+            "kind": cls.kind,
+            "metadata": {
+                "generateName": f"{selfpacedlab_name}-",
+                "labels": {
+                    Babylon.selfpacedlab_id_label: selfpacedlab_id,
+                    Babylon.selfpacedlab_label: selfpacedlab_name,
+                    Babylon.resource_claim_label: resource_claim.name,
+                },
+                "ownerReferences": [resource_claim.as_owner_ref()],
+            },
+            "spec": {
+                "data": data,
+                "resourceClaimName": resource_claim.name,
+                "selfPacedLabName": selfpacedlab_name,
+            },
+        }
+        if assignment:
+            definition['spec']['assignment'] = assignment
+        if lab_user_interface:
+            definition['spec']['labUserInterface'] = lab_user_interface.serialize()
+        if messages:
+            definition['spec']['messages'] = messages
+        if user_name:
+            definition['metadata']['labels'][Babylon.user_name_label] = user_name
+            definition['spec']['userName'] = user_name
+
+        definition = await Babylon.custom_objects_api.create_namespaced_custom_object(
+            group=cls.api_group,
+            namespace=namespace,
+            plural=cls.plural,
+            version=cls.api_version,
+            body=definition,
+        )
+        obj = cls.from_definition(definition)
+        cls.cache[obj.cache_key] = obj
+        return obj
+
+    @property
+    def assignment(self):
+        return self.spec.get('assignment')
+
+    @property
+    def cache_key(self):
+        return (
+            self.namespace,
+            self.selfpacedlab_name,
+            self.resource_claim_name,
+            self.user_name,
+        )
+
+    @property
+    def data(self):
+        return self.spec.get('data', {})
+
+    @property
+    def ignore(self):
+        return Babylon.babylon_ignore_label in self.labels
+
+    @property
+    def lab_user_interface(self):
+        if 'labUserInterface' in self.spec:
+            return LabUserInterface(definition=self.spec['labUserInterface'])
+
+    @property
+    def messages(self):
+        return self.spec.get('messages')
+
+    @property
+    def resource_claim_name(self):
+        return self.spec.get('resourceClaimName')
+
+    @property
+    def user_name(self):
+        return self.spec.get('userName')
+
+    @property
+    def selfpacedlab_name(self):
+        return self.spec.get('selfPacedLabName')
+
+    async def copy_to_selfpacedlab(self):
+        try:
+            selfpacedlab = await self.get_selfpacedlab()
+        except k8sApiException as exception:
+            if exception.status == 404:
+                raise kopf.TemporaryError(
+                    f"SelfPacedLab {self.selfpacedlab_name} was not found.", delay=60
+                )
+            raise
+
+        async with selfpacedlab.lock:
+            await selfpacedlab.merge_patch_status(
+                {
+                    "userAssignments": {
+                        self.name: {
+                            "assignment": self.assignment,
+                            "resourceClaimName": self.resource_claim_name,
+                            "userName": self.user_name,
+                        }
+                    }
+                }
+            )
+
+    async def get_selfpacedlab(self):
+        return await selfpacedlab_import.SelfPacedLab.get(
+            name=self.selfpacedlab_name, namespace=self.namespace
+        )
+
+    async def handle_create(self, logger):
+        async with self.lock:
+            logger.info(f"Handling create for {self}")
+            await self.copy_to_selfpacedlab()
+
+    async def handle_delete(self, logger):
+        async with self.lock:
+            logger.info(f"Handling delete for {self}")
+            await self.remove_from_selfpacedlab()
+
+    async def handle_update(self, logger):
+        async with self.lock:
+            logger.info(f"Handling update for {self}")
+            await self.copy_to_selfpacedlab()
+
+    async def remove_from_selfpacedlab(self):
+        try:
+            selfpacedlab = await self.get_selfpacedlab()
+            async with selfpacedlab.lock:
+                await selfpacedlab.merge_patch_status(
+                    {"userAssignments": {self.name: None}}
+                )
+        except k8sApiException as exception:
+            if exception.status != 404:
+                raise

--- a/selfpacedlab-manager/operator/userassignment.py
+++ b/selfpacedlab-manager/operator/userassignment.py
@@ -1,0 +1,42 @@
+from labuserinterface import LabUserInterface
+
+class UserAssignment:
+    def __init__(self,
+        data = None,
+        definition = None,
+        lab_user_interface = None,
+        messages = None,
+        resource_claim_name = None,
+        user_name = None,
+    ):
+        if definition:
+            self.assignment = definition.get('assignment')
+            self.data = definition.get('data')
+            self.messages = definition.get('messages')
+            self.resource_claim_name = definition.get('resourceClaimName')
+            self.user_name = definition.get('userName')
+            if 'labUserInterface' in definition:
+                self.lab_user_interface = LabUserInterface(definition=definition['labUserInterface'])
+            else:
+                self.lab_user_interface = None
+        else:
+            self.assignment = None
+            self.data = data
+            self.lab_user_interface = lab_user_interface
+            self.messages = messages
+            self.resource_claim_name = resource_claim_name
+            self.user_name = user_name
+
+    def serialize(self):
+        ret = {}
+        if self.data:
+            ret['data'] = self.data
+        if self.lab_user_interface:
+            ret['labUserInterface'] = self.lab_user_interface.serialize()
+        if self.messages:
+            ret['messages'] = self.messages
+        if self.resource_claim_name:
+            ret['resourceClaimName'] = self.resource_claim_name
+        if self.user_name:
+            ret['userName'] = self.user_name
+        return ret


### PR DESCRIPTION
- Add editable SelfPacedLab detail page with inline editing for display name, description, access password, registration mode, dates, and admin settings (white-glove, ops effort, locked, resource pool, Salesforce IDs)
- Add Provisioning tab with pool size, concurrency, start delay, and lifespan fields
- Add public access page at /selfpacedlab/:id for user login/assignment
- Add backend API routes (GET/PUT) for public selfpacedlab access
- Add OAuth proxy skip-auth-regex for selfpacedlab public routes
- Add SelfPacedLabStatus reusable component for pool status display
- Add locked behavior: disable auto-destroy/start editing and delete action
- Hide auto-stop input when self-paced lab is enabled in catalog form
- Fix displayName() to handle SelfPacedLab kind
- Fix admin list links to point to detail page with display name
- Highlight Services nav item on selfpacedlab detail pages