### PR TITLE
fix: use correct assignment label in SelfPacedLabStatus

### DIFF
--- a/catalog/ui/src/app/Admin/admin.css
+++ b/catalog/ui/src/app/Admin/admin.css
@@ -13,10 +13,10 @@
 }
 
 .admin-body.pf-v6-c-page__main-section .pf-v6-c-tabs {
-  margin-left: -100px;
-  padding-left: 100px;
-  margin-right: -100px;
-  padding-right: 100px;
+  margin-left: calc(-1 * var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg)));
+  padding-left: var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg));
+  margin-right: calc(-1 * var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg)));
+  padding-right: var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg));
   margin-bottom: 10pt;
 }
 

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -493,8 +493,8 @@ const SelfPacedLabItemComponent: React.FC<{
                 <DescriptionListGroup>
                   <DescriptionListTerm>Status</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {resourceClaims ? (
-                      <SelfPacedLabStatus resourceClaims={resourceClaims} />
+                    {selfPacedLab.status?.poolCount ? (
+                      <SelfPacedLabStatus poolCount={selfPacedLab.status.poolCount} />
                     ) : (
                       <Spinner size="md" />
                     )}

--- a/catalog/ui/src/app/SelfPacedLabs/selfpacedlab-item.css
+++ b/catalog/ui/src/app/SelfPacedLabs/selfpacedlab-item.css
@@ -4,10 +4,10 @@
 }
 
 .selfpacedlab-item__body.pf-v6-c-page__main-section .pf-v6-c-tabs {
-  margin-left: -100px;
-  padding-left: 100px;
-  margin-right: -100px;
-  padding-right: 100px;
+  margin-left: calc(-1 * var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg)));
+  padding-left: var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg));
+  margin-right: calc(-1 * var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg)));
+  padding-right: var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg));
   margin-bottom: var(--pf-t--global--spacer--sm);
 }
 

--- a/catalog/ui/src/app/Services/services-item.css
+++ b/catalog/ui/src/app/Services/services-item.css
@@ -9,10 +9,10 @@
 }
 
 .services-item__body.pf-v6-c-page__main-section .pf-v6-c-tabs {
-  margin-left: -100px;
-  padding-left: 100px;
-  margin-right: -100px;
-  padding-right: 100px;
+  margin-left: calc(-1 * var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg)));
+  padding-left: var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg));
+  margin-right: calc(-1 * var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg)));
+  padding-right: var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg));
   margin-bottom: var(--pf-t--global--spacer--sm);
 }
 

--- a/catalog/ui/src/app/Workshops/workshops-item.css
+++ b/catalog/ui/src/app/Workshops/workshops-item.css
@@ -4,10 +4,10 @@
 }
 
 .workshops-item__body.pf-v6-c-page__main-section .pf-v6-c-tabs {
-  margin-left: -100px;
-  padding-left: 100px;
-  margin-right: -100px;
-  padding-right: 100px;
+  margin-left: calc(-1 * var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg)));
+  padding-left: var(--pf-v6-c-page__main-section--PaddingLeft, var(--pf-t--global--spacer--lg));
+  margin-right: calc(-1 * var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg)));
+  padding-right: var(--pf-v6-c-page__main-section--PaddingRight, var(--pf-t--global--spacer--lg));
   margin-bottom: var(--pf-t--global--spacer--sm);
 }
 

--- a/catalog/ui/src/app/components/SelfPacedLabStatus.spec.tsx
+++ b/catalog/ui/src/app/components/SelfPacedLabStatus.spec.tsx
@@ -31,7 +31,7 @@ describe('SelfPacedLabStatus', () => {
   });
 
   describe('with resourceClaims prop', () => {
-    const assignmentLabel = 'babylon.gpte.redhat.com/selfpacedlab-assignment';
+    const assignmentLabel = 'babylon.gpte.redhat.com/assigned';
 
     const makeResourceClaim = (overrides: {
       labels?: Record<string, string>;

--- a/catalog/ui/src/app/components/SelfPacedLabStatus.tsx
+++ b/catalog/ui/src/app/components/SelfPacedLabStatus.tsx
@@ -9,7 +9,7 @@ const SelfPacedLabStatus: React.FC<{
   resourceClaims?: ResourceClaim[];
   poolCount?: { ready?: number; assigned?: number; provisioning?: number };
   assignmentLabel?: string;
-}> = ({ resourceClaims, poolCount, assignmentLabel = `${BABYLON_DOMAIN}/selfpacedlab-assignment` }) => {
+}> = ({ resourceClaims, poolCount, assignmentLabel = `${BABYLON_DOMAIN}/assigned` }) => {
   const status = useMemo(() => {
     if (poolCount) {
       return {


### PR DESCRIPTION
The default assignmentLabel was 'selfpacedlab-assignment' but the operator labels assigned ResourceClaims with 'assigned'. This caused assigned instances to be counted as ready instead.