### PR TITLE
Potential fix for code scanning alert no. 15: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -119,7 +119,9 @@ async def provision_rating_by_email_get(provision_uuid: str,
                                         include_details: bool = False
                                         ) -> RatingSchema:
 
-    logger.info(f"Getting rating for request {provision_uuid} and email {email}")
+    safe_provision_uuid = _sanitize_for_log(provision_uuid)
+    safe_email = _sanitize_for_log(email)
+    logger.info(f"Getting rating for request {safe_provision_uuid} and email {safe_email}")
     rating = await Rating.get_provision_rating_by_email(provision_uuid, email)
 
     if not rating:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/15](https://github.com/redhat-cop/babylon/security/code-scanning/15)

To fix log injection safely, sanitize all user-provided values before writing them to logs, removing `\r` and `\n` (at minimum) so attackers cannot break log line structure.

Best fix here (without changing behavior): in `ratings/api/routers/ratings.py`, inside `provision_rating_by_email_get`, sanitize `provision_uuid` and `email` using the existing `_sanitize_for_log` helper, then log the sanitized values. This addresses both CodeQL variants (taint from `provision_uuid` and from `email`) at the same sink with one change. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
