### PR TITLE
Potential fix for code scanning alert no. 24: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -622,14 +622,15 @@ class WebhookServer:
         """Trigger PR cleanup when PR is closed - for merged PRs, keep components; for closed PRs, delete them"""
         try:
             logger = logging.getLogger(f'webhook.{agnosticv_repo.name}.pr{pr_number}')
+            safe_head_ref = str(head_ref).replace('\r', '').replace('\n', '')
             if merged:
-                logger.info(f"PR merged: #{pr_number} ({head_ref}) - triggering full main branch reprocessing")
+                logger.info(f"PR merged: #{pr_number} ({safe_head_ref}) - triggering full main branch reprocessing")
                 # For merged PRs, trigger a full reprocessing of the main branch
                 # This will apply any deletions and ensure components are up to date
                 await self.trigger_main_branch_sync(agnosticv_repo, pr_number, logger)
                 return
             else:
-                logger.info(f"PR closed without merge: #{pr_number} ({head_ref}) - deleting components")
+                logger.info(f"PR closed without merge: #{pr_number} ({safe_head_ref}) - deleting components")
             
             # Only delete components for PRs that were closed without merge
             async with agnosticv_repo.lock:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/24](https://github.com/redhat-cop/babylon/security/code-scanning/24)

General fix: sanitize any user-controlled values before writing them to logs, especially by removing CR/LF (and ideally other non-printable control chars) to prevent log line breaking/forgery.

Best targeted fix here (without changing behavior): in `agnosticv-operator/operator/webhook_server.py`, sanitize `head_ref` inside `trigger_pr_cleanup` before interpolating into log messages. Add a small local sanitization step (e.g., replace `\r` and `\n` with empty strings) and use that sanitized value in both log lines in this method (merged and non-merged branches), since both currently include `head_ref`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
