### PR TITLE
Potential fix for code scanning alert no. 22: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -446,11 +446,20 @@ class WebhookServer:
             "repositories": results
         }, status=200)
     
+    def _sanitize_for_log(self, value):
+        """Sanitize user-controlled values to prevent log injection."""
+        if value is None:
+            return ''
+        return str(value).replace('\r', '').replace('\n', '')
+
     async def trigger_pr_processing(self, agnosticv_repo, pr_number, head_ref, head_sha, action):
         """Process a single specific PR for webhook events"""
         try:
             logger = logging.getLogger(f'webhook.{agnosticv_repo.name}.pr{pr_number}')
-            logger.info(f"PR {action}: #{pr_number} ({head_ref} -> {head_sha})")
+            safe_action = self._sanitize_for_log(action)
+            safe_head_ref = self._sanitize_for_log(head_ref)
+            safe_head_sha = self._sanitize_for_log(head_sha)
+            logger.info(f"PR {safe_action}: #{pr_number} ({safe_head_ref} -> {safe_head_sha})")
             
             # Process only this specific PR
             async with agnosticv_repo.lock:
@@ -461,7 +470,7 @@ class WebhookServer:
                     logger=logger
                 )
             
-            logger.info(f"PR {action} processing completed for #{pr_number}")
+            logger.info(f"PR {safe_action} processing completed for #{pr_number}")
             
         except Exception as e:
             self.logger.error(f"Error processing PR {pr_number}: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/22](https://github.com/redhat-cop/babylon/security/code-scanning/22)

The best fix is to sanitize untrusted values before writing them to logs, specifically removing `\r` and `\n` (and optionally ensuring `None`/non-strings are safely stringified).  
In this snippet, the highest-value minimal change is in `agnosticv-operator/operator/webhook_server.py` at `trigger_pr_processing` (around lines 449–454), right before the vulnerable `logger.info(...)`.

Implement a small helper method inside `WebhookServer` (e.g., `_sanitize_for_log`) that:
- accepts any value,
- converts it to string (empty string for `None`),
- strips `\r` and `\n`.

Then use that helper for `action`, `head_ref`, and `head_sha` in the line 453 log message. This preserves functionality while preventing forged multiline log entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
