### PR TITLE
[1/4] Reorganize help menu and rename feedback link

### DIFF
--- a/catalog/ui/src/app/Header/Header.tsx
+++ b/catalog/ui/src/app/Header/Header.tsx
@@ -76,6 +76,8 @@ const Header: React.FC<{
   };
 
   const userHelpDropdownItems = [];
+
+  // 1. Main help link (RHDP Support)
   if (helpLink) {
     userHelpDropdownItems.push(
       <DropdownItem key="open-support" value={helpLink}>
@@ -84,14 +86,25 @@ const Header: React.FC<{
     );
   }
 
-  if (status_page_url) {
+  // 2. Feedback/Feature Request (moved here, renamed)
+  if (feedback_link) {
     userHelpDropdownItems.push(
-        <DropdownItem key="status-page-link" value={status_page_url}>
-          Status Page
-        </DropdownItem>,
-      );
+      <DropdownItem key="feedback" value={feedback_link}>
+        Feedback/Feature Request
+      </DropdownItem>,
+    );
   }
 
+  // 3. Status Page
+  if (status_page_url) {
+    userHelpDropdownItems.push(
+      <DropdownItem key="status-page-link" value={status_page_url}>
+        Status Page
+      </DropdownItem>,
+    );
+  }
+
+  // 4. Solution Support: Service Level (RHPDS only)
   if (userInterface === 'rhpds') {
     userHelpDropdownItems.push(
       <DropdownItem key="support-sla" value="/support">
@@ -99,6 +112,8 @@ const Header: React.FC<{
       </DropdownItem>,
     );
   }
+
+  // 5. About RHDP
   if (learn_more_link) {
     userHelpDropdownItems.push(
       <DropdownItem key="learn-more" value={learn_more_link}>
@@ -106,6 +121,8 @@ const Header: React.FC<{
       </DropdownItem>,
     );
   }
+
+  // 6. How to videos (RHPDS only)
   if (userInterface === 'rhpds') {
     userHelpDropdownItems.push(
       <DropdownItem
@@ -113,13 +130,6 @@ const Header: React.FC<{
         value="https://videos.learning.redhat.com/channel/RHPDS%2B-%2BRed%2BHat%2BProduct%2Band%2BPortfolio%2BDemo%2BSystem/277722533"
       >
         How to videos
-      </DropdownItem>,
-    );
-  }
-  if (feedback_link) {
-    userHelpDropdownItems.push(
-      <DropdownItem key="feedback" value={feedback_link}>
-        RHDP Support - Feedback/Feature Request
       </DropdownItem>,
     );
   }

--- a/catalog/ui/src/app/Header/Header.tsx
+++ b/catalog/ui/src/app/Header/Header.tsx
@@ -86,7 +86,6 @@ const Header: React.FC<{
     );
   }
 
-  // 2. Feedback/Feature Request (moved here, renamed)
   if (feedback_link) {
     userHelpDropdownItems.push(
       <DropdownItem key="feedback" value={feedback_link}>


### PR DESCRIPTION
## Summary
- Move Feedback/Feature Request link to appear directly under RHDP Support
- Position it above Status Page for better grouping
- Rename from "RHDP Support - Feedback/Feature Request" to "Feedback/Feature Request"

## Changes
- Reordered help menu dropdown items in Header.tsx
- Moved feedback link from last position to second position
- Renamed for clarity (removed redundant "RHDP Support" prefix)

## New Help Menu Order
1. RHDP Support
2. Feedback/Feature Request ← **moved here, renamed**
3. Status Page
4. Solution Support: Service Level
5. About RHDP  
6. How to videos

## Testing
- ✅ Help menu displays items in new order
- ✅ Feedback link renamed correctly
- ✅ All links functional
- ✅ Works across different interfaces
- ✅ Mobile view displays correctly

## Impact
- Better logical grouping of support-related items
- Clearer naming reduces confusion
- No functional changes, UI reorganization only

🤖 Generated with [Claude Code](https://claude.com/claude-code)