### PR TITLE
Potential fix for code scanning alert no. 26: Partial server-side request forgery

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -346,7 +346,16 @@ class WebhookServer:
                 "error": "Invalid pull_request field format"
             }, status=400)
         
-        pr_number = pull_request.get('number', 0)
+        pr_number_raw = pull_request.get('number', 0)
+        try:
+            pr_number = int(pr_number_raw)
+            if pr_number <= 0:
+                raise ValueError("PR number must be positive")
+        except (TypeError, ValueError):
+            return web.json_response({
+                "error": "Invalid pull_request.number"
+            }, status=400)
+
         pr_state = pull_request.get('state', '')
         head_ref = pull_request.get('head', {}).get('ref', '')
         base_ref = pull_request.get('base', {}).get('ref', '')


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/26](https://github.com/redhat-cop/babylon/security/code-scanning/26)

To fix this without changing intended behavior, strictly validate and normalize `pr_number` as an integer before any use in URL construction, and reject invalid values early.

Best single approach in this file:
- In `handle_pull_request_event` (around line 349), replace direct extraction of `pr_number` with:
  - read raw value,
  - convert to `int`,
  - ensure positive (`> 0`),
  - return `400` on invalid input.
- This guarantees downstream calls (`trigger_pr_cleanup`, comment URL construction) use a safe numeric identifier and prevents attacker-controlled path fragments.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
