### PR TITLE
Potential fix for code scanning alert no. 20: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -16,6 +16,10 @@ from .pagination import get_pagination_params
 logger = logging.getLogger('babylon-ratings')
 
 
+def _sanitize_for_log(value: str) -> str:
+    return value.replace('\r', '').replace('\n', '')
+
+
 tags = ["ratings"]
 
 router = APIRouter(tags=tags)
@@ -200,7 +204,8 @@ async def request_rating_post(request_uid: str,
             response_model=WorkshopRequestSchema,
             summary="Get request ID by workshop ID")
 async def workshop_rating_get(workshop_id: str) -> WorkshopRequestSchema:
-    logger.info(f"Getting request ID for workshop {workshop_id}")
+    safe_workshop_id = _sanitize_for_log(workshop_id)
+    logger.info(f"Getting request ID for workshop {safe_workshop_id}")
     request = await ProvisionRequest.get_request_workshop(workshop_id)
     if not request:
         raise HTTPException(status_code=404, detail="Workshop not found")


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/20](https://github.com/redhat-cop/babylon/security/code-scanning/20)

To fix log injection, sanitize untrusted values before writing them to logs, removing newline/control characters that can break log boundaries.

Best fix in this file: add a small helper function that strips `\r` and `\n` from untrusted strings, and use it for `workshop_id` in `workshop_rating_get` before logging. This preserves functionality (same endpoint behavior and lookup key) while making the log message safe.  
Changes needed in `ratings/api/routers/ratings.py`:
1. Add a helper (near logger declaration) such as `_sanitize_for_log(value: str) -> str`.
2. In `workshop_rating_get`, sanitize `workshop_id` only for logging and keep original `workshop_id` for business logic/database call.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
