### PR TITLE
Potential fix for code scanning alert no. 30: Request without certificate validation

### DIFF
--- a/tools/babylon-status/status.py
+++ b/tools/babylon-status/status.py
@@ -12,9 +12,6 @@ import time
 from base64 import b64decode
 from datetime import datetime
 from pprint import pprint
-import urllib3
-
-urllib3.disable_warnings()
 
 def get_tower_api_config():
     tower_secret = core_v1_api.read_namespaced_secret('babylon-tower', 'anarchy-operator')
@@ -27,8 +24,7 @@ def get_tower_job(tower_api, job_id):
     tower_job_url = "https://{0}/api/v2/jobs/{1}/".format(tower_api['hostname'], job_id)
     resp = requests.get(
        tower_job_url,
-       auth=requests.auth.HTTPBasicAuth(tower_api['user'], tower_api['password']),
-       verify=False
+       auth=requests.auth.HTTPBasicAuth(tower_api['user'], tower_api['password'])
     )
     return resp.json()
 


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/30](https://github.com/redhat-cop/babylon/security/code-scanning/30)

The correct fix is to stop disabling certificate verification and use verified TLS instead. The safest minimal change that preserves functionality is:

- Remove `verify=False` from the `requests.get(...)` call so `requests` uses its default secure behavior (`verify=True`).
- Remove the global TLS warning suppression (`urllib3.disable_warnings()`), since warnings should not be suppressed when verification is enabled.

In this snippet, edit `tools/babylon-status/status.py`:
1. Delete the `verify=False` argument in `get_tower_job`.
2. Remove `import urllib3` and the `urllib3.disable_warnings()` call, as they are no longer needed.

No behavior change is introduced beyond enforcing certificate validation (the intended secure behavior).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
