### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/catalog/ui/src/app/components/Editor/ToolbarPlugin.tsx
+++ b/catalog/ui/src/app/components/Editor/ToolbarPlugin.tsx
@@ -70,6 +70,21 @@ function FloatingLinkEditor({ editor }) {
   const [isEditMode, setEditMode] = useState(false);
   const [lastSelection, setLastSelection] = useState(null);
 
+  const sanitizeUrl = useCallback((url) => {
+    if (!url) {
+      return '';
+    }
+    try {
+      const parsed = new URL(url, window.location.origin);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return parsed.href;
+      }
+    } catch (e) {
+      // Invalid URL; fall through and return empty string.
+    }
+    return '';
+  }, []);
+
   const updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
@@ -169,8 +184,9 @@ function FloatingLinkEditor({ editor }) {
             if (event.key === 'Enter') {
               event.preventDefault();
               if (lastSelection !== null) {
-                if (linkUrl !== '') {
-                  editor.dispatchCommand(TOGGLE_LINK_COMMAND, linkUrl);
+                const safeUrl = sanitizeUrl(linkUrl);
+                if (safeUrl !== '') {
+                  editor.dispatchCommand(TOGGLE_LINK_COMMAND, safeUrl);
                 }
                 setEditMode(false);
               }
@@ -183,8 +199,8 @@ function FloatingLinkEditor({ editor }) {
       ) : (
         <>
           <div className="link-input">
-            <a href={linkUrl} target="_blank" rel="noopener noreferrer">
-              {linkUrl}
+            <a href={sanitizeUrl(linkUrl)} target="_blank" rel="noopener noreferrer">
+              {sanitizeUrl(linkUrl)}
             </a>
             <div
               className="link-edit"


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/5](https://github.com/redhat-cop/babylon/security/code-scanning/5)

Best fix: sanitize/validate URLs before using them in `href` and before dispatching link updates, allowing only safe schemes (for example `http:` and `https:`), and falling back to an empty/safe value otherwise.

In `catalog/ui/src/app/components/Editor/ToolbarPlugin.tsx`:
- Add a small helper function (inside `FloatingLinkEditor`) that normalizes and validates URLs using `new URL(...)`.
- Use this sanitized value for:
  1. `<a href={...}>` (line 186 area),
  2. displayed text (optional but keeps UI consistent),
  3. `TOGGLE_LINK_COMMAND` payload when Enter is pressed.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
