### PR TITLE
fix: Add missing RBAC permissions for selfpacedlab-manager

### DIFF
--- a/helm/templates/selfpacedlabManager/clusterrole.yaml
+++ b/helm/templates/selfpacedlabManager/clusterrole.yaml
@@ -13,6 +13,14 @@ metadata:
     app.kubernetes.io/component: selfpacedlab-manager
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -88,4 +96,5 @@ rules:
   verbs:
   - get
   - list
+  - watch
 {{- end }}

--- a/selfpacedlab-manager/helm/templates/rbac.yaml
+++ b/selfpacedlab-manager/helm/templates/rbac.yaml
@@ -90,6 +90,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 {{ if .Values.deploy }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The kopf operator requires list/watch access to customresourcedefinitions in the apiextensions.k8s.io API group to discover CRDs and set up resource watches. This permission was present in the standalone chart but missing from the main babylon helm chart, causing repeated 403 errors on startup.

Also adds the missing watch verb on resourceproviders in both charts, which contributed to the "Not enough permissions to watch" warning.