### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -429,7 +429,7 @@ export function escapeRegex(string: string) {
 export function stripTags(unStrippedHtml: string) {
   if (!unStrippedHtml) return '';
   const parseHTML = new DOMParser().parseFromString(
-    dompurify.sanitize(unStrippedHtml.replace(/<!--.*?-->/g, '').replace(/(\r\n|\n|\r)/gm, '')),
+    dompurify.sanitize(unStrippedHtml.replace(/<!--[\s\S]*?-->/g, '').replace(/(\r\n|\n|\r)/gm, '')),
     'text/html',
   );
   return parseHTML.body.textContent || '';

--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -428,8 +428,16 @@ export function escapeRegex(string: string) {
 
 export function stripTags(unStrippedHtml: string) {
   if (!unStrippedHtml) return '';
+
+  let sanitizedInput = unStrippedHtml;
+  let previousValue: string;
+  do {
+    previousValue = sanitizedInput;
+    sanitizedInput = sanitizedInput.replace(/<!--[\s\S]*?-->/g, '');
+  } while (sanitizedInput !== previousValue);
+
   const parseHTML = new DOMParser().parseFromString(
-    dompurify.sanitize(unStrippedHtml.replace(/<!--[\s\S]*?-->/g, '').replace(/(\r\n|\n|\r)/gm, '')),
+    dompurify.sanitize(sanitizedInput.replace(/(\r\n|\n|\r)/gm, '')),
     'text/html',
   );
   return parseHTML.body.textContent || '';


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/1](https://github.com/redhat-cop/babylon/security/code-scanning/1)

To fix this without changing intended functionality, replace the comment-stripping regex with one that matches across newlines. The best minimal fix is to use `[\s\S]*?` instead of `.*?`, preserving non-greedy behavior while allowing multiline comments.

In `catalog/ui/src/app/util.ts`, update the `stripTags` function at the `replace` call on line 432:

- From: `.replace(/<!--.*?-->/g, '')`
- To: `.replace(/<!--[\s\S]*?-->/g, '')`

No import or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
