### PR TITLE
Potential fix for code scanning alert no. 14: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -73,7 +73,8 @@ async def catalog_item_rating_history_get(asset_uuid: str,
 async def list_ratings_get(pagination: dict = Depends(get_pagination_params),
                            include_details: bool = False) -> List[RatingsListSchema]:
 
-    logger.info(f"Getting ratings list with pagination: {pagination}")
+    safe_pagination = _sanitize_for_log(str(pagination))
+    logger.info(f"Getting ratings list with pagination: {safe_pagination}")
     page = pagination["page"]
     per_page = pagination["per_page"]
     ratings_list = await Rating.list_ratings_paged(page,


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/14](https://github.com/redhat-cop/babylon/security/code-scanning/14)

General fix: never log raw user-controlled values. Sanitize log-bound data by removing CR/LF (and optionally coercing to safe string representations) before interpolation.

Best fix here without changing behavior: reuse the already-defined helper `_sanitize_for_log` and apply it to the `pagination` object converted to string at the logging point in `list_ratings_get`. This is minimal and keeps functionality unchanged (still logs pagination content, but safely).  
Change needed in `ratings/api/routers/ratings.py` at line 76 region:

- Replace:
  - `logger.info(f"Getting ratings list with pagination: {pagination}")`
- With:
  - `safe_pagination = _sanitize_for_log(str(pagination))`
  - `logger.info(f"Getting ratings list with pagination: {safe_pagination}")`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
