### PR TITLE
feat: show Self-Paced Lab tag and hide managed actions 

### DIFF
--- a/catalog/ui/src/app/Services/ServiceActions.tsx
+++ b/catalog/ui/src/app/Services/ServiceActions.tsx
@@ -8,6 +8,7 @@ import {
   checkResourceClaimCanStart,
   checkResourceClaimCanStop,
   isResourceClaimPartOfWorkshop,
+  isResourceClaimPartOfSelfPacedLab,
 } from '@app/util';
 import useInterfaceConfig from '@app/utils/useInterfaceConfig';
 
@@ -35,11 +36,12 @@ const ServiceActions: React.FC<{
   const actionDropdownItems = [];
   const { ratings_enabled } = useInterfaceConfig();
   const isPartOfWorkshop = isResourceClaimPartOfWorkshop(resourceClaim);
+  const isManagedInstance = isPartOfWorkshop || isResourceClaimPartOfSelfPacedLab(resourceClaim);
   const canStart = resourceClaim ? checkResourceClaimCanStart(resourceClaim) : false;
   const canStop = resourceClaim ? checkResourceClaimCanStop(resourceClaim) : false;
   const canRate = resourceClaim && ratings_enabled ? checkResourceClaimCanRate(resourceClaim) : false;
 
-  if (!isPartOfWorkshop && actionHandlers.runtime) {
+  if (!isManagedInstance && actionHandlers.runtime) {
     actionDropdownItems.push(
       <ActionDropdownItem
         key="runtime"
@@ -52,7 +54,7 @@ const ServiceActions: React.FC<{
       />,
     );
   }
-  if (!isPartOfWorkshop && actionHandlers.lifespan) {
+  if (!isManagedInstance && actionHandlers.lifespan) {
     actionDropdownItems.push(
       <ActionDropdownItem
         key="lifespan"
@@ -83,7 +85,7 @@ const ServiceActions: React.FC<{
       />,
     );
   }
-  if (!isPartOfWorkshop && actionHandlers.start) {
+  if (!isManagedInstance && actionHandlers.start) {
     actionDropdownItems.push(
       <ActionDropdownItem
         key="start"
@@ -94,7 +96,7 @@ const ServiceActions: React.FC<{
       />,
     );
   }
-  if (!isPartOfWorkshop && actionHandlers.stop) {
+  if (!isManagedInstance && actionHandlers.stop) {
     actionDropdownItems.push(
       <ActionDropdownItem
         key="stop"
@@ -116,7 +118,7 @@ const ServiceActions: React.FC<{
       <ActionDropdownItem key="reorder" label="Reorder" onSelect={actionHandlers.reorder} />,
     );
   }
-  if (!isPartOfWorkshop && actionHandlers.rate) {
+  if (!isManagedInstance && actionHandlers.rate) {
     actionDropdownItems.push(
       <ActionDropdownItem
         key="rate"

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -80,6 +80,7 @@ import {
   displayName,
   renderContent,
   isResourceClaimPartOfWorkshop,
+  isResourceClaimPartOfSelfPacedLab,
   getStageFromK8sObject,
   compareK8sObjects,
   namespaceToServiceNamespaceMapper,
@@ -390,13 +391,15 @@ const ServicesItemComponent: React.FC<{
   }>({ action: null, submitDisabled: false });
 
   const isPartOfWorkshop = isResourceClaimPartOfWorkshop(resourceClaim);
+  const isPartOfSelfPacedLab = isResourceClaimPartOfSelfPacedLab(resourceClaim);
+  const isManagedInstance = isPartOfWorkshop || isPartOfSelfPacedLab;
 
   const {
     data: serviceAccessConfigResponse,
     isLoading: serviceAccessLoading,
     mutate: mutateServiceAccessConfig,
   } = useSWR<ServiceAccessConfig | typeof FORBIDDEN_RESPONSE | null>(
-    !isPartOfWorkshop && (isAdmin || sessionServiceNamespaces.some((ns) => ns.name === resourceClaim.metadata.namespace))
+    !isManagedInstance && (isAdmin || sessionServiceNamespaces.some((ns) => ns.name === resourceClaim.metadata.namespace))
       ? apiPaths.SERVICE_ACCESS_CONFIG({
           namespace: resourceClaim.metadata.namespace,
           name: resourceClaim.metadata.name,
@@ -598,7 +601,8 @@ const ServicesItemComponent: React.FC<{
   }
   if (isPartOfWorkshop) {
     actionHandlers.manageWorkshop = () => navigate(`/workshops/${serviceNamespace.name}/${workshopName}`);
-  } else {
+  }
+  if (!isManagedInstance) {
     actionHandlers.rate = () => showModal({ action: 'rate', modal: 'action', resourceClaim });
   }
   if (canReorderResourceClaim(resourceClaim, catalogItem, groups, isAdmin)) {
@@ -912,6 +916,14 @@ const ServicesItemComponent: React.FC<{
                   Workshop UI
                 </Label>
               ) : null}
+              {isPartOfSelfPacedLab ? (
+                <Label
+                  key="service-item__selfpacedlab"
+                  tooltipDescription={<div>This service is part of a self-paced lab</div>}
+                >
+                  Self-Paced Lab
+                </Label>
+              ) : null}
               {serviceAlias ? (
                 <Label key="service-alias" tooltipDescription={<div>Alias name for the service</div>}>
                   {serviceAlias}
@@ -1072,11 +1084,11 @@ const ServicesItemComponent: React.FC<{
                       <AutoStopDestroy
                         type="auto-stop"
                         onClick={() => {
-                          if (!isLocked && !isPartOfWorkshop) {
+                          if (!isLocked && !isManagedInstance) {
                             showModal({ action: 'stop', modal: 'scheduleAction', resourceClaim });
                           }
                         }}
-                        isDisabled={isLocked || isPartOfWorkshop}
+                        isDisabled={isLocked || isManagedInstance}
                         resourceClaim={resourceClaim}
                         className="services-item__schedule-btn"
                         time={autoStopTime}
@@ -1085,7 +1097,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListDescription>
                   </DescriptionListGroup>
 
-                  {!externalPlatformUrl && !isPartOfWorkshop && (resourceClaim.status?.lifespan?.end || resourceClaim.spec?.lifespan?.end) ? (
+                  {!externalPlatformUrl && !isManagedInstance && (resourceClaim.status?.lifespan?.end || resourceClaim.spec?.lifespan?.end) ? (
                     <DescriptionListGroup>
                       <DescriptionListTerm>Auto-destroy</DescriptionListTerm>
                       <DescriptionListDescription>
@@ -1182,7 +1194,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListDescription>
                   </DescriptionListGroup>
 
-                  {!isPartOfWorkshop && sfdc_enabled ? (
+                  {!isManagedInstance && sfdc_enabled ? (
                     <DescriptionListGroup>
                       <DescriptionListTerm>Salesforce IDs</DescriptionListTerm>
                       <DescriptionListDescription>
@@ -1199,7 +1211,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListGroup>
                   ) : null}
 
-                  {!isPartOfWorkshop && canManageCollaborators ? (
+                  {!isManagedInstance && canManageCollaborators ? (
                     <DescriptionListGroup>
                       <DescriptionListTerm>
                         Share service{' '}
@@ -1244,7 +1256,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListGroup>
                   ) : null}
 
-                  {!isPartOfWorkshop && isAdmin ? (
+                  {!isManagedInstance && isAdmin ? (
                     <>
                       <DescriptionListGroup className="services-item__admin-section">
                         <DescriptionListTerm>Admin Settings</DescriptionListTerm>
@@ -1448,7 +1460,7 @@ const ServicesItemComponent: React.FC<{
                               isAdmin={isAdmin}
                               groups={groups}
                               externalPlatformUrl={externalPlatformUrl}
-                              isPartOfWorkshop={isPartOfWorkshop}
+                              isPartOfWorkshop={isManagedInstance}
                               startDate={startDate}
                               startTimestamp={startTimestamp}
                               stopDate={stopDate}

--- a/catalog/ui/src/app/Services/renderResourceClaimRow.tsx
+++ b/catalog/ui/src/app/Services/renderResourceClaimRow.tsx
@@ -13,6 +13,7 @@ import {
   displayName,
   getStageFromK8sObject,
   isResourceClaimPartOfWorkshop,
+  isResourceClaimPartOfSelfPacedLab,
 } from '@app/util';
 import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
 import AutoStopDestroy from '@app/components/AutoStopDestroy';
@@ -48,6 +49,8 @@ const renderResourceClaimRow = ({
   const guid = resourceHandle?.name ? resourceHandle.name.replace(/^guid-/, '') : null;
   const workshopName = resourceClaim.metadata?.labels?.[`${BABYLON_DOMAIN}/workshop`];
   const isPartOfWorkshop = isResourceClaimPartOfWorkshop(resourceClaim);
+  const isPartOfSelfPacedLab = isResourceClaimPartOfSelfPacedLab(resourceClaim);
+  const isManagedInstance = isPartOfWorkshop || isPartOfSelfPacedLab;
   const serviceAlias = resourceClaim.metadata?.annotations?.[`${DEMO_DOMAIN}/service-alias`] || '';
   // Find lab user interface information either in the resource claim or inside resources
   // associated with the provisioned service.
@@ -146,6 +149,11 @@ const renderResourceClaimRow = ({
           Workshop UI
         </Label>
       ) : null}
+      {isPartOfSelfPacedLab ? (
+        <Label key="selfpacedlab__ui" tooltipDescription={<div>This service is part of a self-paced lab</div>}>
+          Self-Paced Lab
+        </Label>
+      ) : null}
       {serviceAlias ? (
         <Label key="service-alias" tooltipDescription={<div>Alias name for the service</div>}>
           {serviceAlias}
@@ -205,7 +213,7 @@ const renderResourceClaimRow = ({
         gap: 'var(--pf-t--global--spacer--sm)',
       }}
     >
-      {!isPartOfWorkshop ? (
+      {!isManagedInstance ? (
         <ButtonCircleIcon
           isDisabled={isLocked || !checkResourceClaimCanStart(resourceClaim)}
           onClick={actionHandlers.start}
@@ -214,7 +222,7 @@ const renderResourceClaimRow = ({
           key="actions__start"
         />
       ) : null}
-      {!isPartOfWorkshop ? (
+      {!isManagedInstance ? (
         <ButtonCircleIcon
           isDisabled={isLocked || !checkResourceClaimCanStop(resourceClaim)}
           onClick={actionHandlers.stop}

--- a/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
+++ b/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
@@ -309,6 +309,8 @@ class SelfPacedLabProvisionItem(CachedKopfObject):
         async with self.lock:
             await self.manage_resource_claims(logger=logger, lab=lab)
 
+        await lab.update_status()
+
     async def manage_resource_claims(self, logger, lab):
         logger.debug(f"Manage ResourceClaims for {self}")
 


### PR DESCRIPTION
ResourceClaims with the selfpacedlab label now behave like workshop-owned ones in the catalog UI: a "Self-Paced Lab" tag is shown next to the title, and start/stop, auto-stop, auto-destroy, salesforce, share, rate, and admin actions are hidden.