### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -428,8 +428,14 @@ export function escapeRegex(string: string) {
 
 export function stripTags(unStrippedHtml: string) {
   if (!unStrippedHtml) return '';
+  let sanitizedInput = unStrippedHtml;
+  let previous: string;
+  do {
+    previous = sanitizedInput;
+    sanitizedInput = sanitizedInput.replace(/<!--.*?-->/g, '');
+  } while (sanitizedInput !== previous);
   const parseHTML = new DOMParser().parseFromString(
-    dompurify.sanitize(unStrippedHtml.replace(/<!--.*?-->/g, '').replace(/(\r\n|\n|\r)/gm, '')),
+    dompurify.sanitize(sanitizedInput.replace(/(\r\n|\n|\r)/gm, '')),
     'text/html',
   );
   return parseHTML.body.textContent || '';


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/3](https://github.com/redhat-cop/babylon/security/code-scanning/3)

General fix: when removing patterns composed of multiple characters that can reappear after deletion, either (1) repeatedly apply replacement until the string stabilizes, or (2) avoid such pattern-level stripping and use a robust sanitizer/parser strategy.

Best fix here (minimal, no behavior change intent): in `catalog/ui/src/app/util.ts`, update `stripTags` so comment removal is applied in a stabilization loop before newline removal and DOMPurify. This preserves existing logic while eliminating the incomplete single-pass replacement weakness.

What to change:
- In `stripTags` (around line 429+), replace the inline chained `unStrippedHtml.replace(/<!--.*?-->/g, '')...` with:
  - a local `sanitizedInput` variable initialized from `unStrippedHtml`
  - a `do/while` loop that repeatedly removes `<!--.*?-->` globally until no further changes
  - then remove newlines from the stabilized string
  - pass result to `dompurify.sanitize(...)` as before

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
