### PR TITLE
fix: RBAC, self-paced lab assignments, and workshop provision label

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1410,7 +1410,7 @@ async def update_system_status(request):
         logging.error(f"Unexpected error updating system status: {e}")
         raise web.HTTPInternalServerError(reason="Failed to update system status")
 
-@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments|selfpacedlabs|selfpacedlabitems|selfpacedlabuserassignments}")
+@routes.get("/apis/{api_group:babylon\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:workshops|workshopprovisions|workshopuserassignments|selfpacedlabs|selfpacedlabprovisionitems|selfpacedlabuserassignments}")
 @routes.get("/apis/{api_group:poolboy\\.gpte\\.redhat\\.com}/v1/namespaces/{namespace}/{plural:resourceclaims}")
 async def openshift_api_list_by_get_rbac(request):
     """List items with special handling so that users can list items in a

--- a/catalog/helm/templates/api/clusterrole.yaml
+++ b/catalog/helm/templates/api/clusterrole.yaml
@@ -37,7 +37,7 @@ rules:
   - babylon.gpte.redhat.com
   resources:
   - selfpacedlabs
-  - selfpacedlabitems
+  - selfpacedlabprovisionitems
   verbs:
   - get
   - list

--- a/catalog/helm/templates/api/clusterrole.yaml
+++ b/catalog/helm/templates/api/clusterrole.yaml
@@ -36,6 +36,30 @@ rules:
 - apiGroups:
   - babylon.gpte.redhat.com
   resources:
+  - selfpacedlabs
+  - selfpacedlabitems
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
+  - selfpacedlabuserassignments
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
+  - workshopprovisions
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
   - workshops
   - multiworkshops
   verbs:

--- a/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
@@ -33,7 +33,7 @@ import {
   createServiceRequest,
   CreateServiceRequestParameterValues,
   createSelfPacedLab,
-  createSelfPacedLabItem,
+  createSelfPacedLabProvisionItem,
   createWorkshop,
   createWorkshopProvision,
   fetcher,
@@ -357,7 +357,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
           whiteGloved: formState.whiteGloved,
           salesforceItems: formState.salesforceItems,
         });
-        await createSelfPacedLabItem({
+        await createSelfPacedLabProvisionItem({
           catalogItem: catalogItem,
           poolSize: formState.selfPacedLab.poolSize,
           assignedLifespan: formState.selfPacedLab.assignedLifespan,

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -43,10 +43,10 @@ import {
   fetcherItemsInAllPages,
   patchResourceClaim,
   patchSelfPacedLab,
-  patchSelfPacedLabItem,
+  patchSelfPacedLabProvisionItem,
   SERVICES_KEY,
 } from '@app/api';
-import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabItem as SelfPacedLabItemType, SelfPacedLabUserAssignmentList } from '@app/types';
+import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabProvisionItem as SelfPacedLabProvisionItemType, SelfPacedLabUserAssignmentList } from '@app/types';
 import {
   BABYLON_DOMAIN,
   DEMO_DOMAIN,
@@ -128,16 +128,16 @@ const SelfPacedLabItemComponent: React.FC<{
     fetcher,
   );
 
-  const { data: selfPacedLabItems, mutate: mutateSelfPacedLabItems } = useSWR<SelfPacedLabItemType[]>(
+  const { data: selfPacedLabProvisionItems, mutate: mutateSelfPacedLabProvisionItems } = useSWR<SelfPacedLabProvisionItemType[]>(
     selfPacedLab
-      ? apiPaths.SELF_PACED_LAB_ITEMS({
+      ? apiPaths.SELF_PACED_LAB_PROVISION_ITEMS({
           namespace: serviceNamespaceName,
           selfPacedLabName: selfPacedLab.metadata.name,
         })
       : null,
     () =>
       fetcherItemsInAllPages((continueId) =>
-        apiPaths.SELF_PACED_LAB_ITEMS({
+        apiPaths.SELF_PACED_LAB_PROVISION_ITEMS({
           namespace: serviceNamespaceName,
           selfPacedLabName: selfPacedLab.metadata.name,
           limit: FETCH_BATCH_LIMIT,
@@ -357,11 +357,11 @@ const SelfPacedLabItemComponent: React.FC<{
           currentDate={scheduleAction === 'scheduleDelete' ? autoDestroyTime : autoStartTime}
         />
       </Modal>
-      {selfPacedLabItems && selfPacedLabItems.length > 0 && (
+      {selfPacedLabProvisionItems && selfPacedLabProvisionItems.length > 0 && (
         <SalesforceItemsEditModal
           isOpen={modalEditSalesforce}
           onClose={() => setModalEditSalesforce(false)}
-          items={JSON.parse(selfPacedLabItems[0].spec.parameters?.['salesforce_items'] || '[]')}
+          items={JSON.parse(selfPacedLabProvisionItems[0].spec.parameters?.['salesforce_items'] || '[]')}
           onSave={async (next) => {
             await patchSelfPacedLab({
               name: selfPacedLab.metadata.name,
@@ -375,8 +375,8 @@ const SelfPacedLabItemComponent: React.FC<{
                 },
               },
             });
-            for (const item of selfPacedLabItems) {
-              await patchSelfPacedLabItem({
+            for (const item of selfPacedLabProvisionItems) {
+              await patchSelfPacedLabProvisionItem({
                 name: item.metadata.name,
                 namespace: item.metadata.namespace,
                 patch: {
@@ -612,12 +612,12 @@ const SelfPacedLabItemComponent: React.FC<{
                   </DescriptionListDescription>
                 </DescriptionListGroup>
 
-                {selfPacedLabItems && selfPacedLabItems.length > 0 && sfdc_enabled ? (
+                {selfPacedLabProvisionItems && selfPacedLabProvisionItems.length > 0 && sfdc_enabled ? (
                   <DescriptionListGroup>
                     <DescriptionListTerm>Salesforce IDs</DescriptionListTerm>
                     <DescriptionListDescription>
                       <SalesforceItemsList
-                        items={JSON.parse(selfPacedLabItems[0].spec.parameters?.['salesforce_items'] || '[]')}
+                        items={JSON.parse(selfPacedLabProvisionItems[0].spec.parameters?.['salesforce_items'] || '[]')}
                       />
                       <Button
                         variant="link"
@@ -719,8 +719,8 @@ const SelfPacedLabItemComponent: React.FC<{
           </Tab>
           <Tab eventKey="provision" title={<TabTitleText>Provisioning</TabTitleText>}>
             {activeTab === 'provision' ? (
-              selfPacedLabItems && selfPacedLabItems.length > 0 ? (
-                selfPacedLabItems.map((item) => (
+              selfPacedLabProvisionItems && selfPacedLabProvisionItems.length > 0 ? (
+                selfPacedLabProvisionItems.map((item) => (
                   <DescriptionList isHorizontal key={item.metadata.uid}>
                     <DescriptionListGroup>
                       <DescriptionListTerm>Name</DescriptionListTerm>
@@ -762,11 +762,11 @@ const SelfPacedLabItemComponent: React.FC<{
                           max={200}
                           adminModifier={true}
                           onChange={(value: number) =>
-                            patchSelfPacedLabItem({
+                            patchSelfPacedLabProvisionItem({
                               name: item.metadata.name,
                               namespace: item.metadata.namespace,
                               patch: { spec: { poolSize: value } },
-                            }).then(() => mutateSelfPacedLabItems())
+                            }).then(() => mutateSelfPacedLabProvisionItems())
                           }
                           value={item.spec.poolSize}
                           style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
@@ -788,11 +788,11 @@ const SelfPacedLabItemComponent: React.FC<{
                               min={1}
                               max={30}
                               onChange={(value: number) =>
-                                patchSelfPacedLabItem({
+                                patchSelfPacedLabProvisionItem({
                                   name: item.metadata.name,
                                   namespace: item.metadata.namespace,
                                   patch: { spec: { concurrency: value } },
-                                }).then(() => mutateSelfPacedLabItems())
+                                }).then(() => mutateSelfPacedLabProvisionItems())
                               }
                               value={item.spec.concurrency}
                               style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
@@ -807,11 +807,11 @@ const SelfPacedLabItemComponent: React.FC<{
                               min={10}
                               max={999}
                               onChange={(value: number) =>
-                                patchSelfPacedLabItem({
+                                patchSelfPacedLabProvisionItem({
                                   name: item.metadata.name,
                                   namespace: item.metadata.namespace,
                                   patch: { spec: { startDelay: value } },
-                                }).then(() => mutateSelfPacedLabItems())
+                                }).then(() => mutateSelfPacedLabProvisionItems())
                               }
                               value={item.spec.startDelay}
                               style={{ paddingRight: 'var(--pf-t--global--spacer--md)' }}
@@ -835,11 +835,11 @@ const SelfPacedLabItemComponent: React.FC<{
                         <EditableText
                           aria-label="Edit Assigned Lifespan"
                           onChange={(val: string) =>
-                            patchSelfPacedLabItem({
+                            patchSelfPacedLabProvisionItem({
                               name: item.metadata.name,
                               namespace: item.metadata.namespace,
                               patch: { spec: { assignedLifespan: val } },
-                            }).then(() => mutateSelfPacedLabItems())
+                            }).then(() => mutateSelfPacedLabProvisionItems())
                           }
                           placeholder="e.g. 4h"
                           value={item.spec.assignedLifespan}
@@ -860,11 +860,11 @@ const SelfPacedLabItemComponent: React.FC<{
                         <EditableText
                           aria-label="Edit Unassigned Lifespan"
                           onChange={(val: string) =>
-                            patchSelfPacedLabItem({
+                            patchSelfPacedLabProvisionItem({
                               name: item.metadata.name,
                               namespace: item.metadata.namespace,
                               patch: { spec: { unassignedLifespan: val } },
-                            }).then(() => mutateSelfPacedLabItems())
+                            }).then(() => mutateSelfPacedLabProvisionItems())
                           }
                           placeholder="e.g. 24h"
                           value={item.spec.unassignedLifespan}
@@ -873,10 +873,10 @@ const SelfPacedLabItemComponent: React.FC<{
                     </DescriptionListGroup>
                   </DescriptionList>
                 ))
-              ) : selfPacedLabItems ? (
-                <EmptyState headingLevel="h4" titleText="No SelfPacedLabItems found" variant="sm">
+              ) : selfPacedLabProvisionItems ? (
+                <EmptyState headingLevel="h4" titleText="No SelfPacedLabProvisionItems found" variant="sm">
                   <EmptyStateBody>
-                    This indicates an error has occurred. A SelfPacedLabItem should have been created when this lab was created.
+                    This indicates an error has occurred. A SelfPacedLabProvisionItem should have been created when this lab was created.
                   </EmptyStateBody>
                 </EmptyState>
               ) : (

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -46,7 +46,7 @@ import {
   patchSelfPacedLabItem,
   SERVICES_KEY,
 } from '@app/api';
-import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabItem as SelfPacedLabItemType } from '@app/types';
+import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabItem as SelfPacedLabItemType, SelfPacedLabUserAssignmentList } from '@app/types';
 import {
   BABYLON_DOMAIN,
   DEMO_DOMAIN,
@@ -170,6 +170,19 @@ const SelfPacedLabItemComponent: React.FC<{
     {
       refreshInterval: 8000,
       compare: compareK8sObjectsArr,
+    },
+  );
+
+  const { data: userAssignmentsList } = useSWR<SelfPacedLabUserAssignmentList>(
+    selfPacedLab
+      ? apiPaths.SELF_PACED_LAB_USER_ASSIGNMENTS({
+          namespace: serviceNamespaceName,
+          selfPacedLabName: selfPacedLab.metadata.name,
+        })
+      : null,
+    fetcher,
+    {
+      refreshInterval: 8000,
     },
   );
 
@@ -882,7 +895,7 @@ const SelfPacedLabItemComponent: React.FC<{
                   }
                   onSelectAll={() => {}}
                   rows={resourceClaims.map((rc) => {
-                    const assignment = rc.metadata.labels?.[`${BABYLON_DOMAIN}/selfpacedlab-assignment`];
+                    const userAssignments = userAssignmentsList?.items || [];
                     return {
                       cells: [
                         <>
@@ -892,7 +905,13 @@ const SelfPacedLabItemComponent: React.FC<{
                           {isAdmin ? <OpenshiftConsoleLink key="console" resource={rc} /> : null}
                         </>,
                         <ServiceStatus key="status" resourceClaim={rc} />,
-                        assignment || '-',
+                        <>
+                          {userAssignments.some((uA) => uA.spec.resourceClaimName === rc.metadata.name)
+                            ? userAssignments
+                                .filter((uA) => uA.spec.resourceClaimName === rc.metadata.name)
+                                .map((uA) => <p key={`user-${uA.spec.assignment?.email || 'unassigned'}`}>{uA.spec.assignment?.email || '-'}</p>)
+                            : '-'}
+                        </>,
                         <>
                           <LocalTimestamp key="ts" timestamp={rc.metadata.creationTimestamp} /> (
                           <TimeInterval key="iv" toTimestamp={rc.metadata.creationTimestamp} />)

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -965,6 +965,7 @@ export async function createWorkshopProvision({
       labels: {
         [`${BABYLON_DOMAIN}/catalogItemName`]: catalogItem.metadata.name,
         [`${BABYLON_DOMAIN}/catalogItemNamespace`]: catalogItem.metadata.namespace,
+        [`${BABYLON_DOMAIN}/workshop`]: workshop.metadata.name,
         ...(catalogItem.metadata.labels?.['gpte.redhat.com/asset-uuid']
           ? { 'gpte.redhat.com/asset-uuid': catalogItem.metadata.labels['gpte.redhat.com/asset-uuid'] }
           : {}),

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -18,7 +18,7 @@ import {
   ServiceAccessConfig,
   ServiceNamespace,
   SelfPacedLab,
-  SelfPacedLabItem,
+  SelfPacedLabProvisionItem,
   Workshop,
   WorkshopProvision,
   MultiWorkshop,
@@ -1284,7 +1284,7 @@ export async function createSelfPacedLab({
   throw new Error('Failed to create self-paced lab after maximum retries');
 }
 
-export async function createSelfPacedLabItem({
+export async function createSelfPacedLabProvisionItem({
   catalogItem,
   poolSize,
   assignedLifespan,
@@ -1303,9 +1303,9 @@ export async function createSelfPacedLabItem({
   parameters: Record<string, unknown>;
   selfPacedLab: SelfPacedLab;
 }) {
-  const definition: SelfPacedLabItem = {
+  const definition: SelfPacedLabProvisionItem = {
     apiVersion: `${BABYLON_DOMAIN}/v1`,
-    kind: 'SelfPacedLabItem',
+    kind: 'SelfPacedLabProvisionItem',
     metadata: {
       name: selfPacedLab.metadata.name,
       namespace: selfPacedLab.metadata.namespace,
@@ -1372,7 +1372,7 @@ export async function patchSelfPacedLab({
   });
 }
 
-export async function patchSelfPacedLabItem({
+export async function patchSelfPacedLabProvisionItem({
   name,
   namespace,
   jsonPatch,
@@ -1382,13 +1382,13 @@ export async function patchSelfPacedLabItem({
   namespace: string;
   jsonPatch?: JSONPatch;
   patch?: Record<string, unknown>;
-}): Promise<SelfPacedLabItem> {
+}): Promise<SelfPacedLabProvisionItem> {
   return await patchK8sObject({
     apiVersion: `${BABYLON_DOMAIN}/v1`,
     jsonPatch,
     name,
     namespace,
-    plural: 'selfpacedlabitems',
+    plural: 'selfpacedlabprovisionitems',
     patch,
   });
 }
@@ -2610,7 +2610,7 @@ export const apiPaths = {
     `/apis/${BABYLON_DOMAIN}/v1${namespace ? `/namespaces/${namespace}` : ''}/selfpacedlabs?${
       limit ? `limit=${limit}` : ''
     }${continueId ? `&continue=${continueId}` : ''}`,
-  SELF_PACED_LAB_ITEMS: ({
+  SELF_PACED_LAB_PROVISION_ITEMS: ({
     namespace,
     selfPacedLabName,
     limit,
@@ -2621,7 +2621,7 @@ export const apiPaths = {
     limit?: number | string;
     continueId?: string;
   }) =>
-    `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabitems?labelSelector=${encodeURIComponent(`${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLabName}`)}${
+    `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/selfpacedlabprovisionitems?labelSelector=${encodeURIComponent(`${BABYLON_DOMAIN}/selfpacedlab=${selfPacedLabName}`)}${
       limit ? `&limit=${limit}` : ''
     }${continueId ? `&continue=${continueId}` : ''}`,
   SELF_PACED_LAB_USER_ASSIGNMENTS: ({ namespace, selfPacedLabName }: { namespace: string; selfPacedLabName: string }) =>

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -656,8 +656,8 @@ export interface SelfPacedLabSpec {
   openRegistration?: boolean;
 }
 
-export interface SelfPacedLabItem extends K8sObject {
-  spec: SelfPacedLabItemSpec;
+export interface SelfPacedLabProvisionItem extends K8sObject {
+  spec: SelfPacedLabProvisionItemSpec;
   status?: {
     readyCount?: number;
     provisioningCount?: number;
@@ -666,7 +666,7 @@ export interface SelfPacedLabItem extends K8sObject {
   };
 }
 
-export interface SelfPacedLabItemSpec {
+export interface SelfPacedLabProvisionItemSpec {
   assignedLifespan: string;
   catalogItem: {
     name: string;

--- a/helm/crds/selfpacedlabprovisionitems.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/selfpacedlabprovisionitems.babylon.gpte.redhat.com.yaml
@@ -1,16 +1,16 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: selfpacedlabitems.babylon.gpte.redhat.com
+  name: selfpacedlabprovisionitems.babylon.gpte.redhat.com
 spec:
   conversion:
     strategy: None
   group: babylon.gpte.redhat.com
   names:
-    kind: SelfPacedLabItem
-    listKind: SelfPacedLabItemList
-    plural: selfpacedlabitems
-    singular: selfpacedlabitem
+    kind: SelfPacedLabProvisionItem
+    listKind: SelfPacedLabProvisionItemList
+    plural: selfpacedlabprovisionitems
+    singular: selfpacedlabprovisionitem
   scope: Namespaced
   versions:
   - name: v1
@@ -33,7 +33,7 @@ spec:
             type: object
           spec:
             description: >-
-              Specification of SelfPacedLabItem.
+              Specification of SelfPacedLabProvisionItem.
             type: object
             required:
             - assignedLifespan
@@ -96,7 +96,7 @@ spec:
                 type: string
                 pattern: ^[0-9]+[dhms]$
           status:
-            description: Status of SelfPacedLabItem
+            description: Status of SelfPacedLabProvisionItem
             type: object
             x-kubernetes-preserve-unknown-fields: true
             properties:

--- a/helm/crds/selfpacedlabs.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/selfpacedlabs.babylon.gpte.redhat.com.yaml
@@ -54,7 +54,7 @@ spec:
                 properties:
                   end:
                     description: >-
-                      End of lifespan for SelfPacedLab and any SelfPacedLabItems that belong to it.
+                      End of lifespan for SelfPacedLab and any SelfPacedLabProvisionItems that belong to it.
                       After this time the lab is no longer available and resources are cleaned up.
                     type: string
                     format: date-time
@@ -98,9 +98,9 @@ spec:
                   properties:
                     uid:
                       type: string
-              selfPacedLabItems:
+              selfPacedLabProvisionItems:
                 description: >-
-                  References to SelfPacedLabItems associated with this SelfPacedLab.
+                  References to SelfPacedLabProvisionItems associated with this SelfPacedLab.
                 type: object
                 additionalProperties:
                   type: object

--- a/helm/templates/catalog/interfaces/api/clusterrole.yaml
+++ b/helm/templates/catalog/interfaces/api/clusterrole.yaml
@@ -46,7 +46,7 @@ rules:
   - babylon.gpte.redhat.com
   resources:
   - selfpacedlabs
-  - selfpacedlabitems
+  - selfpacedlabprovisionitems
   verbs:
   - get
   - list

--- a/helm/templates/catalog/interfaces/api/clusterrole.yaml
+++ b/helm/templates/catalog/interfaces/api/clusterrole.yaml
@@ -45,6 +45,30 @@ rules:
 - apiGroups:
   - babylon.gpte.redhat.com
   resources:
+  - selfpacedlabs
+  - selfpacedlabitems
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
+  - selfpacedlabuserassignments
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
+  - workshopprovisions
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - babylon.gpte.redhat.com
+  resources:
   - workshops
   - workshopuserassignments
   - multiworkshops

--- a/helm/templates/selfpacedlabManager/clusterrole.yaml
+++ b/helm/templates/selfpacedlabManager/clusterrole.yaml
@@ -59,6 +59,8 @@ rules:
   - selfpacedlabs/status
   - selfpacedlabitems
   - selfpacedlabitems/status
+  - selfpacedlabuserassignments
+  - selfpacedlabuserassignments/status
   verbs:
   - create
   - delete

--- a/helm/templates/selfpacedlabManager/clusterrole.yaml
+++ b/helm/templates/selfpacedlabManager/clusterrole.yaml
@@ -57,8 +57,8 @@ rules:
   resources:
   - selfpacedlabs
   - selfpacedlabs/status
-  - selfpacedlabitems
-  - selfpacedlabitems/status
+  - selfpacedlabprovisionitems
+  - selfpacedlabprovisionitems/status
   - selfpacedlabuserassignments
   - selfpacedlabuserassignments/status
   verbs:

--- a/selfpacedlab-manager/helm/templates/rbac.yaml
+++ b/selfpacedlab-manager/helm/templates/rbac.yaml
@@ -61,8 +61,8 @@ rules:
   resources:
   - selfpacedlabs
   - selfpacedlabs/status
-  - selfpacedlabitems
-  - selfpacedlabitems/status
+  - selfpacedlabprovisionitems
+  - selfpacedlabprovisionitems/status
   verbs:
   - create
   - delete

--- a/selfpacedlab-manager/operator/babylon.py
+++ b/selfpacedlab-manager/operator/babylon.py
@@ -33,7 +33,7 @@ class Babylon():
     selfpacedlab_label = f"{babylon_domain}/selfpacedlab"
     selfpacedlab_id_label = f"{babylon_domain}/selfpacedlab-id"
     selfpacedlab_uid_label = f"{babylon_domain}/selfpacedlab-uid"
-    selfpacedlab_item_label = f"{babylon_domain}/selfpacedlab-item"
+    selfpacedlab_provision_item_label = f"{babylon_domain}/selfpacedlab-provision-item"
     selfpacedlab_assigned_label = f"{babylon_domain}/assigned"
     selfpacedlab_assigned_at_annotation = f"{babylon_domain}/assigned-at"
     service_access_annotation = f"{babylon_domain}/service-access"

--- a/selfpacedlab-manager/operator/operator.py
+++ b/selfpacedlab-manager/operator/operator.py
@@ -10,7 +10,7 @@ import kopf
 from babylon import Babylon
 from resourceclaim import ResourceClaim
 from selfpacedlab import SelfPacedLab
-from selfpacedlabitem import SelfPacedLabItem
+from selfpacedlabprovisionitem import SelfPacedLabProvisionItem
 from selfpacedlabuserassignment import SelfPacedLabUserAssignment
 from configure_kopf_logging import configure_kopf_logging
 from infinite_relative_backoff import InfiniteRelativeBackoff
@@ -29,7 +29,7 @@ async def on_startup(settings: kopf.OperatorSettings, logger, **_):
 
     await Babylon.on_startup()
     await SelfPacedLab.preload()
-    await SelfPacedLabItem.preload()
+    await SelfPacedLabProvisionItem.preload()
     await SelfPacedLabUserAssignment.preload()
 
 
@@ -105,48 +105,48 @@ async def selfpacedlab_daemon(logger, stopped, **kwargs):
 
 
 @kopf.on.create(
-    SelfPacedLabItem.api_group, SelfPacedLabItem.api_version, SelfPacedLabItem.plural,
+    SelfPacedLabProvisionItem.api_group, SelfPacedLabProvisionItem.api_version, SelfPacedLabProvisionItem.plural,
     labels={Babylon.babylon_ignore_label: kopf.ABSENT},
 )
-async def selfpacedlab_item_create(logger, **kwargs):
-    item = SelfPacedLabItem.load(**kwargs)
+async def selfpacedlab_provision_item_create(logger, **kwargs):
+    item = SelfPacedLabProvisionItem.load(**kwargs)
     await item.handle_create(logger=logger)
 
 
 @kopf.on.delete(
-    SelfPacedLabItem.api_group, SelfPacedLabItem.api_version, SelfPacedLabItem.plural,
+    SelfPacedLabProvisionItem.api_group, SelfPacedLabProvisionItem.api_version, SelfPacedLabProvisionItem.plural,
     labels={Babylon.babylon_ignore_label: kopf.ABSENT},
 )
-async def selfpacedlab_item_delete(logger, **kwargs):
-    item = SelfPacedLabItem.load(**kwargs)
+async def selfpacedlab_provision_item_delete(logger, **kwargs):
+    item = SelfPacedLabProvisionItem.load(**kwargs)
     await item.handle_delete(logger=logger)
 
 
 @kopf.on.resume(
-    SelfPacedLabItem.api_group, SelfPacedLabItem.api_version, SelfPacedLabItem.plural,
+    SelfPacedLabProvisionItem.api_group, SelfPacedLabProvisionItem.api_version, SelfPacedLabProvisionItem.plural,
     labels={Babylon.babylon_ignore_label: kopf.ABSENT},
 )
-async def selfpacedlab_item_resume(logger, **kwargs):
-    item = SelfPacedLabItem.load(**kwargs)
+async def selfpacedlab_provision_item_resume(logger, **kwargs):
+    item = SelfPacedLabProvisionItem.load(**kwargs)
     await item.handle_resume(logger=logger)
 
 
 @kopf.on.update(
-    SelfPacedLabItem.api_group, SelfPacedLabItem.api_version, SelfPacedLabItem.plural,
+    SelfPacedLabProvisionItem.api_group, SelfPacedLabProvisionItem.api_version, SelfPacedLabProvisionItem.plural,
     labels={Babylon.babylon_ignore_label: kopf.ABSENT},
 )
-async def selfpacedlab_item_update(logger, **kwargs):
-    item = SelfPacedLabItem.load(**kwargs)
+async def selfpacedlab_provision_item_update(logger, **kwargs):
+    item = SelfPacedLabProvisionItem.load(**kwargs)
     await item.handle_update(logger=logger)
 
 
 @kopf.daemon(
-    SelfPacedLabItem.api_group, SelfPacedLabItem.api_version, SelfPacedLabItem.plural,
+    SelfPacedLabProvisionItem.api_group, SelfPacedLabProvisionItem.api_version, SelfPacedLabProvisionItem.plural,
     cancellation_timeout=1,
     labels={Babylon.babylon_ignore_label: kopf.ABSENT},
 )
-async def selfpacedlab_item_daemon(logger, stopped, **kwargs):
-    item = SelfPacedLabItem.load(**kwargs)
+async def selfpacedlab_provision_item_daemon(logger, stopped, **kwargs):
+    item = SelfPacedLabProvisionItem.load(**kwargs)
     try:
         while not stopped:
             await item.manage(logger=logger)

--- a/selfpacedlab-manager/operator/selfpacedlab.py
+++ b/selfpacedlab-manager/operator/selfpacedlab.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
 import resourceclaim
-import selfpacedlabitem
+import selfpacedlabprovisionitem
 from babylon import Babylon
 from cachedkopfobject import CachedKopfObject
 
@@ -65,8 +65,8 @@ class SelfPacedLab(CachedKopfObject):
         return self.labels.get(Babylon.white_glove_label)
 
     @property
-    def selfpacedlab_item_names(self) -> list[str]:
-        return list(self.status.get('selfPacedLabItems', {}).keys())
+    def selfpacedlab_provision_item_names(self) -> list[str]:
+        return list(self.status.get('selfPacedLabProvisionItems', {}).keys())
 
     @property
     def selfpacedlab_id(self):
@@ -86,8 +86,8 @@ class SelfPacedLab(CachedKopfObject):
                 return f"{parsed.scheme}://{parsed.netloc}"
         return ''
 
-    def get_selfpacedlab_items(self):
-        return selfpacedlabitem.SelfPacedLabItem.get_for_selfpacedlab(self)
+    def get_selfpacedlab_provision_items(self):
+        return selfpacedlabprovisionitem.SelfPacedLabProvisionItem.get_for_selfpacedlab(self)
 
     async def delete_all_resource_claims(self, logger):
         logger.info(f"Deleting all ResourceClaims for {self}")
@@ -95,9 +95,9 @@ class SelfPacedLab(CachedKopfObject):
             logger.info(f"Deleting {resource_claim_obj}")
             await resource_claim_obj.delete()
 
-    async def delete_all_selfpacedlab_items(self, logger):
-        logger.info(f"Deleting all SelfPacedLabItems for {self}")
-        for item in self.get_selfpacedlab_items():
+    async def delete_all_selfpacedlab_provision_items(self, logger):
+        logger.info(f"Deleting all SelfPacedLabProvisionItems for {self}")
+        for item in self.get_selfpacedlab_provision_items():
             logger.info(f"Deleting {item}")
             await item.delete()
 
@@ -109,7 +109,7 @@ class SelfPacedLab(CachedKopfObject):
     async def handle_delete(self, logger):
         async with self.lock:
             logger.info(f"Handling delete for {self}")
-            await self.delete_all_selfpacedlab_items(logger=logger)
+            await self.delete_all_selfpacedlab_provision_items(logger=logger)
             await self.delete_all_resource_claims(logger=logger)
 
     async def handle_resume(self, logger):
@@ -178,12 +178,12 @@ class SelfPacedLab(CachedKopfObject):
         )
         logger.info("Added %s to %s status", resource_claim_obj, self)
 
-    async def add_selfpacedlab_item_to_status(self, item, logger):
-        if item.name in self.status.get('selfPacedLabItems', {}):
+    async def add_selfpacedlab_provision_item_to_status(self, item, logger):
+        if item.name in self.status.get('selfPacedLabProvisionItems', {}):
             return
         await self.merge_patch_status(
             {
-                "selfPacedLabItems": {
+                "selfPacedLabProvisionItems": {
                     item.name: {"uid": item.uid}
                 }
             }
@@ -196,11 +196,11 @@ class SelfPacedLab(CachedKopfObject):
         await self.merge_patch_status({"resourceClaims": {resource_claim_obj.name: None}})
         logger.info("Removed %s from %s status", resource_claim_obj, self)
 
-    async def remove_selfpacedlab_item_from_status(self, item, logger):
-        if item.name not in self.status.get('selfPacedLabItems', {}):
+    async def remove_selfpacedlab_provision_item_from_status(self, item, logger):
+        if item.name not in self.status.get('selfPacedLabProvisionItems', {}):
             return
         await self.merge_patch_status(
-            {"selfPacedLabItems": {item.name: None}}
+            {"selfPacedLabProvisionItems": {item.name: None}}
         )
         logger.info("Removed %s from %s status", item, self)
 
@@ -209,7 +209,7 @@ class SelfPacedLab(CachedKopfObject):
         total_provisioning_count = 0
         total_assigned_count = 0
 
-        for item in self.get_selfpacedlab_items():
+        for item in self.get_selfpacedlab_provision_items():
             item_status = item.status or {}
             total_ready_count += item_status.get('readyCount', 0)
             total_provisioning_count += item_status.get('provisioningCount', 0)

--- a/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
+++ b/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
@@ -29,11 +29,11 @@ def parse_duration(duration_str):
         return timedelta(seconds=value)
 
 
-class SelfPacedLabItem(CachedKopfObject):
+class SelfPacedLabProvisionItem(CachedKopfObject):
     api_group = Babylon.babylon_domain
     api_version = Babylon.babylon_api_version
-    kind = 'SelfPacedLabItem'
-    plural = 'selfpacedlabitems'
+    kind = 'SelfPacedLabProvisionItem'
+    plural = 'selfpacedlabprovisionitems'
 
     cache = {}
 
@@ -137,7 +137,7 @@ class SelfPacedLabItem(CachedKopfObject):
                     Babylon.selfpacedlab_label: lab.name,
                     Babylon.selfpacedlab_id_label: lab.selfpacedlab_id,
                     Babylon.selfpacedlab_uid_label: lab.uid,
-                    Babylon.selfpacedlab_item_label: self.name,
+                    Babylon.selfpacedlab_provision_item_label: self.name,
                 },
                 "namespace": f"{self.namespace}",
                 "ownerReferences": [self.as_owner_ref()],
@@ -255,7 +255,7 @@ class SelfPacedLabItem(CachedKopfObject):
     async def handle_delete(self, logger):
         try:
             lab = await self.get_selfpacedlab()
-            await lab.remove_selfpacedlab_item_from_status(self, logger=logger)
+            await lab.remove_selfpacedlab_provision_item_from_status(self, logger=logger)
         except k8sApiException as exception:
             if exception.status != 404:
                 logger.exception(
@@ -280,7 +280,7 @@ class SelfPacedLabItem(CachedKopfObject):
     async def list_resource_claims(self):
         async for resource_claim_obj in resourceclaim.ResourceClaim.list(
             label_selector=f"{Babylon.selfpacedlab_label}={self.selfpacedlab_name},"
-            f"{Babylon.selfpacedlab_item_label}={self.name}",
+            f"{Babylon.selfpacedlab_provision_item_label}={self.name}",
             namespace=self.namespace,
         ):
             if resource_claim_obj.deletion_timestamp is not None:
@@ -297,7 +297,7 @@ class SelfPacedLabItem(CachedKopfObject):
                 )
             raise
 
-        await lab.add_selfpacedlab_item_to_status(self, logger=logger)
+        await lab.add_selfpacedlab_provision_item_to_status(self, logger=logger)
 
         if not lab.selfpacedlab_id:
             logger.info(f"Waiting for selfpacedlab id assignment for {lab}")

--- a/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
+++ b/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 
-import kopf
 from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
 from babylon import Babylon
@@ -8,7 +7,6 @@ from cachedkopfobject import CachedKopfObject
 from labuserinterface import LabUserInterface
 
 import resourceclaim as resourceclaim_import
-import selfpacedlab as selfpacedlab_import
 
 
 class SelfPacedLabUserAssignment(CachedKopfObject):
@@ -77,7 +75,7 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
         selfpacedlab_name,
         selfpacedlab_id,
         assignment=None,
-        data={},
+        data=None,
         lab_user_interface=None,
         messages=None,
         user_name=None,
@@ -95,7 +93,7 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
                 "ownerReferences": [resource_claim.as_owner_ref()],
             },
             "spec": {
-                "data": data,
+                "data": data if data is not None else {},
                 "resourceClaimName": resource_claim.name,
                 "selfPacedLabName": selfpacedlab_name,
             },
@@ -163,49 +161,18 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
     def selfpacedlab_name(self):
         return self.spec.get('selfPacedLabName')
 
-    async def copy_to_selfpacedlab(self):
-        try:
-            selfpacedlab = await self.get_selfpacedlab()
-        except k8sApiException as exception:
-            if exception.status == 404:
-                raise kopf.TemporaryError(
-                    f"SelfPacedLab {self.selfpacedlab_name} was not found.", delay=60
-                )
-            raise
-
-        async with selfpacedlab.lock:
-            await selfpacedlab.merge_patch_status(
-                {
-                    "userAssignments": {
-                        self.name: {
-                            "assignment": self.assignment,
-                            "resourceClaimName": self.resource_claim_name,
-                            "userName": self.user_name,
-                        }
-                    }
-                }
-            )
-
-    async def get_selfpacedlab(self):
-        return await selfpacedlab_import.SelfPacedLab.get(
-            name=self.selfpacedlab_name, namespace=self.namespace
-        )
-
     async def handle_create(self, logger):
         async with self.lock:
             logger.info(f"Handling create for {self}")
-            await self.copy_to_selfpacedlab()
             await self.sync_resource_claim_assigned(logger=logger)
 
     async def handle_delete(self, logger):
         async with self.lock:
             logger.info(f"Handling delete for {self}")
-            await self.remove_from_selfpacedlab()
 
     async def handle_update(self, logger):
         async with self.lock:
             logger.info(f"Handling update for {self}")
-            await self.copy_to_selfpacedlab()
             await self.sync_resource_claim_assigned(logger=logger)
 
     async def sync_resource_claim_assigned(self, logger):
@@ -237,13 +204,3 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
             }
         })
 
-    async def remove_from_selfpacedlab(self):
-        try:
-            selfpacedlab = await self.get_selfpacedlab()
-            async with selfpacedlab.lock:
-                await selfpacedlab.merge_patch_status(
-                    {"userAssignments": {self.name: None}}
-                )
-        except k8sApiException as exception:
-            if exception.status != 404:
-                raise

--- a/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
+++ b/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import kopf
 from kubernetes_asyncio.client.exceptions import ApiException as k8sApiException
 
@@ -5,6 +7,7 @@ from babylon import Babylon
 from cachedkopfobject import CachedKopfObject
 from labuserinterface import LabUserInterface
 
+import resourceclaim as resourceclaim_import
 import selfpacedlab as selfpacedlab_import
 
 
@@ -192,6 +195,7 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
         async with self.lock:
             logger.info(f"Handling create for {self}")
             await self.copy_to_selfpacedlab()
+            await self.sync_resource_claim_assigned(logger=logger)
 
     async def handle_delete(self, logger):
         async with self.lock:
@@ -202,6 +206,36 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
         async with self.lock:
             logger.info(f"Handling update for {self}")
             await self.copy_to_selfpacedlab()
+            await self.sync_resource_claim_assigned(logger=logger)
+
+    async def sync_resource_claim_assigned(self, logger):
+        if not self.resource_claim_name or not self.assignment:
+            return
+        try:
+            rc = await resourceclaim_import.ResourceClaim.fetch(
+                name=self.resource_claim_name, namespace=self.namespace
+            )
+        except k8sApiException as exception:
+            if exception.status == 404:
+                logger.warning(f"ResourceClaim {self.resource_claim_name} not found for {self}")
+                return
+            raise
+
+        if rc.labels.get(Babylon.selfpacedlab_assigned_label) == 'true':
+            return
+
+        logger.info(f"Marking {rc} as assigned for {self}")
+        await rc.merge_patch({
+            "metadata": {
+                "labels": {
+                    Babylon.selfpacedlab_assigned_label: "true",
+                },
+                "annotations": {
+                    Babylon.selfpacedlab_assigned_at_annotation:
+                        datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                },
+            }
+        })
 
     async def remove_from_selfpacedlab(self):
         try:


### PR DESCRIPTION
- Add missing RBAC for catalog-api: selfpacedlabs, selfpacedlabitems, selfpacedlabuserassignments, and workshopprovisions
- Add missing RBAC for selfpacedlab-manager: selfpacedlabuserassignments
- Fix self-paced lab instances tab to fetch user assignments from SelfPacedLabUserAssignment resources instead of a non-existent ResourceClaim label
- Mark ResourceClaims as assigned when a user is assigned via SelfPacedLabUserAssignment, enabling warm pool replenishment
- Restore missing babylon.gpte.redhat.com/workshop label on WorkshopProvision creation (regression from multi-workshop feature)