### PR TITLE
fix: Set redis password to explicit null to resolve CodeQL warning

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -98,7 +98,7 @@ oauthProxy:
 redis:
   name: # default use chart name + '-redis'
   deploy: true
-  password:
+  password: null
   generatePassword: true
   image:
     #override:

--- a/notifier/helm/values.yaml
+++ b/notifier/helm/values.yaml
@@ -91,7 +91,7 @@ image:
 redis:
   name: # default use chart name + '-redis'
   deploy: true
-  password:
+  password: null
   generatePassword: true
   image:
     #override:


### PR DESCRIPTION
The bare password: YAML key was interpreted as an empty string, triggering CodeQL js/empty-password-in-configuration-file rule. Setting it to null makes the intent explicit -- no password is provided because generatePassword: true handles it.