### PR TITLE
Add RHDP Support - Feedback/Feature Request button

### DIFF
--- a/catalog/status/interfaces/rhpds.json
+++ b/catalog/status/interfaces/rhpds.json
@@ -5,5 +5,6 @@
     "help_text": "Open Support Case",
     "help_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69",
     "internal_help_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69",
-    "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
+    "feedback_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69/group/75/create/165",
+    "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html"
 }

--- a/catalog/ui/src/app/Header/Header.tsx
+++ b/catalog/ui/src/app/Header/Header.tsx
@@ -119,7 +119,7 @@ const Header: React.FC<{
   if (feedback_link) {
     userHelpDropdownItems.push(
       <DropdownItem key="feedback" value={feedback_link}>
-        Provide Feedback
+        RHDP Support - Feedback/Feature Request
       </DropdownItem>,
     );
   }

--- a/catalog/ui/src/app/Header/PublicHeader.tsx
+++ b/catalog/ui/src/app/Header/PublicHeader.tsx
@@ -58,7 +58,7 @@ const PublicHeader: React.FC = () => {
     ...(feedback_link
       ? [
           <DropdownItem key="feedback" value={feedback_link}>
-            Provide Feedback
+            RHDP Support - Feedback/Feature Request
           </DropdownItem>,
         ]
       : []),

--- a/catalog/ui/src/public/interfaces/rhpds.json
+++ b/catalog/ui/src/public/interfaces/rhpds.json
@@ -5,6 +5,7 @@
   "help_text": "RHDP Support",
   "help_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69",
   "internal_help_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69",
+  "feedback_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69/group/75/create/165",
   "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": true,
   "partner_connect_header_enabled": false,


### PR DESCRIPTION
## Summary
- Adds the **RHDP Support - Feedback/Feature Request** button back to the Help menu in the RHPDS interface
- Links to the RHDP Support Jira Service Desk at https://redhat.atlassian.net/servicedesk/customer/portal/69/group/75/create/165
- Fixes a trailing comma syntax error in `catalog/status/interfaces/rhpds.json`

## Changes
- Added `feedback_link` configuration to both RHPDS interface config files
- Updated button text in `Header.tsx` and `PublicHeader.tsx` from "Provide Feedback" to "RHDP Support - Feedback/Feature Request"

## Test plan
- [ ] Verify the button appears in the Help dropdown menu for RHPDS interface users
- [ ] Confirm clicking the button opens the correct Jira Service Desk link in a new tab
- [ ] Verify no console errors or JSON parsing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)