### PR TITLE
Potential fix for code scanning alert no. 18: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -172,7 +172,8 @@ async def request_rating_get(request_uid: str,
                              include_details: bool = False
                              ) -> Optional[List[RatingSchema]]:
 
-    logger.info(f"Getting rating for request {request_uid}")
+    safe_request_uid = _sanitize_for_log(request_uid)
+    logger.info(f"Getting rating for request {safe_request_uid}")
     ratings = await Rating.get_request_id(request_uid)
 
     if not ratings:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/18](https://github.com/redhat-cop/babylon/security/code-scanning/18)

The best fix is to sanitize all user-controlled values before writing them to logs, specifically removing line-break/control characters that enable log forging. In this file, the safest minimal fix (without changing behavior) is to follow the same existing pattern already used in `request_rating_post` and `workshop_rating_get`: create a sanitized variable and log that instead of raw input.

Change required in `ratings/api/routers/ratings.py`:
- In `request_rating_get` (around lines 171–176), sanitize `request_uid` before logging.
- Keep business logic unchanged: still query using original `request_uid`; only log uses sanitized value.

No new imports or dependencies are needed, since `_sanitize_for_log` is already used in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
