### PR TITLE
ref: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/admin-publish.yaml
+++ b/.github/workflows/admin-publish.yaml
@@ -14,6 +14,10 @@ on:
         type: string
         default: "latest"
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   publish:
     env:

--- a/.github/workflows/agnosticv-operator-pr.yaml
+++ b/.github/workflows/agnosticv-operator-pr.yaml
@@ -11,6 +11,10 @@ on:
       - agnosticv-operator/**
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: "Publish image in quay"

--- a/.github/workflows/agnosticv-operator-publish.yaml
+++ b/.github/workflows/agnosticv-operator-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'agnosticv-operator-v*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/catalog-api-publish.yaml
+++ b/.github/workflows/catalog-api-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'catalog-api-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/catalog-manager-publish.yaml
+++ b/.github/workflows/catalog-manager-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'catalog-manager-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/catalog-status-publish.yaml
+++ b/.github/workflows/catalog-status-publish.yaml
@@ -6,6 +6,10 @@ on:
       - "*"
     tags:
       - "catalog-status-v[0-9]*"
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/catalog-ui-pr.yaml
+++ b/.github/workflows/catalog-ui-pr.yaml
@@ -11,6 +11,10 @@ on:
       - catalog/**
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "UI Tests"

--- a/.github/workflows/catalog-ui-publish.yaml
+++ b/.github/workflows/catalog-ui-publish.yaml
@@ -6,6 +6,10 @@ on:
       - "*"
     tags:
       - "catalog-ui-v[0-9]*"
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/cost-tracker-publish.yaml
+++ b/.github/workflows/cost-tracker-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'cost-tracker-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/lab-ui-manager-publish.yaml
+++ b/.github/workflows/lab-ui-manager-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'lab-ui-manager-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/notifier-publish.yaml
+++ b/.github/workflows/notifier-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'notifier-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -6,6 +6,10 @@ on:
     - '**'
     tags:
     - 'v[0-9]*'
+
+permissions:
+  contents: write
+
 jobs:
   publish-helm-charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/ratings-publish.yaml
+++ b/.github/workflows/ratings-publish.yaml
@@ -14,6 +14,10 @@ on:
         type: string
         default: "latest"
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   publish:
     env:

--- a/.github/workflows/service-access-manager-publish.yaml
+++ b/.github/workflows/service-access-manager-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'service-access-manager-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:

--- a/.github/workflows/workshop-manager-publish.yaml
+++ b/.github/workflows/workshop-manager-publish.yaml
@@ -6,6 +6,10 @@ on:
     - '*'
     tags:
     - 'workshop-manager-v[0-9]*'
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:


### PR DESCRIPTION
Apply least-privilege permissions to all 15 workflows that were missing them, following the principle already established in selfpacedlab-manager-publish.yaml.