### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -111,7 +111,16 @@ export function randomString(length: number): string {
 
 export function recursiveAssign(target: object, source: object): void {
   for (const [k, v] of Object.entries(source)) {
-    if (v !== null && typeof v === 'object' && k in target && target[k] !== null && typeof target[k] === 'object') {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+      continue;
+    }
+    if (
+      v !== null &&
+      typeof v === 'object' &&
+      Object.prototype.hasOwnProperty.call(target, k) &&
+      target[k] !== null &&
+      typeof target[k] === 'object'
+    ) {
       recursiveAssign(target[k], v);
     } else {
       target[k] = v;


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/4](https://github.com/redhat-cop/babylon/security/code-scanning/4)

The safest minimal fix is to harden `recursiveAssign` by rejecting prototype-pollution keys and only recursing into **own** properties of the destination object. Specifically in `catalog/ui/src/app/util.ts`:

- In `recursiveAssign`, skip keys `__proto__`, `constructor`, and `prototype`.
- Replace `k in target` with an own-property check (`Object.prototype.hasOwnProperty.call(target, k)`).
- Keep existing behavior otherwise (recursive merge for object/object; direct assignment for other values).

This preserves normal merge functionality while preventing prototype-chain writes and traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
