### PR TITLE
Potential fix for code scanning alert no. 32: Jinja2 templating with autoescape=False

### DIFF
--- a/notifier/operator/operator.py
+++ b/notifier/operator/operator.py
@@ -92,6 +92,10 @@ j2env = jinja2.Environment(
         )
     ]),
     trim_blocks = True,
+    autoescape = jinja2.select_autoescape(
+        ['html', 'htm', 'xml'],
+        default_for_string = True,
+    ),
 )
 
 # Add to_yaml filter


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/32](https://github.com/redhat-cop/babylon/security/code-scanning/32)

Set `autoescape` explicitly when creating the Jinja2 environment, using `jinja2.select_autoescape(...)`. This preserves expected behavior for non-HTML templates while enabling escaping for HTML/XML-like templates and string-based templates.

Best fix in this snippet: update the `j2env = jinja2.Environment(...)` block in `notifier/operator/operator.py` to include:
- `autoescape=jinja2.select_autoescape(['html', 'htm', 'xml'], default_for_string=True)`

No new imports are needed because `jinja2` is already imported as a module and `select_autoescape` can be referenced via `jinja2.select_autoescape`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
