### PR TITLE
Potential fix for code scanning alert no. 16: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -136,7 +136,8 @@ async def provision_rating_post(provision_uuid: str,
                                 new_rating: RatingProvisionCreateSchema,
                                 include_details: bool = False) -> RatingSchema:
 
-    logger.info(f"Creating or updating rating for provision {provision_uuid}")
+    safe_provision_uuid = _sanitize_for_log(provision_uuid)
+    logger.info(f"Creating or updating rating for provision {safe_provision_uuid}")
     rating = Rating.from_dict(new_rating.model_dump())
     rating.provision_uuid = provision_uuid
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/16](https://github.com/redhat-cop/babylon/security/code-scanning/16)

The best fix is to sanitize `provision_uuid` before it is written to logs, while keeping business behavior unchanged. We should follow the same pattern already used in this file (`_sanitize_for_log`) to ensure consistency and minimal change.

In `ratings/api/routers/ratings.py`, inside `provision_rating_post`:
- Create a local `safe_provision_uuid = _sanitize_for_log(provision_uuid)` immediately before logging.
- Update the `logger.info(...)` call to use `safe_provision_uuid`.
- Keep `rating.provision_uuid = provision_uuid` unchanged so persistence/business logic still uses the original value.

No new imports or dependencies are needed if `_sanitize_for_log` already exists in the file (as implied by lines 159–160).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
