### PR TITLE
Potential fix for code scanning alert no. 21: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -251,8 +251,9 @@ class WebhookServer:
         try:
             # Create a logger for this operation
             logger = logging.getLogger(f'webhook.{agnosticv_repo.name}')
+            safe_branch_name = str(branch_name).replace('\r', '').replace('\n', '')
             
-            logger.info(f"Webhook triggered update for {agnosticv_repo.name}#{branch_name}")
+            logger.info(f"Webhook triggered update for {agnosticv_repo.name}#{safe_branch_name}")
             
             # Acquire lock and trigger update (skip PR processing for push events)
             async with agnosticv_repo.lock:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/21](https://github.com/redhat-cop/babylon/security/code-scanning/21)

General fix: sanitize untrusted values before writing them to logs, especially removing `\r` and `\n` (and optionally other control chars) so user-controlled input cannot create forged multi-line log entries.

Best minimal fix here: sanitize `branch_name` in `trigger_repo_update` right before logging, without changing functional behavior for repo processing. This keeps the operational value (`branch_name`) unchanged for update logic while using a safe, log-only representation.

Edit only `agnosticv-operator/operator/webhook_server.py` in `trigger_repo_update` around line 255:
- Introduce a local `safe_branch_name = str(branch_name).replace('\r', '').replace('\n', '')`
- Use `safe_branch_name` in the log message at line 255.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
