### PR TITLE
fix: Pin docker/build-push-action to commit SHA in ratings-publish

### DIFF
--- a/.github/workflows/admin-publish.yaml
+++ b/.github/workflows/admin-publish.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get image tags
         id: image_tags
@@ -63,13 +63,13 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
           version: latest
         if: steps.image_tags.outputs.IMAGE_TAGS
 
       - name: Login to Image Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push
         if: steps.image_tags.outputs.IMAGE_TAGS
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: admin
           file: admin/Dockerfile

--- a/.github/workflows/agnosticv-operator-pr.yaml
+++ b/.github/workflows/agnosticv-operator-pr.yaml
@@ -19,19 +19,19 @@ jobs:
     env:
       IMAGE_TAGS: ${{ vars.BABYLON_IMAGE_REGISTRY }}/${{ vars.BABYLON_IMAGE_REPOSITORY }}/babylon-agnosticv-operator:${{ github.sha }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
         if: env.IMAGE_TAGS
       - name: Login to registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: env.IMAGE_TAGS
         with:
           registry: ${{ vars.BABYLON_IMAGE_REGISTRY }}
           username: ${{ secrets.BABYLON_IMAGE_REGISTRY_USERNAME }}
           password: ${{ secrets.BABYLON_IMAGE_REGISTRY_PASSWORD }}
       - name: Build and publish image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         if: env.IMAGE_TAGS
         with:
           context: agnosticv-operator

--- a/.github/workflows/agnosticv-operator-publish.yaml
+++ b/.github/workflows/agnosticv-operator-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Get image tags
       id: image_tags
@@ -36,7 +36,7 @@ jobs:
     - name: Buildah Action
       id: buildah-build
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
@@ -46,7 +46,7 @@ jobs:
     - name: Push image to registry
       id: push-to-registry
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}

--- a/.github/workflows/catalog-api-publish.yaml
+++ b/.github/workflows/catalog-api-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Get image tags
       id: image_tags
@@ -42,11 +42,11 @@ jobs:
         fi
 
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       if: steps.image_tags.outputs.IMAGE_TAGS
 
     - name: Login to image registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         registry: ${{ secrets.REGISTRY_URI }}
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
     - name: Build and publish image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         context: catalog/api

--- a/.github/workflows/catalog-manager-publish.yaml
+++ b/.github/workflows/catalog-manager-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Get image tags
       id: image_tags
@@ -42,11 +42,11 @@ jobs:
         fi
 
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       if: steps.image_tags.outputs.IMAGE_TAGS
 
     - name: Login to image registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         registry: ${{ secrets.REGISTRY_URI }}
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
     - name: Build and publish image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         context: catalog-manager

--- a/.github/workflows/catalog-status-publish.yaml
+++ b/.github/workflows/catalog-status-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Get image tags
         id: image_tags
@@ -48,11 +48,11 @@ jobs:
           fi
 
       - name: Set up buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
         if: steps.image_tags.outputs.IMAGE_TAGS
 
       - name: Login to redhat.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REDHAT_REGISTRY_URI }}
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
 
       - name: Login to quay.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
       - name: Build and publish image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}

--- a/.github/workflows/catalog-ui-pr.yaml
+++ b/.github/workflows/catalog-ui-pr.yaml
@@ -20,13 +20,13 @@ jobs:
         os: ["ubuntu-latest"]
         node: ["22"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6
         with:
           version: 11.1.2
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"
@@ -48,26 +48,26 @@ jobs:
       CONTAINER_NAME: ui
       IMAGE_TAGS: ${{ secrets.REGISTRY_URI }}/${{ secrets.GPTE_REGISTRY_REPOSITORY }}/babylon-catalog-ui:${{ github.sha }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
         if: env.IMAGE_TAGS
       - name: Login to redhat.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: env.IMAGE_TAGS
         with:
           registry: ${{ secrets.REDHAT_REGISTRY_URI }}
           username: ${{ secrets.REDHAT_REGISTRY_USERNAME }}
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
       - name: Login to quay.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: env.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}
           username: ${{ secrets.GPTE_REGISTRY_USERNAME }}
           password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
       - name: Build and publish image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         if: env.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}

--- a/.github/workflows/catalog-ui-publish.yaml
+++ b/.github/workflows/catalog-ui-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Get image tags
         id: image_tags
@@ -48,11 +48,11 @@ jobs:
           fi
 
       - name: Set up buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
         if: steps.image_tags.outputs.IMAGE_TAGS
 
       - name: Login to redhat.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REDHAT_REGISTRY_URI }}
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
 
       - name: Login to quay.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
       - name: Build and publish image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}

--- a/.github/workflows/cost-tracker-publish.yaml
+++ b/.github/workflows/cost-tracker-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Get image tags
       id: image_tags
@@ -42,11 +42,11 @@ jobs:
         fi
 
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       if: steps.image_tags.outputs.IMAGE_TAGS
 
     - name: Login to image registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         registry: ${{ secrets.REGISTRY_URI }}
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
     - name: Build and publish image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         context: cost-tracker

--- a/.github/workflows/lab-ui-manager-publish.yaml
+++ b/.github/workflows/lab-ui-manager-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Get image tags
       id: image_tags
@@ -42,11 +42,11 @@ jobs:
         fi
 
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       if: steps.image_tags.outputs.IMAGE_TAGS
 
     - name: Login to image registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # v1.9.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         registry: ${{ secrets.REGISTRY_URI }}
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.GPTE_REGISTRY_PASSWORD }}
 
     - name: Build and publish image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
         context: lab-ui-manager

--- a/.github/workflows/notifier-publish.yaml
+++ b/.github/workflows/notifier-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@master
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Get image tags
       id: image_tags
@@ -36,7 +36,7 @@ jobs:
     - name: Buildah Action
       id: buildah-build
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
@@ -46,7 +46,7 @@ jobs:
     - name: Push image to registry
       id: push-to-registry
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
 
     - name: Checkout gh-pages
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         path: gh-pages
         ref: gh-pages
 
     - name: Configure Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       with:
         version: v3.11.1
 

--- a/.github/workflows/ratings-publish.yaml
+++ b/.github/workflows/ratings-publish.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push
         if: steps.image_tags.outputs.IMAGE_TAGS
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ratings
           file: ratings/Dockerfile

--- a/.github/workflows/ratings-publish.yaml
+++ b/.github/workflows/ratings-publish.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get image tags
         id: image_tags
@@ -53,13 +53,13 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
           version: latest
         if: steps.image_tags.outputs.IMAGE_TAGS
 
       - name: Login to Image Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         if: steps.image_tags.outputs.IMAGE_TAGS
         with:
           registry: ${{ secrets.REGISTRY_URI }}

--- a/.github/workflows/service-access-manager-publish.yaml
+++ b/.github/workflows/service-access-manager-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@master
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Get image tags
       id: image_tags
@@ -36,7 +36,7 @@ jobs:
     - name: Buildah Action
       id: buildah-build
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
@@ -46,7 +46,7 @@ jobs:
     - name: Push image to registry
       id: push-to-registry
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}

--- a/.github/workflows/workshop-manager-publish.yaml
+++ b/.github/workflows/workshop-manager-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@master
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Get image tags
       id: image_tags
@@ -36,7 +36,7 @@ jobs:
     - name: Buildah Action
       id: buildah-build
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
@@ -46,7 +46,7 @@ jobs:
     - name: Push image to registry
       id: push-to-registry
       if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}


### PR DESCRIPTION
Pin docker/build-push-action to 10e90e3 (v6.19.2) to resolve CodeQL actions/unpinned-tag warning. Using a mutable tag for a 3rd party Action can lead to supply chain attacks.