### PR TITLE
Potential fix for code scanning alert no. 13: Log Injection

### DIFF
--- a/ratings/api/routers/ratings.py
+++ b/ratings/api/routers/ratings.py
@@ -52,7 +52,8 @@ async def catalog_item_rating_history_get(asset_uuid: str,
                                           catalog_name: Optional[str] = None,
                                           include_details: bool = False
                                           ) -> List[RatingSchema]:
-    logger.info(f"Getting rating history for catalog item {asset_uuid}")
+    safe_asset_uuid = _sanitize_for_log(asset_uuid)
+    logger.info(f"Getting rating history for catalog item {safe_asset_uuid}")
     average_rating = await Rating.catalog_item_rating(asset_uuid,
                                                       catalog_name,
                                                       include_details)


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/13](https://github.com/redhat-cop/babylon/security/code-scanning/13)

To fix log injection, sanitize user-controlled values before logging by removing line-break/control characters (at minimum `\r` and `\n`) and log only the sanitized value.  
The best fix here is to reuse the existing helper `_sanitize_for_log` already defined in this file (lines 19–20), so behavior is consistent and no new dependency is needed.

Change in `ratings/api/routers/ratings.py`:
- In `catalog_item_rating_history_get` (around line 55), sanitize `asset_uuid` into a local variable and use that variable in `logger.info(...)`.
- Keep business logic unchanged: continue passing the original `asset_uuid` to data access methods so functionality is preserved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
