### PR TITLE
Potential fix for code scanning alert no. 25: Partial server-side request forgery

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -487,15 +487,24 @@ class WebhookServer:
             from babylon import Babylon
             import aiohttp
             
+            # Validate PR number before using it in URL construction
+            try:
+                validated_pr_number = int(pr_number)
+                if validated_pr_number <= 0:
+                    raise ValueError("PR number must be a positive integer")
+            except (TypeError, ValueError):
+                logger.warning(f"Invalid PR number '{pr_number}', skipping merged PR annotation cleanup")
+                return
+
             # Get the files modified by this PR via GitHub API
             github_token = await agnosticv_repo.get_github_token()
             if not github_token:
-                logger.warning(f"No GitHub token available, skipping efficient cleanup for PR #{pr_number}")
+                logger.warning(f"No GitHub token available, skipping efficient cleanup for PR #{validated_pr_number}")
                 return
             
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    f"{agnosticv_repo.github_api_base_url}/pulls/{pr_number}/files",
+                    f"{agnosticv_repo.github_api_base_url}/pulls/{validated_pr_number}/files",
                     headers={
                         "Accept": "application/vnd.github+json",
                         "Authorization": f"Bearer {github_token}",


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/25](https://github.com/redhat-cop/babylon/security/code-scanning/25)

To fix this safely without changing intended behavior, validate and canonicalize `pr_number` as a strict positive integer before using it in the URL, and then build the URL with the validated integer value. This removes attacker control over path metacharacters (`/`, `?`, `#`, `..`, etc.) and preserves existing logic for valid PR numbers.

Best single fix in `agnosticv-operator/operator/webhook_server.py`:
- In `cleanup_merged_pr_annotations(...)`, before `session.get(...)`, convert `pr_number` to `int` inside a guarded block.
- Reject invalid/non-positive values by logging and returning early.
- Use the validated integer in the URL string.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
