### PR TITLE
Potential fix for code scanning alert no. 17: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -156,7 +156,9 @@ async def request_rating_by_email_get(request_uid: str,
                                       include_details: bool = False
                                       ) -> RatingSchema:
 
-    logger.info(f"Getting rating for request {request_uid} and email {email}")
+    safe_request_uid = _sanitize_for_log(request_uid)
+    safe_email = _sanitize_for_log(email)
+    logger.info(f"Getting rating for request {safe_request_uid} and email {safe_email}")
     rating = await Rating.get_request_rating_by_email(request_uid, email)
 
     if not rating:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/17](https://github.com/redhat-cop/babylon/security/code-scanning/17)

General fix: sanitize user-controlled values before writing them into log messages, especially removing `\r` and `\n` (and typically other control chars if desired), then log only sanitized values.

Best minimal fix here (without changing functionality): in `ratings/api/routers/ratings.py`, inside `request_rating_by_email_get`, sanitize both `request_uid` and `email` using the existing `_sanitize_for_log(...)` helper already used elsewhere in this file, and log those sanitized variables. Keep business logic unchanged (still query using original values).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
