### PR TITLE
Potential fix for code scanning alert no. 19: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -16,6 +16,10 @@ from .pagination import get_pagination_params
 logger = logging.getLogger('babylon-ratings')
 
 
+def _sanitize_for_log(value: str) -> str:
+    return value.replace('\r', '').replace('\n', '')
+
+
 tags = ["ratings"]
 
 router = APIRouter(tags=tags)
@@ -184,7 +188,8 @@ async def request_rating_post(request_uid: str,
                               new_rating: RatingCreateSchema,
                               include_details: bool = False) -> RatingSchema:
 
-    logger.info(f"Creating or updating rating for request {request_uid}")
+    safe_request_uid = _sanitize_for_log(request_uid)
+    logger.info(f"Creating or updating rating for request {safe_request_uid}")
     rating = Rating.from_dict(new_rating.model_dump())
     rating.request_id = request_uid
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/19](https://github.com/redhat-cop/babylon/security/code-scanning/19)

General fix: sanitize untrusted values before writing them to logs, removing line-break/control characters that can forge log entries. Prefer a single helper so behavior is consistent and reusable.

Best fix for this file: add a small helper in `ratings/api/routers/ratings.py` (near logger setup) to strip `\r` and `\n`, and use it in the vulnerable log statement at line 187. This keeps functionality unchanged while preventing log-forging via newline injection.

Changes needed:
- In `ratings/api/routers/ratings.py`, define a private sanitizer function (e.g., `_sanitize_for_log`).
- Update the line in `request_rating_post` to log a sanitized `request_uid`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
