### PR TITLE
Potential fix for code scanning alert no. 31: Jinja2 templating with autoescape=False

### DIFF
--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -52,6 +52,7 @@ def error_if_undefined(result):
 jinja2env = jinja2.Environment(
     finalize = error_if_undefined,
     undefined = jinja2.ChainableUndefined,
+    autoescape = jinja2.select_autoescape(['html', 'htm', 'xml']),
 )
 jinja2env.filters['bool'] = lambda x: bool(str2bool(x)) if isinstance(x, str) else bool(x)
 jinja2env.filters['uuid2int'] = lambda x: int(UUID(x))


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/31](https://github.com/redhat-cop/babylon/security/code-scanning/31)

Set explicit autoescaping on the Jinja2 environment creation, ideally using `jinja2.select_autoescape(...)` so escaping is applied for HTML/XML template types while preserving expected behavior for non-HTML templates.

In `agnosticv-operator/operator/agnosticvcomponent.py`, update the `jinja2.Environment(...)` initialization block (around lines 52–55) to add `autoescape=jinja2.select_autoescape(['html', 'htm', 'xml'])`. This is the best minimal fix because it:
- removes dependence on unsafe defaults,
- follows Jinja2 best practice,
- avoids changing existing filters/finalizer/undefined handling,
- minimizes risk of breaking non-HTML template rendering.

No new imports are required because `jinja2` is already imported as a module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
