### PR TITLE
Potential fix for code scanning alert no. 12: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -29,7 +29,8 @@ async def catalog_item_rating_get(asset_uuid: str,
                                   include_details: bool = False
                                   ) -> CatalogItemRatingAverageSchema:
 
-    logger.info(f"Getting rating for catalog item {asset_uuid}")
+    safe_asset_uuid = asset_uuid.replace('\r', '').replace('\n', '')
+    logger.info(f"Getting rating for catalog item {safe_asset_uuid}")
     rating = await Rating.catalog_item_average(asset_uuid,
                                                catalog_name,
                                                include_details)


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/12](https://github.com/redhat-cop/babylon/security/code-scanning/12)

To fix log injection, sanitize untrusted input before writing it to logs by removing newline/control characters that can break log structure (at minimum `\r` and `\n`; ideally all ASCII control chars).  
The best minimal fix here is to sanitize `asset_uuid` right before logging and log the sanitized value, preserving endpoint behavior and response data.

**Change needed in** `ratings/api/routers/ratings.py`:
- In `catalog_item_rating_get`, before line 32 logging call, create a sanitized log-safe variable derived from `asset_uuid`.
- Replace the existing log line to use that sanitized variable.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
