### PR TITLE
[5/5] Add timeline calendar view for workshop scheduling

### DIFF
--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -1949,6 +1949,9 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
+                  <p className="ops-desc" style={{ fontSize: '0.8rem', color: 'var(--pf-t--global--text--color--subtle)', marginBottom: 8 }}>
+                    <em>Auto-stop scheduling coming soon</em>
+                  </p>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extStopDays} min={0}
                       onMinus={() => setExtStopDays(Math.max(0, extStopDays - 1))}

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -111,7 +111,9 @@ import {
   workshopCalendarLocalizer,
   workshopToCalendarEventOps,
 } from '@app/Admin/workshopCalendarEvents';
-import { WorkshopTimeline } from '@app/Admin/Ops/WorkshopTimeline';
+import WorkshopTimeline from '@app/Admin/Ops/WorkshopTimeline';
+// Force webpack to include Timeline
+if (typeof window !== 'undefined') (window as any).__TIMELINE__ = WorkshopTimeline;
 
 import './admin.css';
 import './ops.css';

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -2246,7 +2246,10 @@ const Ops: React.FC = () => {
               )}
               {workshopView === 'timeline' && (
                 <WorkshopTimeline
-                  workshops={targets}
+                  workshops={targets.map(ws => ({
+                    ...ws,
+                    resourceClaims: resourceClaimsByWorkshop.get(wsKey(ws)) || []
+                  }))}
                   selectedWorkshops={selectedWs}
                   onSelectWorkshop={(id, selected) => {
                     setSelectedWs(prev => {

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -1951,9 +1951,6 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
-                  <Alert variant="info" isInline title="Feature coming soon" style={{ marginBottom: 12 }}>
-                    <p>Automated stop scheduling will allow setting future stop times when creating workshops.</p>
-                  </Alert>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extStopDays} min={0}
                       onMinus={() => setExtStopDays(Math.max(0, extStopDays - 1))}
@@ -1983,9 +1980,6 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
-                  <Alert variant="info" isInline title="Feature coming soon" style={{ marginBottom: 12 }}>
-                    <p>Automated destroy scheduling will allow setting future destroy times when creating workshops.</p>
-                  </Alert>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extDestroyDays} min={0}
                       onMinus={() => setExtDestroyDays(Math.max(0, extDestroyDays - 1))}

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -317,7 +317,7 @@ const SCHEDULE_FILTER_CHIPS: { label: string; value: OpsScheduleFilterKey }[] = 
 
 let alertKeyCounter = 0;
 
-function dateUrgency(iso?: string): 'critical' | 'warning' | 'ok' | null {
+export function dateUrgency(iso?: string): 'critical' | 'warning' | 'ok' | null {
   if (!iso) return null;
   const remaining = new Date(iso).getTime() - Date.now();
   if (remaining < 0) return 'critical';
@@ -326,7 +326,7 @@ function dateUrgency(iso?: string): 'critical' | 'warning' | 'ok' | null {
   return 'ok';
 }
 
-function relativeTime(iso: string): string {
+export function relativeTime(iso: string): string {
   const diff = new Date(iso).getTime() - Date.now();
   if (diff < 0) {
     const ago = Math.abs(diff);
@@ -2290,12 +2290,24 @@ const Ops: React.FC = () => {
                       return next;
                     });
                   }}
+                  onBatchSelect={(keys) => {
+                    setSelectedWs(new Set(keys));
+                  }}
+                  onDeselectAll={() => {
+                    setSelectedWs(new Set());
+                  }}
                   onClickWorkshop={(id) => {
                     const workshop = targets.find(ws => wsKey(ws) === id);
                     if (workshop) {
                       navigate(wsDetailPath(workshop));
                     }
                   }}
+                  getSeats={getSeats}
+                  getProvisionProgress={getProvisionProgress}
+                  getCurrentCount={getCurrentCount}
+                  multiWorkshopsByName={multiWorkshopsByName}
+                  isMultiNs={isMultiNs}
+                  timezone={timezone}
                 />
               )}
               {workshopView === 'table' && (

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -73,7 +73,6 @@ import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import MoonIcon from '@patternfly/react-icons/dist/js/icons/moon-icon';
 import SunIcon from '@patternfly/react-icons/dist/js/icons/sun-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/js/icons/sort-amount-down-icon';
-import RedoIcon from '@patternfly/react-icons/dist/js/icons/redo-icon';
 
 import {
   apiPaths,
@@ -991,28 +990,6 @@ const Ops: React.FC = () => {
   }, [effectiveTargets, getCurrentCount, getSeats, getFailedCount]);
 
   const failedInstancesAnalysis = useMemo(() => {
-<<<<<<< HEAD
-    const failedWorkshops: Array<{
-      workshop: Workshop;
-      namespace: string;
-      failedClaims: ResourceClaim[];
-      failedCount: number;
-    }> = [];
-
-    for (const ws of operationTargets) {
-      const claims = resourceClaimsByWorkshop.get(wsKey(ws)) || [];
-      const failedClaims = claims.filter(rc =>
-        !rc.metadata.deletionTimestamp && isResourceClaimFailed(rc)
-      );
-
-      if (failedClaims.length > 0) {
-        failedWorkshops.push({
-          workshop: ws,
-          namespace: ws.metadata.namespace,
-          failedClaims,
-          failedCount: failedClaims.length,
-        });
-=======
     const failedWorkshops: { workshop: Workshop; failedClaims: ResourceClaim[]; failedCount: number; jobUrls: string[] }[] = [];
     const allJobUrls: string[] = [];
 
@@ -1035,17 +1012,13 @@ const Ops: React.FC = () => {
         const jobUrls = failedClaims.map(getProvisionJobUrl).filter((url): url is string => url !== null);
         allJobUrls.push(...jobUrls);
         failedWorkshops.push({ workshop: ws, failedClaims, failedCount: failedClaims.length, jobUrls });
->>>>>>> e620f7c2 (feat(ops): add bulk open AAP2 jobs for failed instances)
       }
     }
 
     return {
       totalFailed: failedWorkshops.reduce((sum, fw) => sum + fw.failedCount, 0),
       failedWorkshops,
-<<<<<<< HEAD
-=======
       allJobUrls,
->>>>>>> e620f7c2 (feat(ops): add bulk open AAP2 jobs for failed instances)
     };
   }, [operationTargets, resourceClaimsByWorkshop]);
 
@@ -1397,7 +1370,6 @@ const Ops: React.FC = () => {
     else addAlert(AlertVariant.danger, `Scale: ${ok} succeeded, ${fail} failed`);
   };
 
-<<<<<<< HEAD
   const handleRedeployFailed = async () => {
     setShowRedeployConfirm(false);
     setRedeployLoading(true);
@@ -1434,7 +1406,9 @@ const Ops: React.FC = () => {
         AlertVariant.danger,
         `Redeploy: ${succeeded} succeeded, ${failed} failed`,
       );
-=======
+    }
+  };
+
   const handleOpenFailedJobs = (urls: string[], batchSize = 10) => {
     const toOpen = urls.slice(0, batchSize);
     toOpen.forEach((url) => window.open(url, '_blank'));
@@ -1443,7 +1417,6 @@ const Ops: React.FC = () => {
       addAlert(AlertVariant.info, `Opened ${batchSize} jobs. ${urls.length - batchSize} remaining.`);
     } else {
       addAlert(AlertVariant.success, `Opened ${urls.length} AAP2 job(s) in new tabs`);
->>>>>>> e620f7c2 (feat(ops): add bulk open AAP2 jobs for failed instances)
     }
   };
 
@@ -1585,7 +1558,7 @@ const Ops: React.FC = () => {
           <SplitItem>
             <ProjectSelector
               currentNamespaceName={namespace}
-              onSelect={(n) => { setWorkshopFilter(''); setWorkshopSearchText(''); navigate(`/admin/ops/${n.name}`); }}
+              onSelect={(n) => { setWorkshopSearchText(''); navigate(`/admin/ops/${n.name}`); }}
             />
           </SplitItem>
           <SplitItem isFilled>
@@ -2093,35 +2066,25 @@ const Ops: React.FC = () => {
               {/* Redeploy Failed Services */}
               <Card isFullHeight className="ops-redeploy-failed">
                 <CardTitle>
-<<<<<<< HEAD
-                  <RedoIcon className="ops-card-icon" /> Redeploy Failed Services
-=======
                   <RedoIcon className="ops-card-icon" />
                   Redeploy Failed Services
->>>>>>> e620f7c2 (feat(ops): add bulk open AAP2 jobs for failed instances)
                 </CardTitle>
                 <CardBody>
                   {failedInstancesAnalysis.totalFailed > 0 ? (
                     <>
-<<<<<<< HEAD
                       <p style={{ marginBottom: 'var(--pf-t--global--spacer--sm)' }}>
                         Found <strong>{failedInstancesAnalysis.totalFailed}</strong> failed instance(s) across{' '}
                         <strong>{failedInstancesAnalysis.failedWorkshops.length}</strong> workshop(s)
                       </p>
-                      <Button
-                        variant="warning"
-                        onClick={() => setShowRedeployConfirm(true)}
-                        isLoading={redeployLoading}
-                        isDisabled={anyLoading}
-                      >
-                        Redeploy Failed Services
-                      </Button>
-=======
-                      <p>
-                        Found <strong>{failedInstancesAnalysis.totalFailed}</strong> failed instance(s)
-                        across <strong>{failedInstancesAnalysis.failedWorkshops.length}</strong> workshop(s)
-                      </p>
-                      <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', marginTop: 'var(--pf-t--global--spacer--md)' }}>
+                      <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)' }}>
+                        <Button
+                          variant="warning"
+                          onClick={() => setShowRedeployConfirm(true)}
+                          isLoading={redeployLoading}
+                          isDisabled={anyLoading}
+                        >
+                          Redeploy Failed Services
+                        </Button>
                         <Tooltip content={failedJobsTooltip}>
                           <Dropdown
                             isOpen={isBatchMenuOpen}
@@ -2153,7 +2116,6 @@ const Ops: React.FC = () => {
                           </Dropdown>
                         </Tooltip>
                       </div>
->>>>>>> e620f7c2 (feat(ops): add bulk open AAP2 jobs for failed instances)
                     </>
                   ) : (
                     <p className="ops-muted">No failed instances found</p>
@@ -2958,7 +2920,7 @@ const Ops: React.FC = () => {
             <ul style={{ marginTop: 'var(--pf-t--global--spacer--sm)', marginBottom: 'var(--pf-t--global--spacer--sm)' }}>
               {failedInstancesAnalysis.failedWorkshops.map(fw => (
                 <li key={wsKey(fw.workshop)}>
-                  <strong>{displayName(fw.workshop)}</strong> ({fw.namespace}): {fw.failedCount} failed
+                  <strong>{displayName(fw.workshop)}</strong> ({fw.workshop.metadata.namespace}): {fw.failedCount} failed
                 </li>
               ))}
             </ul>

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -1981,6 +1981,9 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
+                  <p className="ops-desc" style={{ fontSize: '0.8rem', color: 'var(--pf-t--global--text--color--subtle)', marginBottom: 8 }}>
+                    <em>Auto-destroy scheduling coming soon</em>
+                  </p>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extDestroyDays} min={0}
                       onMinus={() => setExtDestroyDays(Math.max(0, extDestroyDays - 1))}
@@ -2153,6 +2156,11 @@ const Ops: React.FC = () => {
                         of {targets.length} total
                       </span>
                     )}
+                    {summary.seatsAssigned > 0 && (
+                      <span style={{ marginLeft: 12, fontSize: '0.78rem', color: 'var(--pf-t--global--color--green--200)' }}>
+                        {summary.seatsAssigned}/{summary.seatsTotal} seats running
+                      </span>
+                    )}
                   </Title>
                 </SplitItem>
                 <SplitItem>
@@ -2191,6 +2199,29 @@ const Ops: React.FC = () => {
                       <span style={{ marginLeft: 6, fontSize: '0.85rem' }}>{showPasswords ? 'Hide passwords' : 'Show passwords'}</span>
                     </Button>
                   </SplitItem>
+                )}
+                {workshopView === 'timeline' && (
+                  <>
+                    <SplitItem>
+                      <Button
+                        variant="link"
+                        onClick={() => setSelectedWs(new Set(targets.map(wsKey)))}
+                        isDisabled={selectedWs.size === targets.length}
+                      >
+                        Select all
+                      </Button>
+                    </SplitItem>
+                    {hasSelection && (
+                      <SplitItem>
+                        <Button
+                          variant="link"
+                          onClick={() => setSelectedWs(new Set())}
+                        >
+                          Clear selection
+                        </Button>
+                      </SplitItem>
+                    )}
+                  </>
                 )}
                 <SplitItem>
                   <Tooltip content="Export to CSV">

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -91,6 +91,7 @@ import {
   ResourceClaim, ResourceClaimList,
   MultiWorkshop, MultiWorkshopList,
   ServiceNamespace,
+  WorkshopWithResourceClaims,
 } from '@app/types';
 import {
   displayName,
@@ -2249,7 +2250,7 @@ const Ops: React.FC = () => {
                   workshops={targets.map(ws => ({
                     ...ws,
                     resourceClaims: resourceClaimsByWorkshop.get(wsKey(ws)) || []
-                  }))}
+                  } as WorkshopWithResourceClaims))}
                   selectedWorkshops={selectedWs}
                   onSelectWorkshop={(id, selected) => {
                     setSelectedWs(prev => {

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -114,6 +114,7 @@ import { WorkshopTimeline } from '@app/Admin/Ops/WorkshopTimeline';
 
 import './admin.css';
 import './ops.css';
+import './Ops/timeline.css';
 import '!style-loader!css-loader!react-big-calendar/lib/css/react-big-calendar.css';
 
 interface OpsAlert {
@@ -2256,8 +2257,10 @@ const Ops: React.FC = () => {
                     });
                   }}
                   onClickWorkshop={(id) => {
-                    const [namespace, name] = id.split('/');
-                    navigate(`/workshops/${namespace}/${name}`);
+                    const workshop = targets.find(ws => wsKey(ws) === id);
+                    if (workshop) {
+                      navigate(wsDetailPath(workshop));
+                    }
                   }}
                 />
               )}

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -65,6 +65,7 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import DownloadIcon from '@patternfly/react-icons/dist/js/icons/download-icon';
 import TableIcon from '@patternfly/react-icons/dist/js/icons/table-icon';
 import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outlined-calendar-alt-icon';
+import ChartLineIcon from '@patternfly/react-icons/dist/js/icons/chart-line-icon';
 import ListIcon from '@patternfly/react-icons/dist/js/icons/list-icon';
 import StarIcon from '@patternfly/react-icons/dist/js/icons/star-icon';
 import RedoIcon from '@patternfly/react-icons/dist/js/icons/redo-icon';
@@ -109,6 +110,7 @@ import {
   workshopCalendarLocalizer,
   workshopToCalendarEventOps,
 } from '@app/Admin/workshopCalendarEvents';
+import { WorkshopTimeline } from '@app/Admin/Ops/WorkshopTimeline';
 
 import './admin.css';
 import './ops.css';
@@ -696,7 +698,7 @@ const Ops: React.FC = () => {
   const [sortMode, setSortMode] = useState<OpsSortMode>('start-asc');
   const [tablePage, setTablePage] = useState(1);
   const [tablePerPage, setTablePerPage] = useState(20); // Changed from OPS_GROUP_PAGE_DEFAULT (18) to align with pagination options
-  const [workshopView, setWorkshopView] = useState<'table' | 'calendar'>('table');
+  const [workshopView, setWorkshopView] = useState<'table' | 'calendar' | 'timeline'>('table');
 
   const targets = useMemo(() => {
     let list = workshops;
@@ -2166,6 +2168,14 @@ const Ops: React.FC = () => {
                         if (selected) setWorkshopView('calendar');
                       }}
                     />
+                    <ToggleGroupItem
+                      icon={<ChartLineIcon />}
+                      text="Timeline"
+                      isSelected={workshopView === 'timeline'}
+                      onChange={(_e, selected) => {
+                        if (selected) setWorkshopView('timeline');
+                      }}
+                    />
                   </ToggleGroup>
                 </SplitItem>
                 {workshopView === 'table' && (
@@ -2232,6 +2242,24 @@ const Ops: React.FC = () => {
                     />
                   )}
                 </div>
+              )}
+              {workshopView === 'timeline' && (
+                <WorkshopTimeline
+                  workshops={targets}
+                  selectedWorkshops={selectedWs}
+                  onSelectWorkshop={(id, selected) => {
+                    setSelectedWs(prev => {
+                      const next = new Set(prev);
+                      if (selected) next.add(id);
+                      else next.delete(id);
+                      return next;
+                    });
+                  }}
+                  onClickWorkshop={(id) => {
+                    const [namespace, name] = id.split('/');
+                    navigate(`/workshops/${namespace}/${name}`);
+                  }}
+                />
               )}
               {workshopView === 'table' && (
               <div className="ops-table-wrap">

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -1951,9 +1951,9 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
-                  <p className="ops-desc" style={{ fontSize: '0.8rem', color: 'var(--pf-t--global--text--color--subtle)', marginBottom: 8 }}>
-                    <em>Auto-stop scheduling coming soon</em>
-                  </p>
+                  <Alert variant="info" isInline title="Feature coming soon" style={{ marginBottom: 12 }}>
+                    <p>Automated stop scheduling will allow setting future stop times when creating workshops.</p>
+                  </Alert>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extStopDays} min={0}
                       onMinus={() => setExtStopDays(Math.max(0, extStopDays - 1))}
@@ -1983,9 +1983,9 @@ const Ops: React.FC = () => {
                   </Tooltip>
                 </CardTitle>
                 <CardBody>
-                  <p className="ops-desc" style={{ fontSize: '0.8rem', color: 'var(--pf-t--global--text--color--subtle)', marginBottom: 8 }}>
-                    <em>Auto-destroy scheduling coming soon</em>
-                  </p>
+                  <Alert variant="info" isInline title="Feature coming soon" style={{ marginBottom: 12 }}>
+                    <p>Automated destroy scheduling will allow setting future destroy times when creating workshops.</p>
+                  </Alert>
                   <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)', alignItems: 'center', flexWrap: 'wrap' }}>
                     <NumberInput value={extDestroyDays} min={0}
                       onMinus={() => setExtDestroyDays(Math.max(0, extDestroyDays - 1))}

--- a/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback } from 'react';
+import {
+  Button,
+  DatePicker,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+
+export interface TimelineControlsProps {
+  startDate: Date;
+  endDate: Date;
+  onDateChange: (start: Date, end: Date) => void;
+}
+
+function getMonday(d: Date): Date {
+  const date = new Date(d);
+  const day = date.getDay();
+  const diff = date.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(date.setDate(diff));
+}
+
+function getSunday(d: Date): Date {
+  const monday = getMonday(d);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return sunday;
+}
+
+function getStartOfDay(d: Date): Date {
+  const date = new Date(d);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function getEndOfDay(d: Date): Date {
+  const date = new Date(d);
+  date.setHours(23, 59, 59, 999);
+  return date;
+}
+
+export const TimelineControls: React.FC<TimelineControlsProps> = ({
+  startDate,
+  endDate,
+  onDateChange,
+}) => {
+  const handleToday = useCallback(() => {
+    const today = new Date();
+    onDateChange(getStartOfDay(today), getEndOfDay(today));
+  }, [onDateChange]);
+
+  const handleThisWeek = useCallback(() => {
+    const today = new Date();
+    const monday = getMonday(today);
+    const sunday = getSunday(today);
+    onDateChange(getStartOfDay(monday), getEndOfDay(sunday));
+  }, [onDateChange]);
+
+  const handleNextWeek = useCallback(() => {
+    const today = new Date();
+    const nextMonday = new Date(today);
+    nextMonday.setDate(today.getDate() + (7 - today.getDay() + 1));
+    const nextSunday = new Date(nextMonday);
+    nextSunday.setDate(nextMonday.getDate() + 6);
+    onDateChange(getStartOfDay(nextMonday), getEndOfDay(nextSunday));
+  }, [onDateChange]);
+
+  const handleThisMonth = useCallback(() => {
+    const today = new Date();
+    const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+    const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    onDateChange(getStartOfDay(firstDay), getEndOfDay(lastDay));
+  }, [onDateChange]);
+
+  const handleStartDateChange = useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+      if (value) {
+        const newStart = new Date(value);
+        if (!isNaN(newStart.getTime())) {
+          onDateChange(getStartOfDay(newStart), endDate);
+        }
+      }
+    },
+    [endDate, onDateChange]
+  );
+
+  const handleEndDateChange = useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+      if (value) {
+        const newEnd = new Date(value);
+        if (!isNaN(newEnd.getTime())) {
+          onDateChange(startDate, getEndOfDay(newEnd));
+        }
+      }
+    },
+    [startDate, onDateChange]
+  );
+
+  const formatDate = (date: Date): string => {
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <Toolbar>
+      <ToolbarContent>
+        <ToolbarGroup variant="button-group">
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleToday}>
+              Today
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleThisWeek}>
+              This Week
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleNextWeek}>
+              Next Week
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleThisMonth}>
+              This Month
+            </Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <DatePicker
+              value={startDate.toISOString().split('T')[0]}
+              onChange={handleStartDateChange}
+              aria-label="Start date"
+              placeholder="Start date"
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <DatePicker
+              value={endDate.toISOString().split('T')[0]}
+              onChange={handleEndDateChange}
+              aria-label="End date"
+              placeholder="End date"
+            />
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarItem>
+          <span style={{ whiteSpace: 'nowrap' }}>
+            {formatDate(startDate)} - {formatDate(endDate)}
+          </span>
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+};
+
+export default TimelineControls;

--- a/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
@@ -12,6 +12,7 @@ export interface TimelineControlsProps {
   startDate: Date;
   endDate: Date;
   onDateChange: (start: Date, end: Date) => void;
+  timezone: string;
 }
 
 function getMonday(d: Date): Date {
@@ -44,6 +45,7 @@ export const TimelineControls: React.FC<TimelineControlsProps> = ({
   startDate,
   endDate,
   onDateChange,
+  timezone,
 }) => {
   const handleToday = useCallback(() => {
     const today = new Date();
@@ -98,11 +100,9 @@ export const TimelineControls: React.FC<TimelineControlsProps> = ({
   );
 
   const formatDate = (date: Date): string => {
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+    if (timezone !== 'local') opts.timeZone = timezone;
+    return date.toLocaleDateString('en-US', opts);
   };
 
   return (

--- a/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineControls.tsx
@@ -108,7 +108,7 @@ export const TimelineControls: React.FC<TimelineControlsProps> = ({
   return (
     <Toolbar>
       <ToolbarContent>
-        <ToolbarGroup variant="button-group">
+        <ToolbarGroup>
           <ToolbarItem>
             <Button variant="secondary" onClick={handleToday}>
               Today

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -38,7 +38,7 @@ function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; 
   return { start, end };
 }
 
-function workshopsOverlap(w1: Workshop, w2: Workshop): boolean {
+function workshopsOverlap(w1: WorkshopWithResourceClaims, w2: WorkshopWithResourceClaims): boolean {
   const { start: s1, end: e1 } = getWorkshopDates(w1);
   const { start: s2, end: e2 } = getWorkshopDates(w2);
   return s1 < e2 && s2 < e1;

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -116,7 +116,7 @@ export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
             <div
               style={{
                 textAlign: 'center',
-                color: 'var(--pf-v5-global--Color--200)',
+                color: 'var(--pf-t--global--text--color--subtle, #6c757d)',
                 padding: '20px',
               }}
             >

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -115,38 +115,38 @@ export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
   if (workshops.length === 0) return null;
 
   return (
-    <div className={`tl-swimlane tl-swimlane--${status.toLowerCase()}`}>
+    <div className={`timeline-swimlane timeline-swimlane--${status.toLowerCase()}`}>
       <button
-        className="tl-swimlane__header"
+        className="timeline-swimlane__header"
         onClick={() => setIsExpanded(!isExpanded)}
         aria-expanded={isExpanded}
       >
-        <span className="tl-swimlane__toggle">
+        <span className="timeline-swimlane__toggle">
           {isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
         </span>
         <Checkbox
-          id={`tl-swimlane-cb-${status}`}
+          id={`timeline-swimlane-cb-${status}`}
           isChecked={allSelected ? true : someSelected ? null : false}
           onChange={handleSwimlaneSelect}
           onClick={(e) => e.stopPropagation()}
-          className="tl-swimlane__checkbox"
+          className="timeline-swimlane__checkbox"
           aria-label={`Select all ${status} workshops`}
         />
-        <span className="tl-swimlane__icon">{STATUS_ICONS[status]}</span>
+        <span className="timeline-swimlane__icon">{STATUS_ICONS[status]}</span>
         <strong>{status}</strong>
-        <Badge isRead className="tl-swimlane__count">{workshops.length}</Badge>
+        <Badge isRead className="timeline-swimlane__count">{workshops.length}</Badge>
       </button>
 
       {isExpanded && (
         <div
-          className="tl-swimlane__body"
+          className="timeline-swimlane__body"
           style={{ height: rows.length > 0 ? `${rows.length * 46 + 16}px` : '60px' }}
         >
           {nowPercent !== null && (
-            <div className="tl-now-line" style={{ left: `${nowPercent}%` }} />
+            <div className="timeline-now-line" style={{ left: `${nowPercent}%` }} />
           )}
           {rows.map((row, rowIndex) => (
-            <div key={rowIndex} className="tl-swimlane__row" style={{ top: `${rowIndex * 46 + 8}px` }}>
+            <div key={rowIndex} className="timeline-swimlane__row" style={{ top: `${rowIndex * 46 + 8}px` }}>
               {row.workshops.map((workshop) => (
                 <WorkshopBar
                   key={`${workshop.metadata.namespace}/${workshop.metadata.name}`}

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -2,12 +2,12 @@ import React, { useState, useMemo } from 'react';
 import { Badge, Button } from '@patternfly/react-core';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
-import { Workshop } from '@app/types';
+import { WorkshopWithResourceClaims } from '@app/types';
 import WorkshopBar from './WorkshopBar';
 
 export interface TimelineSwimlaneProps {
   status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped';
-  workshops: Workshop[];
+  workshops: WorkshopWithResourceClaims[];
   viewStart: Date;
   viewEnd: Date;
   selectedWorkshops: Set<string>;
@@ -16,10 +16,10 @@ export interface TimelineSwimlaneProps {
 }
 
 interface WorkshopRow {
-  workshops: Workshop[];
+  workshops: WorkshopWithResourceClaims[];
 }
 
-function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } {
+function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } {
   const spec = workshop.spec;
   const lifespan = spec?.lifespan;
 
@@ -44,7 +44,7 @@ function workshopsOverlap(w1: Workshop, w2: Workshop): boolean {
   return s1 < e2 && s2 < e1;
 }
 
-function arrangeWorkshopsInRows(workshops: Workshop[]): WorkshopRow[] {
+function arrangeWorkshopsInRows(workshops: WorkshopWithResourceClaims[]): WorkshopRow[] {
   const rows: WorkshopRow[] = [];
 
   workshops.forEach((workshop) => {
@@ -133,11 +133,11 @@ export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
               >
                 {row.workshops.map((workshop) => (
                   <WorkshopBar
-                    key={workshop.metadata.name}
+                    key={`${workshop.metadata.namespace}/${workshop.metadata.name}`}
                     workshop={workshop}
                     viewStart={viewStart}
                     viewEnd={viewEnd}
-                    isSelected={selectedWorkshops.has(workshop.metadata.name)}
+                    isSelected={selectedWorkshops.has(`${workshop.metadata.namespace}/${workshop.metadata.name}`)}
                     onSelect={onSelectWorkshop}
                     onClick={onClickWorkshop}
                   />

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useMemo } from 'react';
+import { Badge, Button } from '@patternfly/react-core';
+import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
+import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
+import { Workshop } from '@app/types';
+import WorkshopBar from './WorkshopBar';
+
+export interface TimelineSwimlaneProps {
+  status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped';
+  workshops: Workshop[];
+  viewStart: Date;
+  viewEnd: Date;
+  selectedWorkshops: Set<string>;
+  onSelectWorkshop: (id: string, selected: boolean) => void;
+  onClickWorkshop: (id: string) => void;
+}
+
+interface WorkshopRow {
+  workshops: Workshop[];
+}
+
+function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } {
+  const spec = workshop.spec;
+  const lifespan = spec?.lifespan;
+
+  let start = new Date();
+  let end = new Date();
+  end.setDate(end.getDate() + 7);
+
+  if (lifespan?.start) {
+    start = new Date(lifespan.start);
+  }
+
+  if (lifespan?.end) {
+    end = new Date(lifespan.end);
+  }
+
+  return { start, end };
+}
+
+function workshopsOverlap(w1: Workshop, w2: Workshop): boolean {
+  const { start: s1, end: e1 } = getWorkshopDates(w1);
+  const { start: s2, end: e2 } = getWorkshopDates(w2);
+  return s1 < e2 && s2 < e1;
+}
+
+function arrangeWorkshopsInRows(workshops: Workshop[]): WorkshopRow[] {
+  const rows: WorkshopRow[] = [];
+
+  workshops.forEach((workshop) => {
+    // Find a row where this workshop doesn't overlap with any existing workshop
+    let placed = false;
+    for (const row of rows) {
+      const hasOverlap = row.workshops.some((w) => workshopsOverlap(w, workshop));
+      if (!hasOverlap) {
+        row.workshops.push(workshop);
+        placed = true;
+        break;
+      }
+    }
+
+    // If no suitable row found, create a new one
+    if (!placed) {
+      rows.push({ workshops: [workshop] });
+    }
+  });
+
+  return rows;
+}
+
+export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
+  status,
+  workshops,
+  viewStart,
+  viewEnd,
+  selectedWorkshops,
+  onSelectWorkshop,
+  onClickWorkshop,
+}) => {
+  // Default expansion state: Running and Failed are expanded
+  const defaultExpanded = status === 'Running' || status === 'Failed';
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  const rows = useMemo(() => arrangeWorkshopsInRows(workshops), [workshops]);
+
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className="timeline-swimlane">
+      <div className="timeline-swimlane-header">
+        <Button
+          variant="plain"
+          onClick={toggleExpanded}
+          icon={isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
+          style={{ marginRight: '8px' }}
+        >
+          <strong style={{ fontSize: '14px' }}>{status}</strong>
+          <Badge isRead style={{ marginLeft: '8px' }}>
+            {workshops.length}
+          </Badge>
+        </Button>
+      </div>
+      {isExpanded && (
+        <div
+          className="timeline-swimlane-body"
+          style={{
+            position: 'relative',
+            minHeight: '60px',
+            height: rows.length > 0 ? `${rows.length * 40 + 20}px` : '60px',
+            padding: '10px 0',
+          }}
+        >
+          {rows.length === 0 ? (
+            <div
+              style={{
+                textAlign: 'center',
+                color: 'var(--pf-v5-global--Color--200)',
+                padding: '20px',
+              }}
+            >
+              No workshops
+            </div>
+          ) : (
+            rows.map((row, rowIndex) => (
+              <div
+                key={rowIndex}
+                style={{
+                  position: 'relative',
+                  height: '40px',
+                }}
+              >
+                {row.workshops.map((workshop) => (
+                  <WorkshopBar
+                    key={workshop.metadata.name}
+                    workshop={workshop}
+                    viewStart={viewStart}
+                    viewEnd={viewEnd}
+                    isSelected={selectedWorkshops.has(workshop.metadata.name)}
+                    onSelect={onSelectWorkshop}
+                    onClick={onClickWorkshop}
+                  />
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TimelineSwimlane;

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -1,9 +1,16 @@
-import React, { useState, useMemo } from 'react';
-import { Badge, Button } from '@patternfly/react-core';
+import React, { useState, useMemo, useCallback } from 'react';
+import { Badge, Checkbox } from '@patternfly/react-core';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
-import { WorkshopWithResourceClaims } from '@app/types';
+import { Workshop, WorkshopWithResourceClaims, MultiWorkshop } from '@app/types';
 import WorkshopBar from './WorkshopBar';
+
+interface ProvisionProgress {
+  desired: number;
+  claimed: number;
+  failed: number;
+  concurrency: number;
+}
 
 export interface TimelineSwimlaneProps {
   status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped';
@@ -13,28 +20,30 @@ export interface TimelineSwimlaneProps {
   selectedWorkshops: Set<string>;
   onSelectWorkshop: (id: string, selected: boolean) => void;
   onClickWorkshop: (id: string) => void;
+  getSeats: (ws: Workshop) => { assigned: number; total: number } | null;
+  getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
+  getCurrentCount: (ws: Workshop) => number | null;
+  multiWorkshopsByName: Map<string, MultiWorkshop>;
+  isMultiNs: boolean;
+  timezone: string;
+  nowPercent: number | null;
 }
 
 interface WorkshopRow {
   workshops: WorkshopWithResourceClaims[];
 }
 
-function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } {
-  const spec = workshop.spec;
-  const lifespan = spec?.lifespan;
+function wsKey(ws: WorkshopWithResourceClaims): string {
+  return `${ws.metadata.namespace}/${ws.metadata.name}`;
+}
 
+function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } {
+  const lifespan = workshop.spec?.lifespan;
   let start = new Date();
   let end = new Date();
   end.setDate(end.getDate() + 7);
-
-  if (lifespan?.start) {
-    start = new Date(lifespan.start);
-  }
-
-  if (lifespan?.end) {
-    end = new Date(lifespan.end);
-  }
-
+  if (lifespan?.start) start = new Date(lifespan.start);
+  if (lifespan?.end) end = new Date(lifespan.end);
   return { start, end };
 }
 
@@ -46,27 +55,26 @@ function workshopsOverlap(w1: WorkshopWithResourceClaims, w2: WorkshopWithResour
 
 function arrangeWorkshopsInRows(workshops: WorkshopWithResourceClaims[]): WorkshopRow[] {
   const rows: WorkshopRow[] = [];
-
   workshops.forEach((workshop) => {
-    // Find a row where this workshop doesn't overlap with any existing workshop
     let placed = false;
     for (const row of rows) {
-      const hasOverlap = row.workshops.some((w) => workshopsOverlap(w, workshop));
-      if (!hasOverlap) {
+      if (!row.workshops.some((w) => workshopsOverlap(w, workshop))) {
         row.workshops.push(workshop);
         placed = true;
         break;
       }
     }
-
-    // If no suitable row found, create a new one
-    if (!placed) {
-      rows.push({ workshops: [workshop] });
-    }
+    if (!placed) rows.push({ workshops: [workshop] });
   });
-
   return rows;
 }
+
+const STATUS_ICONS: Record<string, string> = {
+  Running: '▶',
+  Failed: '⚠',
+  Upcoming: '⏰',
+  Stopped: '⏹',
+};
 
 export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
   status,
@@ -76,75 +84,88 @@ export const TimelineSwimlane: React.FC<TimelineSwimlaneProps> = ({
   selectedWorkshops,
   onSelectWorkshop,
   onClickWorkshop,
+  getSeats,
+  getProvisionProgress,
+  getCurrentCount,
+  multiWorkshopsByName,
+  isMultiNs,
+  timezone,
+  nowPercent,
 }) => {
-  // Default expansion state: Running and Failed are expanded
   const defaultExpanded = status === 'Running' || status === 'Failed';
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-
   const rows = useMemo(() => arrangeWorkshopsInRows(workshops), [workshops]);
 
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
-  };
+  const workshopKeys = useMemo(() => workshops.map(ws => wsKey(ws)), [workshops]);
+
+  const allSelected = useMemo(
+    () => workshopKeys.length > 0 && workshopKeys.every(k => selectedWorkshops.has(k)),
+    [workshopKeys, selectedWorkshops]
+  );
+
+  const someSelected = useMemo(
+    () => !allSelected && workshopKeys.some(k => selectedWorkshops.has(k)),
+    [allSelected, workshopKeys, selectedWorkshops]
+  );
+
+  const handleSwimlaneSelect = useCallback((_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+    workshopKeys.forEach(k => onSelectWorkshop(k, checked));
+  }, [workshopKeys, onSelectWorkshop]);
+
+  if (workshops.length === 0) return null;
 
   return (
-    <div className="timeline-swimlane">
-      <div className="timeline-swimlane-header">
-        <Button
-          variant="plain"
-          onClick={toggleExpanded}
-          icon={isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
-          style={{ marginRight: '8px' }}
-        >
-          <strong style={{ fontSize: '14px' }}>{status}</strong>
-          <Badge isRead style={{ marginLeft: '8px' }}>
-            {workshops.length}
-          </Badge>
-        </Button>
-      </div>
+    <div className={`tl-swimlane tl-swimlane--${status.toLowerCase()}`}>
+      <button
+        className="tl-swimlane__header"
+        onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+      >
+        <span className="tl-swimlane__toggle">
+          {isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
+        </span>
+        <Checkbox
+          id={`tl-swimlane-cb-${status}`}
+          isChecked={allSelected ? true : someSelected ? null : false}
+          onChange={handleSwimlaneSelect}
+          onClick={(e) => e.stopPropagation()}
+          className="tl-swimlane__checkbox"
+          aria-label={`Select all ${status} workshops`}
+        />
+        <span className="tl-swimlane__icon">{STATUS_ICONS[status]}</span>
+        <strong>{status}</strong>
+        <Badge isRead className="tl-swimlane__count">{workshops.length}</Badge>
+      </button>
+
       {isExpanded && (
         <div
-          className="timeline-swimlane-body"
-          style={{
-            position: 'relative',
-            minHeight: '60px',
-            height: rows.length > 0 ? `${rows.length * 40 + 20}px` : '60px',
-            padding: '10px 0',
-          }}
+          className="tl-swimlane__body"
+          style={{ height: rows.length > 0 ? `${rows.length * 46 + 16}px` : '60px' }}
         >
-          {rows.length === 0 ? (
-            <div
-              style={{
-                textAlign: 'center',
-                color: 'var(--pf-t--global--text--color--subtle, #6c757d)',
-                padding: '20px',
-              }}
-            >
-              No workshops
-            </div>
-          ) : (
-            rows.map((row, rowIndex) => (
-              <div
-                key={rowIndex}
-                style={{
-                  position: 'relative',
-                  height: '40px',
-                }}
-              >
-                {row.workshops.map((workshop) => (
-                  <WorkshopBar
-                    key={`${workshop.metadata.namespace}/${workshop.metadata.name}`}
-                    workshop={workshop}
-                    viewStart={viewStart}
-                    viewEnd={viewEnd}
-                    isSelected={selectedWorkshops.has(`${workshop.metadata.namespace}/${workshop.metadata.name}`)}
-                    onSelect={onSelectWorkshop}
-                    onClick={onClickWorkshop}
-                  />
-                ))}
-              </div>
-            ))
+          {nowPercent !== null && (
+            <div className="tl-now-line" style={{ left: `${nowPercent}%` }} />
           )}
+          {rows.map((row, rowIndex) => (
+            <div key={rowIndex} className="tl-swimlane__row" style={{ top: `${rowIndex * 46 + 8}px` }}>
+              {row.workshops.map((workshop) => (
+                <WorkshopBar
+                  key={`${workshop.metadata.namespace}/${workshop.metadata.name}`}
+                  workshop={workshop}
+                  viewStart={viewStart}
+                  viewEnd={viewEnd}
+                  isSelected={selectedWorkshops.has(`${workshop.metadata.namespace}/${workshop.metadata.name}`)}
+                  onSelect={onSelectWorkshop}
+                  onClick={onClickWorkshop}
+                  getSeats={getSeats}
+                  getProvisionProgress={getProvisionProgress}
+                  getCurrentCount={getCurrentCount}
+                  multiWorkshopsByName={multiWorkshopsByName}
+                  isMultiNs={isMultiNs}
+                  timezone={timezone}
+                />
+              ))}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -11,31 +11,42 @@ export interface WorkshopBarProps {
   onClick: (id: string) => void;
 }
 
-interface WorkshopCondition {
-  type: string;
-  status: string;
-}
-
 function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
-  const status = workshop.status;
-  if (!status) return 'Upcoming';
+  const now = Date.now();
+  const resourceClaims = workshop.status?.resourceClaims || [];
 
-  // Check for failed state
-  if (status.phase === 'Failed' || status.conditions?.some((c: WorkshopCondition) => c.type === 'Failed' && c.status === 'True')) {
-    return 'Failed';
+  // Check if any resource claim failed (reuse Ops.tsx logic)
+  const hasFailed = resourceClaims.some(rc => {
+    const state = rc.status?.resources?.[0]?.state;
+    if (!state || state.kind !== 'AnarchySubject') return false;
+    const provisionState = state.spec?.vars?.current_state;
+    return provisionState === 'provision-failed' || provisionState === 'provision-error';
+  });
+
+  if (hasFailed) return 'Failed';
+
+  // Check if workshop has started (has provisioned instances)
+  const hasStarted = resourceClaims.some(rc =>
+    rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'started' ||
+    rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'provision-complete'
+  );
+
+  // Check dates
+  const startDate = workshop.spec?.actionSchedule?.start || workshop.spec?.lifespan?.start;
+  const stopDate = workshop.spec?.actionSchedule?.stop;
+
+  if (startDate && new Date(startDate).getTime() > now) {
+    return 'Upcoming';
   }
 
-  // Check for running state
-  if (status.phase === 'Running' || status.phase === 'Active') {
-    return 'Running';
-  }
-
-  // Check for stopped state
-  if (status.phase === 'Stopped' || status.phase === 'Terminated') {
+  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) {
     return 'Stopped';
   }
 
-  // Default to upcoming
+  if (hasStarted) {
+    return 'Running';
+  }
+
   return 'Upcoming';
 }
 

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback } from 'react';
+import { Checkbox, Tooltip } from '@patternfly/react-core';
+import { Workshop } from '@app/types';
+import WorkshopStatus from '@app/Workshops/WorkshopStatus';
+
+export interface WorkshopBarProps {
+  workshop: Workshop;
+  viewStart: Date;
+  viewEnd: Date;
+  isSelected: boolean;
+  onSelect: (id: string, selected: boolean) => void;
+  onClick: (id: string) => void;
+}
+
+function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+  const status = workshop.status;
+  if (!status) return 'Upcoming';
+
+  // Check for failed state
+  if (status.phase === 'Failed' || status.conditions?.some((c: any) => c.type === 'Failed' && c.status === 'True')) {
+    return 'Failed';
+  }
+
+  // Check for running state
+  if (status.phase === 'Running' || status.phase === 'Active') {
+    return 'Running';
+  }
+
+  // Check for stopped state
+  if (status.phase === 'Stopped' || status.phase === 'Terminated') {
+    return 'Stopped';
+  }
+
+  // Default to upcoming
+  return 'Upcoming';
+}
+
+function getStatusColor(status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped'): string {
+  switch (status) {
+    case 'Running':
+      return 'var(--pf-v5-global--success-color--100)';
+    case 'Failed':
+      return 'var(--pf-v5-global--danger-color--100)';
+    case 'Upcoming':
+      return 'var(--pf-v5-global--primary-color--100)';
+    case 'Stopped':
+      return 'var(--pf-v5-global--Color--200)';
+  }
+}
+
+function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } {
+  const spec = workshop.spec;
+  const lifespan = spec?.lifespan;
+
+  let start = new Date();
+  let end = new Date();
+  end.setDate(end.getDate() + 7); // Default to 7 days from now
+
+  if (lifespan?.start) {
+    start = new Date(lifespan.start);
+  }
+
+  if (lifespan?.end) {
+    end = new Date(lifespan.end);
+  }
+
+  return { start, end };
+}
+
+export const WorkshopBar: React.FC<WorkshopBarProps> = ({
+  workshop,
+  viewStart,
+  viewEnd,
+  isSelected,
+  onSelect,
+  onClick,
+}) => {
+  const { start: workshopStart, end: workshopEnd } = getWorkshopDates(workshop);
+  const status = getWorkshopStatus(workshop);
+  const color = getStatusColor(status);
+
+  // Calculate position and width
+  const totalViewDays = (viewEnd.getTime() - viewStart.getTime()) / (1000 * 60 * 60 * 24);
+  const clippedStart = new Date(Math.max(workshopStart.getTime(), viewStart.getTime()));
+  const clippedEnd = new Date(Math.min(workshopEnd.getTime(), viewEnd.getTime()));
+  const daysFromViewStart = (clippedStart.getTime() - viewStart.getTime()) / (1000 * 60 * 60 * 24);
+  const workshopDurationDays = (clippedEnd.getTime() - clippedStart.getTime()) / (1000 * 60 * 60 * 24);
+
+  const leftPercent = (daysFromViewStart / totalViewDays) * 100;
+  const widthPercent = Math.max((workshopDurationDays / totalViewDays) * 100, 2); // Minimum 2% width
+
+  const handleCheckboxChange = useCallback(
+    (checked: boolean) => {
+      onSelect(workshop.metadata.name, checked);
+    },
+    [onSelect, workshop.metadata.name]
+  );
+
+  const handleBarClick = useCallback(() => {
+    onClick(workshop.metadata.name);
+  }, [onClick, workshop.metadata.name]);
+
+  const workshopName = workshop.spec?.displayName || workshop.metadata.name;
+
+  const tooltipContent = (
+    <div>
+      <div><strong>{workshopName}</strong></div>
+      <div>Status: {status}</div>
+      <div>Start: {workshopStart.toLocaleDateString()}</div>
+      <div>End: {workshopEnd.toLocaleDateString()}</div>
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <div
+        className={`workshop-bar workshop-bar-${status.toLowerCase()}${isSelected ? ' workshop-bar-selected' : ''}`}
+        style={{
+          position: 'absolute',
+          left: `${leftPercent}%`,
+          width: `${widthPercent}%`,
+          backgroundColor: color,
+          height: '32px',
+          borderRadius: '4px',
+          padding: '4px 8px',
+          display: 'flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          boxShadow: isSelected
+            ? '0 0 0 2px var(--pf-v5-global--primary-color--100)'
+            : '0 1px 2px rgba(0,0,0,0.1)',
+          border: isSelected ? '2px solid var(--pf-v5-global--primary-color--100)' : 'none',
+          transition: 'box-shadow 0.2s',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+        }}
+        onClick={handleBarClick}
+      >
+        <Checkbox
+          id={`workshop-bar-checkbox-${workshop.metadata.name}`}
+          isChecked={isSelected}
+          onChange={(_event, checked) => handleCheckboxChange(checked)}
+          onClick={(e) => e.stopPropagation()}
+          style={{ marginRight: '8px' }}
+          aria-label={`Select ${workshopName}`}
+        />
+        <span
+          style={{
+            color: 'white',
+            fontSize: '12px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {workshopName}
+        </span>
+      </div>
+    </Tooltip>
+  );
+};
+
+export default WorkshopBar;

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -53,13 +53,13 @@ function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming
 function getStatusColor(status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped'): string {
   switch (status) {
     case 'Running':
-      return 'var(--pf-v5-global--success-color--100)';
+      return 'var(--pf-t--global--color--green--200, #28a745)';
     case 'Failed':
-      return 'var(--pf-v5-global--danger-color--100)';
+      return 'var(--pf-t--global--color--red--200, #dc3545)';
     case 'Upcoming':
-      return 'var(--pf-v5-global--primary-color--100)';
+      return 'var(--pf-t--global--color--blue--200, #007bff)';
     case 'Stopped':
-      return 'var(--pf-v5-global--Color--200)';
+      return 'var(--pf-t--global--color--gray--400, #6c757d)';
   }
 }
 
@@ -104,16 +104,18 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
   const leftPercent = (daysFromViewStart / totalViewDays) * 100;
   const widthPercent = Math.max((workshopDurationDays / totalViewDays) * 100, 2); // Minimum 2% width
 
+  const workshopKey = `${workshop.metadata.namespace}/${workshop.metadata.name}`;
+
   const handleCheckboxChange = useCallback(
     (checked: boolean) => {
-      onSelect(workshop.metadata.name, checked);
+      onSelect(workshopKey, checked);
     },
-    [onSelect, workshop.metadata.name]
+    [onSelect, workshopKey]
   );
 
   const handleBarClick = useCallback(() => {
-    onClick(workshop.metadata.name);
-  }, [onClick, workshop.metadata.name]);
+    onClick(workshopKey);
+  }, [onClick, workshopKey]);
 
   const workshopName = workshop.spec?.displayName || workshop.metadata.name;
 
@@ -142,9 +144,9 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
           alignItems: 'center',
           cursor: 'pointer',
           boxShadow: isSelected
-            ? '0 0 0 2px var(--pf-v5-global--primary-color--100)'
+            ? '0 0 0 2px var(--pf-t--global--color--blue--200, #007bff)'
             : '0 1px 2px rgba(0,0,0,0.1)',
-          border: isSelected ? '2px solid var(--pf-v5-global--primary-color--100)' : 'none',
+          border: isSelected ? '2px solid var(--pf-t--global--color--blue--200, #007bff)' : 'none',
           transition: 'box-shadow 0.2s',
           overflow: 'hidden',
           whiteSpace: 'nowrap',

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -147,14 +147,14 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
   }, [timezone]);
 
   const barUrgencyClass = worstUrgency && status !== 'stopped' && status !== 'upcoming'
-    ? ` tl-bar--urgency-${worstUrgency}`
+    ? ` timeline-bar--urgency-${worstUrgency}`
     : '';
 
   const tooltipContent = (
-    <div className="tl-bar-tooltip">
-      <div className="tl-bar-tooltip-name">{name}</div>
-      <div className="tl-bar-tooltip-meta">{workshop.metadata.name}</div>
-      <table className="tl-bar-tooltip-table">
+    <div className="timeline-bar-tooltip">
+      <div className="timeline-bar-tooltip-name">{name}</div>
+      <div className="timeline-bar-tooltip-meta">{workshop.metadata.name}</div>
+      <table className="timeline-bar-tooltip-table">
         <tbody>
           <tr><td>Namespace</td><td>{ns}</td></tr>
           <tr><td>Status</td><td style={{ textTransform: 'capitalize' }}>{status}</td></tr>
@@ -168,7 +168,7 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
           {stopIso && (
             <tr>
               <td>Auto-Stop</td>
-              <td className={stopUrgency === 'critical' ? 'tl-tooltip-critical' : stopUrgency === 'warning' ? 'tl-tooltip-warning' : ''}>
+              <td className={stopUrgency === 'critical' ? 'timeline-tooltip-critical' : stopUrgency === 'warning' ? 'timeline-tooltip-warning' : ''}>
                 {formatFullDate(stopIso)} ({relativeTime(stopIso)})
               </td>
             </tr>
@@ -176,13 +176,13 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
           {destroyIso && (
             <tr>
               <td>Auto-Destroy</td>
-              <td className={destroyUrgency === 'critical' ? 'tl-tooltip-critical' : destroyUrgency === 'warning' ? 'tl-tooltip-warning' : ''}>
+              <td className={destroyUrgency === 'critical' ? 'timeline-tooltip-critical' : destroyUrgency === 'warning' ? 'timeline-tooltip-warning' : ''}>
                 {formatFullDate(destroyIso)} ({relativeTime(destroyIso)})
               </td>
             </tr>
           )}
           {workshop.spec?.accessPassword && (
-            <tr><td>Password</td><td><code className="tl-tooltip-password">{workshop.spec.accessPassword}</code></td></tr>
+            <tr><td>Password</td><td><code className="timeline-tooltip-password">{workshop.spec.accessPassword}</code></td></tr>
           )}
           {workshop.spec?.openRegistration !== false
             ? <tr><td>Registration</td><td>Open</td></tr>
@@ -195,7 +195,7 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
   return (
     <Tooltip content={tooltipContent} maxWidth="400px">
       <div
-        className={`tl-bar tl-bar--${status}${isSelected ? ' tl-bar--selected' : ''}${barUrgencyClass}`}
+        className={`timeline-bar timeline-bar--${status}${isSelected ? ' timeline-bar--selected' : ''}${barUrgencyClass}`}
         style={{
           left: `${leftPercent}%`,
           width: `${widthPercent}%`,
@@ -203,40 +203,40 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
         onClick={handleBarClick}
       >
         <Checkbox
-          id={`tl-cb-${workshop.metadata.name}`}
+          id={`timeline-cb-${workshop.metadata.name}`}
           isChecked={isSelected}
           onChange={(_event, checked) => handleCheckboxChange(checked)}
           onClick={(e) => e.stopPropagation()}
-          className="tl-bar__checkbox"
+          className="timeline-bar__checkbox"
           aria-label={`Select ${name}`}
         />
 
-        <span className="tl-bar__name">{name}</span>
+        <span className="timeline-bar__name">{name}</span>
 
-        <span className="tl-bar__details">
+        <span className="timeline-bar__details">
           {urgencyTag && (
-            <span className={`tl-bar__badge tl-bar__badge--urgency tl-bar__badge--urgency-${worstUrgency}`}>
+            <span className={`timeline-bar__badge timeline-bar__badge--urgency timeline-bar__badge--urgency-${worstUrgency}`}>
               {urgencyTag}
             </span>
           )}
           {isMultiNs && (
-            <span className="tl-bar__badge tl-bar__badge--ns">{ns.replace(/^user-|-redhat-com.*$/g, '').slice(0, 20)}</span>
+            <span className="timeline-bar__badge timeline-bar__badge--ns">{ns.replace(/^user-|-redhat-com.*$/g, '').slice(0, 20)}</span>
           )}
           {isMultiAsset && (
-            <span className="tl-bar__badge tl-bar__badge--multi">MA</span>
+            <span className="timeline-bar__badge timeline-bar__badge--multi">MA</span>
           )}
           {seatText && (
-            <span className={`tl-bar__badge tl-bar__badge--seats${seats && seats.assigned >= seats.total ? ' tl-bar__badge--seats-full' : ''}`}>
+            <span className={`timeline-bar__badge timeline-bar__badge--seats${seats && seats.assigned >= seats.total ? ' timeline-bar__badge--seats-full' : ''}`}>
               {seatText}
             </span>
           )}
           {instanceText && (
-            <span className="tl-bar__badge tl-bar__badge--inst">
+            <span className="timeline-bar__badge timeline-bar__badge--inst">
               {instanceText}
             </span>
           )}
           {progress && progress.failed > 0 && (
-            <span className="tl-bar__badge tl-bar__badge--fail">
+            <span className="timeline-bar__badge timeline-bar__badge--fail">
               {progress.failed}
             </span>
           )}

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { Checkbox, Tooltip } from '@patternfly/react-core';
 import { Workshop } from '@app/types';
-import WorkshopStatus from '@app/Workshops/WorkshopStatus';
 
 export interface WorkshopBarProps {
   workshop: Workshop;
@@ -12,12 +11,17 @@ export interface WorkshopBarProps {
   onClick: (id: string) => void;
 }
 
+interface WorkshopCondition {
+  type: string;
+  status: string;
+}
+
 function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
   const status = workshop.status;
   if (!status) return 'Upcoming';
 
   // Check for failed state
-  if (status.phase === 'Failed' || status.conditions?.some((c: any) => c.type === 'Failed' && c.status === 'True')) {
+  if (status.phase === 'Failed' || status.conditions?.some((c: WorkshopCondition) => c.type === 'Failed' && c.status === 'True')) {
     return 'Failed';
   }
 

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -1,6 +1,15 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Checkbox, Tooltip } from '@patternfly/react-core';
-import { WorkshopWithResourceClaims } from '@app/types';
+import { Workshop, WorkshopWithResourceClaims, MultiWorkshop } from '@app/types';
+import { displayName, BABYLON_DOMAIN, getStageFromK8sObject } from '@app/util';
+import { dateUrgency, relativeTime } from '../Ops';
+
+interface ProvisionProgress {
+  desired: number;
+  claimed: number;
+  failed: number;
+  concurrency: number;
+}
 
 export interface WorkshopBarProps {
   workshop: WorkshopWithResourceClaims;
@@ -9,13 +18,18 @@ export interface WorkshopBarProps {
   isSelected: boolean;
   onSelect: (id: string, selected: boolean) => void;
   onClick: (id: string) => void;
+  getSeats: (ws: Workshop) => { assigned: number; total: number } | null;
+  getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
+  getCurrentCount: (ws: Workshop) => number | null;
+  multiWorkshopsByName: Map<string, MultiWorkshop>;
+  isMultiNs: boolean;
+  timezone: string;
 }
 
-function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'running' | 'failed' | 'upcoming' | 'stopped' {
   const now = Date.now();
   const resourceClaims = workshop.resourceClaims || [];
 
-  // Check if any resource claim failed (reuse Ops.tsx logic)
   const hasFailed = resourceClaims.some(rc => {
     const state = rc.status?.resources?.[0]?.state;
     if (!state || state.kind !== 'AnarchySubject') return false;
@@ -23,62 +37,32 @@ function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'F
     return provisionState === 'provision-failed' || provisionState === 'provision-error';
   });
 
-  if (hasFailed) return 'Failed';
+  if (hasFailed) return 'failed';
 
-  // Check if workshop has started (has provisioned instances)
+  if (workshop.spec?.provisionDisabled) return 'stopped';
+
   const hasStarted = resourceClaims.some(rc =>
     rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'started' ||
     rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'provision-complete'
   );
 
-  // Check dates
   const startDate = workshop.spec?.actionSchedule?.start || workshop.spec?.lifespan?.start;
   const stopDate = workshop.spec?.actionSchedule?.stop;
 
-  if (startDate && new Date(startDate).getTime() > now) {
-    return 'Upcoming';
-  }
+  if (startDate && new Date(startDate).getTime() > now) return 'upcoming';
+  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) return 'stopped';
+  if (hasStarted) return 'running';
 
-  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) {
-    return 'Stopped';
-  }
-
-  if (hasStarted) {
-    return 'Running';
-  }
-
-  return 'Upcoming';
-}
-
-function getStatusColor(status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped'): string {
-  switch (status) {
-    case 'Running':
-      return 'var(--pf-t--global--color--green--200, #28a745)';
-    case 'Failed':
-      return 'var(--pf-t--global--color--red--200, #dc3545)';
-    case 'Upcoming':
-      return 'var(--pf-t--global--color--blue--200, #007bff)';
-    case 'Stopped':
-      return 'var(--pf-t--global--color--gray--400, #6c757d)';
-  }
+  return 'upcoming';
 }
 
 function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } {
-  const spec = workshop.spec;
-  const lifespan = spec?.lifespan;
-
+  const lifespan = workshop.spec?.lifespan;
   let start = new Date();
   let end = new Date();
-  end.setDate(end.getDate() + 7); // Default to 7 days from now
-
-  if (lifespan?.start) {
-    start = new Date(lifespan.start);
-  }
-
-  if (lifespan?.end) {
-    end = new Date(lifespan.end);
-  }
-
+  end.setDate(end.getDate() + 7);
+  if (lifespan?.start) start = new Date(lifespan.start);
+  if (lifespan?.end) end = new Date(lifespan.end);
   return { start, end };
 }
 
@@ -89,88 +73,173 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
   isSelected,
   onSelect,
   onClick,
+  getSeats,
+  getProvisionProgress,
+  getCurrentCount,
+  multiWorkshopsByName,
+  isMultiNs,
+  timezone,
 }) => {
   const { start: workshopStart, end: workshopEnd } = getWorkshopDates(workshop);
   const status = getWorkshopStatus(workshop);
-  const color = getStatusColor(status);
 
-  // Calculate position and width
-  const totalViewDays = (viewEnd.getTime() - viewStart.getTime()) / (1000 * 60 * 60 * 24);
+  const totalViewMs = viewEnd.getTime() - viewStart.getTime();
   const clippedStart = new Date(Math.max(workshopStart.getTime(), viewStart.getTime()));
   const clippedEnd = new Date(Math.min(workshopEnd.getTime(), viewEnd.getTime()));
-  const daysFromViewStart = (clippedStart.getTime() - viewStart.getTime()) / (1000 * 60 * 60 * 24);
-  const workshopDurationDays = (clippedEnd.getTime() - clippedStart.getTime()) / (1000 * 60 * 60 * 24);
-
-  const leftPercent = (daysFromViewStart / totalViewDays) * 100;
-  const widthPercent = Math.max((workshopDurationDays / totalViewDays) * 100, 2); // Minimum 2% width
+  const leftPercent = ((clippedStart.getTime() - viewStart.getTime()) / totalViewMs) * 100;
+  const widthPercent = Math.max(((clippedEnd.getTime() - clippedStart.getTime()) / totalViewMs) * 100, 3);
 
   const workshopKey = `${workshop.metadata.namespace}/${workshop.metadata.name}`;
+  const name = displayName(workshop);
+  const ns = workshop.metadata.namespace;
+  const stage = getStageFromK8sObject(workshop);
+
+  const mwSource = workshop.metadata.annotations?.[`${BABYLON_DOMAIN}/multiworkshop-source`];
+  const isMultiAsset = !!mwSource;
+
+  const seats = useMemo(() => getSeats(workshop), [getSeats, workshop]);
+  const progress = useMemo(() => getProvisionProgress(workshop), [getProvisionProgress, workshop]);
+  const instanceCount = useMemo(() => getCurrentCount(workshop), [getCurrentCount, workshop]);
+
+  const stopIso = workshop.spec?.actionSchedule?.stop;
+  const destroyIso = workshop.spec?.lifespan?.end;
+  const stopUrgency = dateUrgency(stopIso);
+  const destroyUrgency = dateUrgency(destroyIso);
+
+  const worstUrgency = stopUrgency === 'critical' || destroyUrgency === 'critical'
+    ? 'critical'
+    : stopUrgency === 'warning' || destroyUrgency === 'warning'
+      ? 'warning'
+      : null;
+
+  const urgencyTag = useMemo(() => {
+    if (status === 'stopped' || status === 'upcoming') return null;
+    if (stopUrgency === 'critical' && stopIso) return `stop ${relativeTime(stopIso)}`;
+    if (destroyUrgency === 'critical' && destroyIso) return `destroy ${relativeTime(destroyIso)}`;
+    if (stopUrgency === 'warning' && stopIso) return `stop ${relativeTime(stopIso)}`;
+    if (destroyUrgency === 'warning' && destroyIso) return `destroy ${relativeTime(destroyIso)}`;
+    return null;
+  }, [status, stopUrgency, destroyUrgency, stopIso, destroyIso]);
 
   const handleCheckboxChange = useCallback(
-    (checked: boolean) => {
-      onSelect(workshopKey, checked);
-    },
+    (checked: boolean) => onSelect(workshopKey, checked),
     [onSelect, workshopKey]
   );
 
-  const handleBarClick = useCallback(() => {
-    onClick(workshopKey);
-  }, [onClick, workshopKey]);
+  const handleBarClick = useCallback(() => onClick(workshopKey), [onClick, workshopKey]);
 
-  const workshopName = workshop.spec?.displayName || workshop.metadata.name;
+  const seatText = seats ? `${seats.assigned}/${seats.total}` : null;
+  const instanceText = instanceCount !== null ? `${instanceCount}` : progress ? `${progress.claimed}/${progress.desired}` : null;
+
+  const formatShortDate = useCallback((d: Date): string => {
+    const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
+    if (timezone !== 'local') opts.timeZone = timezone;
+    return d.toLocaleDateString('en-US', opts);
+  }, [timezone]);
+
+  const formatFullDate = useCallback((iso: string): string => {
+    const d = new Date(iso);
+    const opts: Intl.DateTimeFormatOptions = {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+    };
+    if (timezone !== 'local') opts.timeZone = timezone;
+    return d.toLocaleString('en-US', opts);
+  }, [timezone]);
+
+  const barUrgencyClass = worstUrgency && status !== 'stopped' && status !== 'upcoming'
+    ? ` tl-bar--urgency-${worstUrgency}`
+    : '';
 
   const tooltipContent = (
-    <div>
-      <div><strong>{workshopName}</strong></div>
-      <div>Status: {status}</div>
-      <div>Start: {workshopStart.toLocaleDateString()}</div>
-      <div>End: {workshopEnd.toLocaleDateString()}</div>
+    <div className="tl-bar-tooltip">
+      <div className="tl-bar-tooltip-name">{name}</div>
+      <div className="tl-bar-tooltip-meta">{workshop.metadata.name}</div>
+      <table className="tl-bar-tooltip-table">
+        <tbody>
+          <tr><td>Namespace</td><td>{ns}</td></tr>
+          <tr><td>Status</td><td style={{ textTransform: 'capitalize' }}>{status}</td></tr>
+          {stage && <tr><td>Stage</td><td>{stage}</td></tr>}
+          {isMultiAsset && <tr><td>Type</td><td>Multi-Asset</td></tr>}
+          {seats && <tr><td>Seats</td><td>{seats.assigned} / {seats.total} assigned</td></tr>}
+          {progress && <tr><td>Instances</td><td>{progress.claimed} / {progress.desired}{progress.failed > 0 ? ` (${progress.failed} failed)` : ''}</td></tr>}
+          {progress && progress.concurrency > 0 && <tr><td>Concurrency</td><td>{progress.concurrency}</td></tr>}
+          <tr><td>Start</td><td>{formatShortDate(workshopStart)}</td></tr>
+          <tr><td>End</td><td>{formatShortDate(workshopEnd)}</td></tr>
+          {stopIso && (
+            <tr>
+              <td>Auto-Stop</td>
+              <td className={stopUrgency === 'critical' ? 'tl-tooltip-critical' : stopUrgency === 'warning' ? 'tl-tooltip-warning' : ''}>
+                {formatFullDate(stopIso)} ({relativeTime(stopIso)})
+              </td>
+            </tr>
+          )}
+          {destroyIso && (
+            <tr>
+              <td>Auto-Destroy</td>
+              <td className={destroyUrgency === 'critical' ? 'tl-tooltip-critical' : destroyUrgency === 'warning' ? 'tl-tooltip-warning' : ''}>
+                {formatFullDate(destroyIso)} ({relativeTime(destroyIso)})
+              </td>
+            </tr>
+          )}
+          {workshop.spec?.accessPassword && (
+            <tr><td>Password</td><td><code className="tl-tooltip-password">{workshop.spec.accessPassword}</code></td></tr>
+          )}
+          {workshop.spec?.openRegistration !== false
+            ? <tr><td>Registration</td><td>Open</td></tr>
+            : <tr><td>Registration</td><td>Pre-registration</td></tr>}
+        </tbody>
+      </table>
     </div>
   );
 
   return (
-    <Tooltip content={tooltipContent}>
+    <Tooltip content={tooltipContent} maxWidth="400px">
       <div
-        className={`workshop-bar workshop-bar-${status.toLowerCase()}${isSelected ? ' workshop-bar-selected' : ''}`}
+        className={`tl-bar tl-bar--${status}${isSelected ? ' tl-bar--selected' : ''}${barUrgencyClass}`}
         style={{
-          position: 'absolute',
           left: `${leftPercent}%`,
           width: `${widthPercent}%`,
-          backgroundColor: color,
-          height: '32px',
-          borderRadius: '4px',
-          padding: '4px 8px',
-          display: 'flex',
-          alignItems: 'center',
-          cursor: 'pointer',
-          boxShadow: isSelected
-            ? '0 0 0 2px var(--pf-t--global--color--blue--200, #007bff)'
-            : '0 1px 2px rgba(0,0,0,0.1)',
-          border: isSelected ? '2px solid var(--pf-t--global--color--blue--200, #007bff)' : 'none',
-          transition: 'box-shadow 0.2s',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
         }}
         onClick={handleBarClick}
       >
         <Checkbox
-          id={`workshop-bar-checkbox-${workshop.metadata.name}`}
+          id={`tl-cb-${workshop.metadata.name}`}
           isChecked={isSelected}
           onChange={(_event, checked) => handleCheckboxChange(checked)}
           onClick={(e) => e.stopPropagation()}
-          style={{ marginRight: '8px' }}
-          aria-label={`Select ${workshopName}`}
+          className="tl-bar__checkbox"
+          aria-label={`Select ${name}`}
         />
-        <span
-          style={{
-            color: 'white',
-            fontSize: '12px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {workshopName}
+
+        <span className="tl-bar__name">{name}</span>
+
+        <span className="tl-bar__details">
+          {urgencyTag && (
+            <span className={`tl-bar__badge tl-bar__badge--urgency tl-bar__badge--urgency-${worstUrgency}`}>
+              {urgencyTag}
+            </span>
+          )}
+          {isMultiNs && (
+            <span className="tl-bar__badge tl-bar__badge--ns">{ns.replace(/^user-|-redhat-com.*$/g, '').slice(0, 20)}</span>
+          )}
+          {isMultiAsset && (
+            <span className="tl-bar__badge tl-bar__badge--multi">MA</span>
+          )}
+          {seatText && (
+            <span className={`tl-bar__badge tl-bar__badge--seats${seats && seats.assigned >= seats.total ? ' tl-bar__badge--seats-full' : ''}`}>
+              {seatText}
+            </span>
+          )}
+          {instanceText && (
+            <span className="tl-bar__badge tl-bar__badge--inst">
+              {instanceText}
+            </span>
+          )}
+          {progress && progress.failed > 0 && (
+            <span className="tl-bar__badge tl-bar__badge--fail">
+              {progress.failed}
+            </span>
+          )}
         </span>
       </div>
     </Tooltip>

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { Checkbox, Tooltip } from '@patternfly/react-core';
-import { Workshop } from '@app/types';
+import { WorkshopWithResourceClaims } from '@app/types';
 
 export interface WorkshopBarProps {
-  workshop: Workshop;
+  workshop: WorkshopWithResourceClaims;
   viewStart: Date;
   viewEnd: Date;
   isSelected: boolean;
@@ -11,9 +11,9 @@ export interface WorkshopBarProps {
   onClick: (id: string) => void;
 }
 
-function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
   const now = Date.now();
-  const resourceClaims = workshop.status?.resourceClaims || [];
+  const resourceClaims = workshop.resourceClaims || [];
 
   // Check if any resource claim failed (reuse Ops.tsx logic)
   const hasFailed = resourceClaims.some(rc => {
@@ -63,7 +63,7 @@ function getStatusColor(status: 'Running' | 'Failed' | 'Upcoming' | 'Stopped'): 
   }
 }
 
-function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } {
+function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } {
   const spec = workshop.spec;
   const lifespan = spec?.lifespan;
 

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -1,0 +1,260 @@
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { Card, CardBody, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { Workshop } from '@app/types';
+import TimelineControls from './TimelineControls';
+import TimelineSwimlane from './TimelineSwimlane';
+
+export interface WorkshopTimelineProps {
+  workshops: Workshop[];
+  selectedWorkshops: Set<string>;
+  onSelectWorkshop: (id: string, selected: boolean) => void;
+  onClickWorkshop: (id: string) => void;
+}
+
+function getMonday(d: Date): Date {
+  const date = new Date(d);
+  const day = date.getDay();
+  const diff = date.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(date.setDate(diff));
+}
+
+function getSunday(d: Date): Date {
+  const monday = getMonday(d);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return sunday;
+}
+
+function getStartOfDay(d: Date): Date {
+  const date = new Date(d);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function getEndOfDay(d: Date): Date {
+  const date = new Date(d);
+  date.setHours(23, 59, 59, 999);
+  return date;
+}
+
+function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+  const status = workshop.status;
+  if (!status) return 'Upcoming';
+
+  if (status.phase === 'Failed' || status.conditions?.some((c: any) => c.type === 'Failed' && c.status === 'True')) {
+    return 'Failed';
+  }
+
+  if (status.phase === 'Running' || status.phase === 'Active') {
+    return 'Running';
+  }
+
+  if (status.phase === 'Stopped' || status.phase === 'Terminated') {
+    return 'Stopped';
+  }
+
+  return 'Upcoming';
+}
+
+function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } | null {
+  const spec = workshop.spec;
+  const lifespan = spec?.lifespan;
+
+  if (!lifespan?.start && !lifespan?.end) {
+    return null;
+  }
+
+  let start = new Date();
+  let end = new Date();
+  end.setDate(end.getDate() + 7);
+
+  if (lifespan?.start) {
+    start = new Date(lifespan.start);
+  }
+
+  if (lifespan?.end) {
+    end = new Date(lifespan.end);
+  }
+
+  return { start, end };
+}
+
+function workshopInDateRange(workshop: Workshop, viewStart: Date, viewEnd: Date): boolean {
+  const dates = getWorkshopDates(workshop);
+  if (!dates) return true; // Show workshops without dates
+
+  return dates.start < viewEnd && dates.end > viewStart;
+}
+
+const STORAGE_KEY = 'opsTimelineDateRange';
+
+export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
+  workshops,
+  selectedWorkshops,
+  onSelectWorkshop,
+  onClickWorkshop,
+}) => {
+  // Initialize date range from localStorage or default to "This Week"
+  const [dateRange, setDateRange] = useState<{ start: Date; end: Date }>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return {
+          start: new Date(parsed.start),
+          end: new Date(parsed.end),
+        };
+      }
+    } catch (e) {
+      // Ignore parse errors
+    }
+
+    // Default to "This Week"
+    const today = new Date();
+    const monday = getMonday(today);
+    const sunday = getSunday(today);
+    return {
+      start: getStartOfDay(monday),
+      end: getEndOfDay(sunday),
+    };
+  });
+
+  // Save date range to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          start: dateRange.start.toISOString(),
+          end: dateRange.end.toISOString(),
+        })
+      );
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }, [dateRange]);
+
+  const handleDateChange = useCallback((start: Date, end: Date) => {
+    setDateRange({ start, end });
+  }, []);
+
+  // Filter workshops to those visible in date range and group by status
+  const groupedWorkshops = useMemo(() => {
+    const visibleWorkshops = workshops.filter((w) => workshopInDateRange(w, dateRange.start, dateRange.end));
+
+    const grouped = {
+      Running: [] as Workshop[],
+      Failed: [] as Workshop[],
+      Upcoming: [] as Workshop[],
+      Stopped: [] as Workshop[],
+    };
+
+    visibleWorkshops.forEach((workshop) => {
+      const status = getWorkshopStatus(workshop);
+      grouped[status].push(workshop);
+    });
+
+    return grouped;
+  }, [workshops, dateRange]);
+
+  // Generate date grid
+  const dateGrid = useMemo(() => {
+    const days: Date[] = [];
+    const current = new Date(dateRange.start);
+
+    while (current <= dateRange.end) {
+      days.push(new Date(current));
+      current.setDate(current.getDate() + 1);
+    }
+
+    return days;
+  }, [dateRange]);
+
+  const totalWorkshops =
+    groupedWorkshops.Running.length +
+    groupedWorkshops.Failed.length +
+    groupedWorkshops.Upcoming.length +
+    groupedWorkshops.Stopped.length;
+
+  return (
+    <div className="timeline-container">
+      <TimelineControls
+        startDate={dateRange.start}
+        endDate={dateRange.end}
+        onDateChange={handleDateChange}
+      />
+
+      {totalWorkshops === 0 ? (
+        <EmptyState>
+          <EmptyStateBody>No workshops match the selected date range</EmptyStateBody>
+        </EmptyState>
+      ) : (
+        <>
+          <div className="timeline-grid" style={{ display: 'flex', borderBottom: '1px solid #d2d2d2', padding: '8px 0' }}>
+            {dateGrid.map((day, index) => {
+              const isToday =
+                day.toDateString() === new Date().toDateString();
+              return (
+                <div
+                  key={index}
+                  style={{
+                    flex: 1,
+                    textAlign: 'center',
+                    fontSize: '11px',
+                    fontWeight: isToday ? 'bold' : 'normal',
+                    color: isToday ? 'var(--pf-v5-global--primary-color--100)' : undefined,
+                    borderRight: index < dateGrid.length - 1 ? '1px solid #f0f0f0' : 'none',
+                  }}
+                >
+                  {day.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                </div>
+              );
+            })}
+          </div>
+
+          <TimelineSwimlane
+            status="Running"
+            workshops={groupedWorkshops.Running}
+            viewStart={dateRange.start}
+            viewEnd={dateRange.end}
+            selectedWorkshops={selectedWorkshops}
+            onSelectWorkshop={onSelectWorkshop}
+            onClickWorkshop={onClickWorkshop}
+          />
+
+          <TimelineSwimlane
+            status="Failed"
+            workshops={groupedWorkshops.Failed}
+            viewStart={dateRange.start}
+            viewEnd={dateRange.end}
+            selectedWorkshops={selectedWorkshops}
+            onSelectWorkshop={onSelectWorkshop}
+            onClickWorkshop={onClickWorkshop}
+          />
+
+          <TimelineSwimlane
+            status="Upcoming"
+            workshops={groupedWorkshops.Upcoming}
+            viewStart={dateRange.start}
+            viewEnd={dateRange.end}
+            selectedWorkshops={selectedWorkshops}
+            onSelectWorkshop={onSelectWorkshop}
+            onClickWorkshop={onClickWorkshop}
+          />
+
+          <TimelineSwimlane
+            status="Stopped"
+            workshops={groupedWorkshops.Stopped}
+            viewStart={dateRange.start}
+            viewEnd={dateRange.end}
+            selectedWorkshops={selectedWorkshops}
+            onSelectWorkshop={onSelectWorkshop}
+            onClickWorkshop={onClickWorkshop}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default WorkshopTimeline;

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
-import { Workshop } from '@app/types';
+import { WorkshopWithResourceClaims } from '@app/types';
 import TimelineControls from './TimelineControls';
 import TimelineSwimlane from './TimelineSwimlane';
 
 export interface WorkshopTimelineProps {
-  workshops: Workshop[];
+  workshops: WorkshopWithResourceClaims[];
   selectedWorkshops: Set<string>;
   onSelectWorkshop: (id: string, selected: boolean) => void;
   onClickWorkshop: (id: string) => void;
@@ -37,9 +37,9 @@ function getEndOfDay(d: Date): Date {
   return date;
 }
 
-function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
   const now = Date.now();
-  const resourceClaims = workshop.status?.resourceClaims || [];
+  const resourceClaims = workshop.resourceClaims || [];
 
   // Check if any resource claim failed (reuse Ops.tsx logic)
   const hasFailed = resourceClaims.some(rc => {
@@ -76,7 +76,7 @@ function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming
   return 'Upcoming';
 }
 
-function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } | null {
+function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } | null {
   const spec = workshop.spec;
   const lifespan = spec?.lifespan;
 
@@ -99,7 +99,7 @@ function getWorkshopDates(workshop: Workshop): { start: Date; end: Date } | null
   return { start, end };
 }
 
-function workshopInDateRange(workshop: Workshop, viewStart: Date, viewEnd: Date): boolean {
+function workshopInDateRange(workshop: WorkshopWithResourceClaims, viewStart: Date, viewEnd: Date): boolean {
   const dates = getWorkshopDates(workshop);
   if (!dates) return true; // Show workshops without dates
 
@@ -163,10 +163,10 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
     const visibleWorkshops = workshops.filter((w) => workshopInDateRange(w, dateRange.start, dateRange.end));
 
     const grouped = {
-      Running: [] as Workshop[],
-      Failed: [] as Workshop[],
-      Upcoming: [] as Workshop[],
-      Stopped: [] as Workshop[],
+      Running: [] as WorkshopWithResourceClaims[],
+      Failed: [] as WorkshopWithResourceClaims[],
+      Upcoming: [] as WorkshopWithResourceClaims[],
+      Stopped: [] as WorkshopWithResourceClaims[],
     };
 
     visibleWorkshops.forEach((workshop) => {

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -11,11 +11,6 @@ export interface WorkshopTimelineProps {
   onClickWorkshop: (id: string) => void;
 }
 
-interface WorkshopCondition {
-  type: string;
-  status: string;
-}
-
 function getMonday(d: Date): Date {
   const date = new Date(d);
   const day = date.getDay();
@@ -43,19 +38,39 @@ function getEndOfDay(d: Date): Date {
 }
 
 function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
-  const status = workshop.status;
-  if (!status) return 'Upcoming';
+  const now = Date.now();
+  const resourceClaims = workshop.status?.resourceClaims || [];
 
-  if (status.phase === 'Failed' || status.conditions?.some((c: WorkshopCondition) => c.type === 'Failed' && c.status === 'True')) {
-    return 'Failed';
+  // Check if any resource claim failed (reuse Ops.tsx logic)
+  const hasFailed = resourceClaims.some(rc => {
+    const state = rc.status?.resources?.[0]?.state;
+    if (!state || state.kind !== 'AnarchySubject') return false;
+    const provisionState = state.spec?.vars?.current_state;
+    return provisionState === 'provision-failed' || provisionState === 'provision-error';
+  });
+
+  if (hasFailed) return 'Failed';
+
+  // Check if workshop has started (has provisioned instances)
+  const hasStarted = resourceClaims.some(rc =>
+    rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'started' ||
+    rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'provision-complete'
+  );
+
+  // Check dates
+  const startDate = workshop.spec?.actionSchedule?.start || workshop.spec?.lifespan?.start;
+  const stopDate = workshop.spec?.actionSchedule?.stop;
+
+  if (startDate && new Date(startDate).getTime() > now) {
+    return 'Upcoming';
   }
 
-  if (status.phase === 'Running' || status.phase === 'Active') {
-    return 'Running';
-  }
-
-  if (status.phase === 'Stopped' || status.phase === 'Terminated') {
+  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) {
     return 'Stopped';
+  }
+
+  if (hasStarted) {
+    return 'Running';
   }
 
   return 'Upcoming';

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -225,10 +225,10 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
   };
 
   return (
-    <div className="tl-container">
+    <div className="timeline-container">
       <TimelineControls startDate={dateRange.start} endDate={dateRange.end} onDateChange={handleDateChange} timezone={timezone} />
 
-      <div className="tl-quick-select">
+      <div className="timeline-quick-select">
         {SELECT_BUTTONS.map(btn => {
           const count = btn.status === 'all'
             ? totalWorkshops
@@ -242,14 +242,14 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
               color={btn.color as any}
               isCompact
               onClick={() => handleQuickSelect(btn.status)}
-              className="tl-quick-select__btn"
+              className="timeline-quick-select__btn"
             >
               {btn.label}{count > 0 ? ` (${count})` : ''}
             </Label>
           );
         })}
         {selectedWorkshops.size > 0 && (
-          <Badge isRead className="tl-quick-select__count">{selectedWorkshops.size} selected</Badge>
+          <Badge isRead className="timeline-quick-select__count">{selectedWorkshops.size} selected</Badge>
         )}
       </div>
 
@@ -259,9 +259,9 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
         </EmptyState>
       ) : (
         <>
-          <div className="tl-date-grid">
+          <div className="timeline-date-grid">
             {nowPercent !== null && (
-              <div className="tl-now-marker" style={{ left: `${nowPercent}%` }} title="Now" />
+              <div className="timeline-now-marker" style={{ left: `${nowPercent}%` }} title="Now" />
             )}
             {dateGrid.map((day, i) => {
               const isToday = day.toDateString() === todayStr;
@@ -269,10 +269,10 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
               return (
                 <div
                   key={i}
-                  className={`tl-date-cell${isToday ? ' tl-date-cell--today' : ''}${isWeekend ? ' tl-date-cell--weekend' : ''}`}
+                  className={`timeline-date-cell${isToday ? ' timeline-date-cell--today' : ''}${isWeekend ? ' timeline-date-cell--weekend' : ''}`}
                 >
-                  <span className="tl-date-cell__dow">{formatDateCell(day, { weekday: 'short' })}</span>
-                  <span className="tl-date-cell__day">{formatDateCell(day, { month: 'short', day: 'numeric' })}</span>
+                  <span className="timeline-date-cell__dow">{formatDateCell(day, { weekday: 'short' })}</span>
+                  <span className="timeline-date-cell__day">{formatDateCell(day, { month: 'short', day: 'numeric' })}</span>
                 </div>
               );
             })}

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Card, CardBody, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { Workshop } from '@app/types';
 import TimelineControls from './TimelineControls';
 import TimelineSwimlane from './TimelineSwimlane';
@@ -9,6 +9,11 @@ export interface WorkshopTimelineProps {
   selectedWorkshops: Set<string>;
   onSelectWorkshop: (id: string, selected: boolean) => void;
   onClickWorkshop: (id: string) => void;
+}
+
+interface WorkshopCondition {
+  type: string;
+  status: string;
 }
 
 function getMonday(d: Date): Date {
@@ -41,7 +46,7 @@ function getWorkshopStatus(workshop: Workshop): 'Running' | 'Failed' | 'Upcoming
   const status = workshop.status;
   if (!status) return 'Upcoming';
 
-  if (status.phase === 'Failed' || status.conditions?.some((c: any) => c.type === 'Failed' && c.status === 'True')) {
+  if (status.phase === 'Failed' || status.conditions?.some((c: WorkshopCondition) => c.type === 'Failed' && c.status === 'True')) {
     return 'Failed';
   }
 

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -1,14 +1,29 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
-import { WorkshopWithResourceClaims } from '@app/types';
+import { Badge, EmptyState, EmptyStateBody, Label } from '@patternfly/react-core';
+import { Workshop, WorkshopWithResourceClaims, MultiWorkshop } from '@app/types';
 import TimelineControls from './TimelineControls';
 import TimelineSwimlane from './TimelineSwimlane';
+
+interface ProvisionProgress {
+  desired: number;
+  claimed: number;
+  failed: number;
+  concurrency: number;
+}
 
 export interface WorkshopTimelineProps {
   workshops: WorkshopWithResourceClaims[];
   selectedWorkshops: Set<string>;
   onSelectWorkshop: (id: string, selected: boolean) => void;
+  onBatchSelect: (keys: string[]) => void;
+  onDeselectAll: () => void;
   onClickWorkshop: (id: string) => void;
+  getSeats: (ws: Workshop) => { assigned: number; total: number } | null;
+  getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
+  getCurrentCount: (ws: Workshop) => number | null;
+  multiWorkshopsByName: Map<string, MultiWorkshop>;
+  isMultiNs: boolean;
+  timezone: string;
 }
 
 function getMonday(d: Date): Date {
@@ -37,172 +52,206 @@ function getEndOfDay(d: Date): Date {
   return date;
 }
 
-function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
+function wsKey(ws: WorkshopWithResourceClaims): string {
+  return `${ws.metadata.namespace}/${ws.metadata.name}`;
+}
+
+export function getWorkshopStatus(workshop: WorkshopWithResourceClaims): 'Running' | 'Failed' | 'Upcoming' | 'Stopped' {
   const now = Date.now();
   const resourceClaims = workshop.resourceClaims || [];
 
-  // Check if any resource claim failed (reuse Ops.tsx logic)
   const hasFailed = resourceClaims.some(rc => {
     const state = rc.status?.resources?.[0]?.state;
     if (!state || state.kind !== 'AnarchySubject') return false;
     const provisionState = state.spec?.vars?.current_state;
     return provisionState === 'provision-failed' || provisionState === 'provision-error';
   });
-
   if (hasFailed) return 'Failed';
 
-  // Check if workshop has started (has provisioned instances)
+  if (workshop.spec?.provisionDisabled) return 'Stopped';
+
   const hasStarted = resourceClaims.some(rc =>
     rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'started' ||
     rc.status?.resources?.[0]?.state?.spec?.vars?.current_state === 'provision-complete'
   );
 
-  // Check dates
   const startDate = workshop.spec?.actionSchedule?.start || workshop.spec?.lifespan?.start;
   const stopDate = workshop.spec?.actionSchedule?.stop;
 
-  if (startDate && new Date(startDate).getTime() > now) {
-    return 'Upcoming';
-  }
-
-  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) {
-    return 'Stopped';
-  }
-
-  if (hasStarted) {
-    return 'Running';
-  }
-
+  if (startDate && new Date(startDate).getTime() > now) return 'Upcoming';
+  if (stopDate && new Date(stopDate).getTime() < now && !hasStarted) return 'Stopped';
+  if (hasStarted) return 'Running';
   return 'Upcoming';
 }
 
 function getWorkshopDates(workshop: WorkshopWithResourceClaims): { start: Date; end: Date } | null {
-  const spec = workshop.spec;
-  const lifespan = spec?.lifespan;
-
-  if (!lifespan?.start && !lifespan?.end) {
-    return null;
-  }
-
+  const lifespan = workshop.spec?.lifespan;
+  if (!lifespan?.start && !lifespan?.end) return null;
   let start = new Date();
   let end = new Date();
   end.setDate(end.getDate() + 7);
-
-  if (lifespan?.start) {
-    start = new Date(lifespan.start);
-  }
-
-  if (lifespan?.end) {
-    end = new Date(lifespan.end);
-  }
-
+  if (lifespan?.start) start = new Date(lifespan.start);
+  if (lifespan?.end) end = new Date(lifespan.end);
   return { start, end };
 }
 
 function workshopInDateRange(workshop: WorkshopWithResourceClaims, viewStart: Date, viewEnd: Date): boolean {
   const dates = getWorkshopDates(workshop);
-  if (!dates) return true; // Show workshops without dates
-
+  if (!dates) return true;
   return dates.start < viewEnd && dates.end > viewStart;
 }
 
 const STORAGE_KEY = 'opsTimelineDateRange';
 
+type StatusKey = 'Running' | 'Failed' | 'Upcoming' | 'Stopped';
+
+const SELECT_BUTTONS: { label: string; status: StatusKey | 'all' | 'none'; color: 'green' | 'red' | 'blue' | 'orange' | 'grey' }[] = [
+  { label: 'Select All', status: 'all', color: 'grey' },
+  { label: 'Running', status: 'Running', color: 'green' },
+  { label: 'Failed', status: 'Failed', color: 'red' },
+  { label: 'Upcoming', status: 'Upcoming', color: 'blue' },
+  { label: 'Stopped', status: 'Stopped', color: 'orange' },
+  { label: 'Deselect', status: 'none', color: 'grey' },
+];
+
 export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
   workshops,
   selectedWorkshops,
   onSelectWorkshop,
+  onBatchSelect,
+  onDeselectAll,
   onClickWorkshop,
+  getSeats,
+  getProvisionProgress,
+  getCurrentCount,
+  multiWorkshopsByName,
+  isMultiNs,
+  timezone,
 }) => {
-  // Initialize date range from localStorage or default to "This Week"
   const [dateRange, setDateRange] = useState<{ start: Date; end: Date }>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
         const parsed = JSON.parse(stored);
-        return {
-          start: new Date(parsed.start),
-          end: new Date(parsed.end),
-        };
+        return { start: new Date(parsed.start), end: new Date(parsed.end) };
       }
-    } catch (e) {
-      // Ignore parse errors
-    }
-
-    // Default to "This Week"
+    } catch (e) { /* ignore */ }
     const today = new Date();
-    const monday = getMonday(today);
-    const sunday = getSunday(today);
-    return {
-      start: getStartOfDay(monday),
-      end: getEndOfDay(sunday),
-    };
+    return { start: getStartOfDay(getMonday(today)), end: getEndOfDay(getSunday(today)) };
   });
 
-  // Save date range to localStorage
   useEffect(() => {
     try {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          start: dateRange.start.toISOString(),
-          end: dateRange.end.toISOString(),
-        })
-      );
-    } catch (e) {
-      // Ignore storage errors
-    }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        start: dateRange.start.toISOString(),
+        end: dateRange.end.toISOString(),
+      }));
+    } catch (e) { /* ignore */ }
   }, [dateRange]);
 
   const handleDateChange = useCallback((start: Date, end: Date) => {
     setDateRange({ start, end });
   }, []);
 
-  // Filter workshops to those visible in date range and group by status
   const groupedWorkshops = useMemo(() => {
-    const visibleWorkshops = workshops.filter((w) => workshopInDateRange(w, dateRange.start, dateRange.end));
-
-    const grouped = {
-      Running: [] as WorkshopWithResourceClaims[],
-      Failed: [] as WorkshopWithResourceClaims[],
-      Upcoming: [] as WorkshopWithResourceClaims[],
-      Stopped: [] as WorkshopWithResourceClaims[],
+    const visible = workshops.filter(w => workshopInDateRange(w, dateRange.start, dateRange.end));
+    const grouped: Record<StatusKey, WorkshopWithResourceClaims[]> = {
+      Running: [], Failed: [], Upcoming: [], Stopped: [],
     };
-
-    visibleWorkshops.forEach((workshop) => {
-      const status = getWorkshopStatus(workshop);
-      grouped[status].push(workshop);
+    visible.forEach(ws => {
+      grouped[getWorkshopStatus(ws)].push(ws);
     });
-
     return grouped;
   }, [workshops, dateRange]);
 
-  // Generate date grid
   const dateGrid = useMemo(() => {
     const days: Date[] = [];
     const current = new Date(dateRange.start);
-
     while (current <= dateRange.end) {
       days.push(new Date(current));
       current.setDate(current.getDate() + 1);
     }
-
     return days;
   }, [dateRange]);
 
-  const totalWorkshops =
-    groupedWorkshops.Running.length +
-    groupedWorkshops.Failed.length +
-    groupedWorkshops.Upcoming.length +
-    groupedWorkshops.Stopped.length;
+  const totalWorkshops = Object.values(groupedWorkshops).reduce((s, arr) => s + arr.length, 0);
+  const todayStr = new Date().toDateString();
+
+  const handleQuickSelect = useCallback((status: StatusKey | 'all' | 'none') => {
+    if (status === 'none') {
+      onDeselectAll();
+      return;
+    }
+    if (status === 'all') {
+      const allKeys: string[] = [];
+      for (const arr of Object.values(groupedWorkshops)) {
+        arr.forEach(ws => allKeys.push(wsKey(ws)));
+      }
+      onBatchSelect(allKeys);
+      return;
+    }
+    const keys = (groupedWorkshops[status] || []).map(ws => wsKey(ws));
+    onBatchSelect(keys);
+  }, [groupedWorkshops, onBatchSelect, onDeselectAll]);
+
+  const nowPercent = useMemo(() => {
+    const now = Date.now();
+    const start = dateRange.start.getTime();
+    const end = dateRange.end.getTime();
+    if (now < start || now > end) return null;
+    return ((now - start) / (end - start)) * 100;
+  }, [dateRange]);
+
+  const formatDateCell = useCallback((day: Date, opts: Intl.DateTimeFormatOptions) => {
+    if (timezone !== 'local') {
+      return day.toLocaleDateString('en-US', { ...opts, timeZone: timezone });
+    }
+    return day.toLocaleDateString('en-US', opts);
+  }, [timezone]);
+
+  const swimlaneProps = {
+    viewStart: dateRange.start,
+    viewEnd: dateRange.end,
+    selectedWorkshops,
+    onSelectWorkshop,
+    onClickWorkshop,
+    getSeats,
+    getProvisionProgress,
+    getCurrentCount,
+    multiWorkshopsByName,
+    isMultiNs,
+    timezone,
+    nowPercent,
+  };
 
   return (
-    <div className="timeline-container">
-      <TimelineControls
-        startDate={dateRange.start}
-        endDate={dateRange.end}
-        onDateChange={handleDateChange}
-      />
+    <div className="tl-container">
+      <TimelineControls startDate={dateRange.start} endDate={dateRange.end} onDateChange={handleDateChange} timezone={timezone} />
+
+      <div className="tl-quick-select">
+        {SELECT_BUTTONS.map(btn => {
+          const count = btn.status === 'all'
+            ? totalWorkshops
+            : btn.status === 'none'
+              ? selectedWorkshops.size
+              : (groupedWorkshops[btn.status] || []).length;
+          if (btn.status !== 'all' && btn.status !== 'none' && count === 0) return null;
+          return (
+            <Label
+              key={btn.label}
+              color={btn.color as any}
+              isCompact
+              onClick={() => handleQuickSelect(btn.status)}
+              className="tl-quick-select__btn"
+            >
+              {btn.label}{count > 0 ? ` (${count})` : ''}
+            </Label>
+          );
+        })}
+        {selectedWorkshops.size > 0 && (
+          <Badge isRead className="tl-quick-select__count">{selectedWorkshops.size} selected</Badge>
+        )}
+      </div>
 
       {totalWorkshops === 0 ? (
         <EmptyState>
@@ -210,67 +259,33 @@ export const WorkshopTimeline: React.FC<WorkshopTimelineProps> = ({
         </EmptyState>
       ) : (
         <>
-          <div className="timeline-grid" style={{ display: 'flex', borderBottom: '1px solid #d2d2d2', padding: '8px 0' }}>
-            {dateGrid.map((day, index) => {
-              const isToday =
-                day.toDateString() === new Date().toDateString();
+          <div className="tl-date-grid">
+            {nowPercent !== null && (
+              <div className="tl-now-marker" style={{ left: `${nowPercent}%` }} title="Now" />
+            )}
+            {dateGrid.map((day, i) => {
+              const isToday = day.toDateString() === todayStr;
+              const isWeekend = day.getDay() === 0 || day.getDay() === 6;
               return (
                 <div
-                  key={index}
-                  style={{
-                    flex: 1,
-                    textAlign: 'center',
-                    fontSize: '11px',
-                    fontWeight: isToday ? 'bold' : 'normal',
-                    color: isToday ? 'var(--pf-v5-global--primary-color--100)' : undefined,
-                    borderRight: index < dateGrid.length - 1 ? '1px solid #f0f0f0' : 'none',
-                  }}
+                  key={i}
+                  className={`tl-date-cell${isToday ? ' tl-date-cell--today' : ''}${isWeekend ? ' tl-date-cell--weekend' : ''}`}
                 >
-                  {day.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                  <span className="tl-date-cell__dow">{formatDateCell(day, { weekday: 'short' })}</span>
+                  <span className="tl-date-cell__day">{formatDateCell(day, { month: 'short', day: 'numeric' })}</span>
                 </div>
               );
             })}
           </div>
 
-          <TimelineSwimlane
-            status="Running"
-            workshops={groupedWorkshops.Running}
-            viewStart={dateRange.start}
-            viewEnd={dateRange.end}
-            selectedWorkshops={selectedWorkshops}
-            onSelectWorkshop={onSelectWorkshop}
-            onClickWorkshop={onClickWorkshop}
-          />
-
-          <TimelineSwimlane
-            status="Failed"
-            workshops={groupedWorkshops.Failed}
-            viewStart={dateRange.start}
-            viewEnd={dateRange.end}
-            selectedWorkshops={selectedWorkshops}
-            onSelectWorkshop={onSelectWorkshop}
-            onClickWorkshop={onClickWorkshop}
-          />
-
-          <TimelineSwimlane
-            status="Upcoming"
-            workshops={groupedWorkshops.Upcoming}
-            viewStart={dateRange.start}
-            viewEnd={dateRange.end}
-            selectedWorkshops={selectedWorkshops}
-            onSelectWorkshop={onSelectWorkshop}
-            onClickWorkshop={onClickWorkshop}
-          />
-
-          <TimelineSwimlane
-            status="Stopped"
-            workshops={groupedWorkshops.Stopped}
-            viewStart={dateRange.start}
-            viewEnd={dateRange.end}
-            selectedWorkshops={selectedWorkshops}
-            onSelectWorkshop={onSelectWorkshop}
-            onClickWorkshop={onClickWorkshop}
-          />
+          {(['Running', 'Failed', 'Upcoming', 'Stopped'] as const).map(status => (
+            <TimelineSwimlane
+              key={status}
+              status={status}
+              workshops={groupedWorkshops[status]}
+              {...swimlaneProps}
+            />
+          ))}
         </>
       )}
     </div>

--- a/catalog/ui/src/app/Admin/Ops/timeline.css
+++ b/catalog/ui/src/app/Admin/Ops/timeline.css
@@ -21,6 +21,23 @@
   margin-bottom: 8px;
 }
 
+/* Swimlane backgrounds by status */
+.ops-swimlane-running {
+  background: var(--pf-t--global--color--green--50, rgba(40, 167, 69, 0.1));
+}
+
+.ops-swimlane-failed {
+  background: var(--pf-t--global--color--red--50, rgba(220, 53, 69, 0.1));
+}
+
+.ops-swimlane-upcoming {
+  background: var(--pf-t--global--color--blue--50, rgba(0, 102, 204, 0.05));
+}
+
+.ops-swimlane-stopped {
+  background: var(--pf-t--global--color--orange--50, rgba(255, 152, 0, 0.1));
+}
+
 .timeline-swimlane-header {
   padding: 12px 16px;
   background: var(--pf-v5-global--BackgroundColor--200);
@@ -65,21 +82,25 @@
   border: 2px solid var(--pf-v5-global--primary-color--100);
 }
 
-/* Status-based colors */
+/* Status-based colors - dark mode compatible */
 .workshop-bar-running {
-  background-color: var(--pf-v5-global--success-color--100);
+  background: var(--pf-t--global--color--green--200, #28a745);
+  color: var(--pf-t--global--text--color--on-dark, white);
 }
 
 .workshop-bar-failed {
-  background-color: var(--pf-v5-global--danger-color--100);
+  background: var(--pf-t--global--color--red--200, #dc3545);
+  color: var(--pf-t--global--text--color--on-dark, white);
 }
 
 .workshop-bar-upcoming {
-  background-color: var(--pf-v5-global--primary-color--100);
+  background: var(--pf-t--global--color--blue--200, #0066cc);
+  color: var(--pf-t--global--text--color--on-dark, white);
 }
 
 .workshop-bar-stopped {
-  background-color: var(--pf-v5-global--Color--200);
+  background: var(--pf-t--global--color--orange--200, #ff9800);
+  color: var(--pf-t--global--text--color--on-dark, white);
 }
 
 /* Workshop Bar Checkbox */

--- a/catalog/ui/src/app/Admin/Ops/timeline.css
+++ b/catalog/ui/src/app/Admin/Ops/timeline.css
@@ -1,5 +1,5 @@
 /* ── Timeline Container ── */
-.tl-container {
+.timeline-container {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -9,7 +9,7 @@
 }
 
 /* ── Quick Select Bar ── */
-.tl-quick-select {
+.timeline-quick-select {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -17,27 +17,27 @@
   padding: 4px 0;
 }
 
-.tl-quick-select__btn {
+.timeline-quick-select__btn {
   cursor: pointer;
   user-select: none;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
-.tl-quick-select__btn:hover {
+.timeline-quick-select__btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.tl-quick-select__btn:active {
+.timeline-quick-select__btn:active {
   transform: translateY(0);
 }
 
-.tl-quick-select__count {
+.timeline-quick-select__count {
   margin-left: 8px;
 }
 
 /* ── Date Grid ── */
-.tl-date-grid {
+.timeline-date-grid {
   display: flex;
   position: relative;
   border-bottom: 2px solid var(--pf-t--global--border--color--default, #d2d2d2);
@@ -49,7 +49,7 @@
   backdrop-filter: blur(8px);
 }
 
-.tl-date-cell {
+.timeline-date-cell {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -61,11 +61,11 @@
   transition: background-color 0.15s ease;
 }
 
-.tl-date-cell:last-child {
+.timeline-date-cell:last-child {
   border-right: none;
 }
 
-.tl-date-cell__dow {
+.timeline-date-cell__dow {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -73,28 +73,28 @@
   font-weight: 500;
 }
 
-.tl-date-cell__day {
+.timeline-date-cell__day {
   font-size: 12px;
   font-weight: 500;
   color: var(--pf-t--global--text--color--regular, #151515);
 }
 
-.tl-date-cell--today {
+.timeline-date-cell--today {
   background: color-mix(in srgb, var(--pf-t--global--color--brand--default, #06c) 8%, transparent);
   border-radius: 6px;
 }
 
-.tl-date-cell--today .tl-date-cell__day {
+.timeline-date-cell--today .timeline-date-cell__day {
   color: var(--pf-t--global--color--brand--default, #06c);
   font-weight: 700;
 }
 
-.tl-date-cell--weekend {
+.timeline-date-cell--weekend {
   opacity: 0.65;
 }
 
 /* ── Now Marker (date grid) ── */
-.tl-now-marker {
+.timeline-now-marker {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -104,7 +104,7 @@
   pointer-events: none;
 }
 
-.tl-now-marker::after {
+.timeline-now-marker::after {
   content: '';
   position: absolute;
   top: -3px;
@@ -116,7 +116,7 @@
 }
 
 /* ── Now Line (inside swimlanes) ── */
-.tl-now-line {
+.timeline-now-line {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -128,18 +128,18 @@
 }
 
 /* ── Swimlane ── */
-.tl-swimlane {
+.timeline-swimlane {
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
   transition: box-shadow 0.2s ease;
 }
 
-.tl-swimlane:hover {
+.timeline-swimlane:hover {
   box-shadow: 0 2px 8px color-mix(in srgb, currentColor 6%, transparent);
 }
 
-.tl-swimlane__header {
+.timeline-swimlane__header {
   all: unset;
   box-sizing: border-box;
   display: flex;
@@ -152,44 +152,44 @@
   transition: background-color 0.15s ease;
 }
 
-.tl-swimlane__header:hover {
+.timeline-swimlane__header:hover {
   filter: brightness(0.97);
 }
 
-.tl-swimlane__toggle {
+.timeline-swimlane__toggle {
   display: flex;
   align-items: center;
   color: var(--pf-t--global--text--color--subtle, #6a6e73);
 }
 
-.tl-swimlane__checkbox {
+.timeline-swimlane__checkbox {
   flex-shrink: 0;
 }
 
-.tl-swimlane__icon {
+.timeline-swimlane__icon {
   font-size: 14px;
   line-height: 1;
 }
 
-.tl-swimlane__count {
+.timeline-swimlane__count {
   margin-left: auto;
 }
 
 /* Status-specific swimlane styling */
-.tl-swimlane--running .tl-swimlane__header {
+.timeline-swimlane--running .timeline-swimlane__header {
   background: color-mix(in srgb, var(--pf-t--global--color--status--success--default, #3e8635) 10%, var(--pf-t--global--background--color--primary--default, #fff));
 }
-.tl-swimlane--failed .tl-swimlane__header {
+.timeline-swimlane--failed .timeline-swimlane__header {
   background: color-mix(in srgb, var(--pf-t--global--color--status--danger--default, #c9190b) 10%, var(--pf-t--global--background--color--primary--default, #fff));
 }
-.tl-swimlane--upcoming .tl-swimlane__header {
+.timeline-swimlane--upcoming .timeline-swimlane__header {
   background: color-mix(in srgb, var(--pf-t--global--color--status--info--default, #06c) 8%, var(--pf-t--global--background--color--primary--default, #fff));
 }
-.tl-swimlane--stopped .tl-swimlane__header {
+.timeline-swimlane--stopped .timeline-swimlane__header {
   background: color-mix(in srgb, var(--pf-t--global--color--status--warning--default, #f0ab00) 10%, var(--pf-t--global--background--color--primary--default, #fff));
 }
 
-.tl-swimlane__body {
+.timeline-swimlane__body {
   position: relative;
   min-height: 60px;
   padding: 0 8px;
@@ -197,7 +197,7 @@
   border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
-.tl-swimlane__row {
+.timeline-swimlane__row {
   position: absolute;
   left: 0;
   right: 0;
@@ -205,7 +205,7 @@
 }
 
 /* ── Workshop Bar ── */
-.tl-bar {
+.timeline-bar {
   position: absolute;
   height: 36px;
   border-radius: 6px;
@@ -223,45 +223,45 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
-.tl-bar:hover {
+.timeline-bar:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1);
   filter: brightness(1.08);
   z-index: 1;
 }
 
-.tl-bar:active {
+.timeline-bar:active {
   transform: translateY(0);
   filter: brightness(0.95);
 }
 
-.tl-bar--selected {
+.timeline-bar--selected {
   outline: 2px solid var(--pf-t--global--color--brand--default, #06c);
   outline-offset: 1px;
 }
 
 /* Status colors */
-.tl-bar--running {
+.timeline-bar--running {
   background: linear-gradient(135deg, var(--pf-t--global--color--status--success--default, #3e8635), color-mix(in srgb, var(--pf-t--global--color--status--success--default, #3e8635) 80%, #000));
 }
-.tl-bar--failed {
+.timeline-bar--failed {
   background: linear-gradient(135deg, var(--pf-t--global--color--status--danger--default, #c9190b), color-mix(in srgb, var(--pf-t--global--color--status--danger--default, #c9190b) 80%, #000));
 }
-.tl-bar--upcoming {
+.timeline-bar--upcoming {
   background: linear-gradient(135deg, var(--pf-t--global--color--status--info--default, #06c), color-mix(in srgb, var(--pf-t--global--color--status--info--default, #06c) 80%, #000));
 }
-.tl-bar--stopped {
+.timeline-bar--stopped {
   background: linear-gradient(135deg, var(--pf-t--global--color--status--warning--default, #f0ab00), color-mix(in srgb, var(--pf-t--global--color--status--warning--default, #f0ab00) 80%, #000));
   color: #151515;
 }
 
 /* ── Urgency States ── */
-.tl-bar--urgency-critical {
+.timeline-bar--urgency-critical {
   animation: urgency-pulse 1.5s ease-in-out infinite;
   box-shadow: 0 0 0 2px rgba(201, 25, 11, 0.6), 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
-.tl-bar--urgency-warning {
+.timeline-bar--urgency-warning {
   box-shadow: 0 0 0 2px rgba(240, 171, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
@@ -274,16 +274,16 @@
   }
 }
 
-.tl-bar__checkbox {
+.timeline-bar__checkbox {
   flex-shrink: 0;
 }
 
-.tl-bar__checkbox .pf-v6-c-check__input,
-.tl-bar__checkbox .pf-v5-c-check__input {
+.timeline-bar__checkbox .pf-v6-c-check__input,
+.timeline-bar__checkbox .pf-v5-c-check__input {
   cursor: pointer;
 }
 
-.tl-bar__name {
+.timeline-bar__name {
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -291,7 +291,7 @@
   min-width: 0;
 }
 
-.tl-bar__details {
+.timeline-bar__details {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -299,7 +299,7 @@
 }
 
 /* ── Bar badges ── */
-.tl-bar__badge {
+.timeline-bar__badge {
   display: inline-flex;
   align-items: center;
   padding: 1px 5px;
@@ -312,11 +312,11 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
-.tl-bar--stopped .tl-bar__badge {
+.timeline-bar--stopped .timeline-bar__badge {
   background: rgba(0, 0, 0, 0.1);
 }
 
-.tl-bar__badge--ns {
+.timeline-bar__badge--ns {
   max-width: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -324,32 +324,32 @@
   font-style: italic;
 }
 
-.tl-bar__badge--multi {
+.timeline-bar__badge--multi {
   background: rgba(255, 255, 255, 0.35);
   font-weight: 700;
 }
 
-.tl-bar__badge--seats-full {
+.timeline-bar__badge--seats-full {
   background: rgba(255, 255, 255, 0.4);
   animation: pulse-badge 2s ease-in-out infinite;
 }
 
-.tl-bar__badge--fail {
+.timeline-bar__badge--fail {
   background: rgba(255, 0, 0, 0.3);
 }
 
-.tl-bar__badge--urgency {
+.timeline-bar__badge--urgency {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 9px;
 }
 
-.tl-bar__badge--urgency-critical {
+.timeline-bar__badge--urgency-critical {
   background: rgba(255, 255, 255, 0.45);
 }
 
-.tl-bar__badge--urgency-warning {
+.timeline-bar__badge--urgency-warning {
   background: rgba(255, 255, 255, 0.3);
 }
 
@@ -359,51 +359,51 @@
 }
 
 /* ── Tooltip ── */
-.tl-bar-tooltip {
+.timeline-bar-tooltip {
   font-size: 13px;
   line-height: 1.5;
 }
 
-.tl-bar-tooltip-name {
+.timeline-bar-tooltip-name {
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 2px;
 }
 
-.tl-bar-tooltip-meta {
+.timeline-bar-tooltip-meta {
   font-size: 11px;
   opacity: 0.7;
   margin-bottom: 6px;
   font-family: monospace;
 }
 
-.tl-bar-tooltip-table {
+.timeline-bar-tooltip-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.tl-bar-tooltip-table td {
+.timeline-bar-tooltip-table td {
   padding: 2px 0;
 }
 
-.tl-bar-tooltip-table td:first-child {
+.timeline-bar-tooltip-table td:first-child {
   font-weight: 500;
   padding-right: 12px;
   white-space: nowrap;
   opacity: 0.8;
 }
 
-.tl-tooltip-critical {
+.timeline-tooltip-critical {
   color: #ff6b6b;
   font-weight: 600;
 }
 
-.tl-tooltip-warning {
+.timeline-tooltip-warning {
   color: #ffd43b;
   font-weight: 600;
 }
 
-.tl-tooltip-password {
+.timeline-tooltip-password {
   background: rgba(255, 255, 255, 0.15);
   padding: 1px 5px;
   border-radius: 3px;
@@ -415,22 +415,22 @@
 
 /* ── Responsive ── */
 @container (max-width: 900px) {
-  .tl-bar__details {
+  .timeline-bar__details {
     display: none;
   }
-  .tl-date-cell {
+  .timeline-date-cell {
     min-width: 50px;
   }
-  .tl-date-cell__dow {
+  .timeline-date-cell__dow {
     display: none;
   }
 }
 
 @media (max-width: 768px) {
-  .tl-container {
+  .timeline-container {
     display: none;
   }
-  .tl-mobile-message {
+  .timeline-mobile-message {
     text-align: center;
     padding: 32px;
     color: var(--pf-t--global--text--color--subtle, #6a6e73);
@@ -438,16 +438,16 @@
 }
 
 /* ── Scrollbar ── */
-.tl-container::-webkit-scrollbar {
+.timeline-container::-webkit-scrollbar {
   height: 6px;
 }
-.tl-container::-webkit-scrollbar-track {
+.timeline-container::-webkit-scrollbar-track {
   background: transparent;
 }
-.tl-container::-webkit-scrollbar-thumb {
+.timeline-container::-webkit-scrollbar-thumb {
   background: var(--pf-t--global--border--color--default, #d2d2d2);
   border-radius: 3px;
 }
-.tl-container::-webkit-scrollbar-thumb:hover {
+.timeline-container::-webkit-scrollbar-thumb:hover {
   background: var(--pf-t--global--text--color--subtle, #6a6e73);
 }

--- a/catalog/ui/src/app/Admin/Ops/timeline.css
+++ b/catalog/ui/src/app/Admin/Ops/timeline.css
@@ -1,0 +1,166 @@
+/* Timeline Container */
+.timeline-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-x: auto;
+  padding: 16px;
+}
+
+/* Timeline Grid */
+.timeline-grid {
+  position: relative;
+  background: var(--pf-v5-global--BackgroundColor--100);
+}
+
+/* Timeline Swimlane */
+.timeline-swimlane {
+  border: 1px solid var(--pf-v5-global--BorderColor--100);
+  border-radius: 4px;
+  background: var(--pf-v5-global--BackgroundColor--100);
+  margin-bottom: 8px;
+}
+
+.timeline-swimlane-header {
+  padding: 12px 16px;
+  background: var(--pf-v5-global--BackgroundColor--200);
+  border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
+  display: flex;
+  align-items: center;
+}
+
+.timeline-swimlane-header strong {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.timeline-swimlane-body {
+  padding: 16px;
+  position: relative;
+  background: var(--pf-v5-global--BackgroundColor--100);
+}
+
+/* Workshop Bar */
+.workshop-bar {
+  position: absolute;
+  height: 32px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.1s ease;
+  overflow: hidden;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.workshop-bar:hover {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px);
+}
+
+.workshop-bar-selected {
+  box-shadow: 0 0 0 2px var(--pf-v5-global--primary-color--100) !important;
+  border: 2px solid var(--pf-v5-global--primary-color--100);
+}
+
+/* Status-based colors */
+.workshop-bar-running {
+  background-color: var(--pf-v5-global--success-color--100);
+}
+
+.workshop-bar-failed {
+  background-color: var(--pf-v5-global--danger-color--100);
+}
+
+.workshop-bar-upcoming {
+  background-color: var(--pf-v5-global--primary-color--100);
+}
+
+.workshop-bar-stopped {
+  background-color: var(--pf-v5-global--Color--200);
+}
+
+/* Workshop Bar Checkbox */
+.workshop-bar .pf-v5-c-check {
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.workshop-bar .pf-v5-c-check__input {
+  cursor: pointer;
+}
+
+/* Workshop Bar Text */
+.workshop-bar span {
+  color: white;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+/* Responsive breakpoints */
+@media (max-width: 1200px) {
+  .timeline-grid {
+    font-size: 10px;
+  }
+
+  .workshop-bar {
+    height: 28px;
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 768px) {
+  .timeline-container {
+    display: none;
+  }
+
+  .timeline-mobile-message {
+    text-align: center;
+    padding: 32px;
+    color: var(--pf-v5-global--Color--200);
+  }
+}
+
+/* Date grid cells */
+.timeline-grid > div {
+  min-width: 80px;
+}
+
+/* Today indicator */
+.timeline-grid-today {
+  background-color: var(--pf-v5-global--palette--blue-50);
+}
+
+/* Overlapping bar positioning */
+.timeline-swimlane-body > div {
+  margin-bottom: 8px;
+}
+
+/* Empty state styling */
+.timeline-swimlane-body .pf-v5-c-empty-state {
+  padding: 20px;
+}
+
+/* Scrollbar styling */
+.timeline-container::-webkit-scrollbar {
+  height: 8px;
+}
+
+.timeline-container::-webkit-scrollbar-track {
+  background: var(--pf-v5-global--BackgroundColor--200);
+  border-radius: 4px;
+}
+
+.timeline-container::-webkit-scrollbar-thumb {
+  background: var(--pf-v5-global--Color--200);
+  border-radius: 4px;
+}
+
+.timeline-container::-webkit-scrollbar-thumb:hover {
+  background: var(--pf-v5-global--Color--300);
+}

--- a/catalog/ui/src/app/Admin/Ops/timeline.css
+++ b/catalog/ui/src/app/Admin/Ops/timeline.css
@@ -1,187 +1,453 @@
-/* Timeline Container */
-.timeline-container {
+/* ── Timeline Container ── */
+.tl-container {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   overflow-x: auto;
   padding: 16px;
+  container-type: inline-size;
 }
 
-/* Timeline Grid */
-.timeline-grid {
-  position: relative;
-  background: var(--pf-v5-global--BackgroundColor--100);
-}
-
-/* Timeline Swimlane */
-.timeline-swimlane {
-  border: 1px solid var(--pf-v5-global--BorderColor--100);
-  border-radius: 4px;
-  background: var(--pf-v5-global--BackgroundColor--100);
-  margin-bottom: 8px;
-}
-
-/* Swimlane backgrounds by status */
-.ops-swimlane-running {
-  background: var(--pf-t--global--color--green--50, rgba(40, 167, 69, 0.1));
-}
-
-.ops-swimlane-failed {
-  background: var(--pf-t--global--color--red--50, rgba(220, 53, 69, 0.1));
-}
-
-.ops-swimlane-upcoming {
-  background: var(--pf-t--global--color--blue--50, rgba(0, 102, 204, 0.05));
-}
-
-.ops-swimlane-stopped {
-  background: var(--pf-t--global--color--orange--50, rgba(255, 152, 0, 0.1));
-}
-
-.timeline-swimlane-header {
-  padding: 12px 16px;
-  background: var(--pf-v5-global--BackgroundColor--200);
-  border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
+/* ── Quick Select Bar ── */
+.tl-quick-select {
   display: flex;
   align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 4px 0;
 }
 
-.timeline-swimlane-header strong {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.timeline-swimlane-body {
-  padding: 16px;
-  position: relative;
-  background: var(--pf-v5-global--BackgroundColor--100);
-}
-
-/* Workshop Bar */
-.workshop-bar {
-  position: absolute;
-  height: 32px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  padding: 4px 8px;
+.tl-quick-select__btn {
   cursor: pointer;
-  transition: box-shadow 0.2s ease, transform 0.1s ease;
-  overflow: hidden;
-  white-space: nowrap;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  user-select: none;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
-.workshop-bar:hover {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+.tl-quick-select__btn:hover {
   transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.workshop-bar-selected {
-  box-shadow: 0 0 0 2px var(--pf-v5-global--primary-color--100) !important;
-  border: 2px solid var(--pf-v5-global--primary-color--100);
+.tl-quick-select__btn:active {
+  transform: translateY(0);
 }
 
-/* Status-based colors - dark mode compatible */
-.workshop-bar-running {
-  background: var(--pf-t--global--color--green--200, #28a745);
-  color: var(--pf-t--global--text--color--on-dark, white);
+.tl-quick-select__count {
+  margin-left: 8px;
 }
 
-.workshop-bar-failed {
-  background: var(--pf-t--global--color--red--200, #dc3545);
-  color: var(--pf-t--global--text--color--on-dark, white);
+/* ── Date Grid ── */
+.tl-date-grid {
+  display: flex;
+  position: relative;
+  border-bottom: 2px solid var(--pf-t--global--border--color--default, #d2d2d2);
+  padding: 6px 0;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--pf-t--global--background--color--primary--default, #fff);
+  backdrop-filter: blur(8px);
 }
 
-.workshop-bar-upcoming {
-  background: var(--pf-t--global--color--blue--200, #0066cc);
-  color: var(--pf-t--global--text--color--on-dark, white);
+.tl-date-cell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 70px;
+  padding: 4px 0;
+  border-right: 1px solid color-mix(in srgb, var(--pf-t--global--border--color--default, #d2d2d2) 50%, transparent);
+  transition: background-color 0.15s ease;
 }
 
-.workshop-bar-stopped {
-  background: var(--pf-t--global--color--orange--200, #ff9800);
-  color: var(--pf-t--global--text--color--on-dark, white);
+.tl-date-cell:last-child {
+  border-right: none;
 }
 
-/* Workshop Bar Checkbox */
-.workshop-bar .pf-v5-c-check {
-  margin-right: 8px;
+.tl-date-cell__dow {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--pf-t--global--text--color--subtle, #6a6e73);
+  font-weight: 500;
+}
+
+.tl-date-cell__day {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--pf-t--global--text--color--regular, #151515);
+}
+
+.tl-date-cell--today {
+  background: color-mix(in srgb, var(--pf-t--global--color--brand--default, #06c) 8%, transparent);
+  border-radius: 6px;
+}
+
+.tl-date-cell--today .tl-date-cell__day {
+  color: var(--pf-t--global--color--brand--default, #06c);
+  font-weight: 700;
+}
+
+.tl-date-cell--weekend {
+  opacity: 0.65;
+}
+
+/* ── Now Marker (date grid) ── */
+.tl-now-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--pf-t--global--color--status--danger--default, #c9190b);
+  z-index: 3;
+  pointer-events: none;
+}
+
+.tl-now-marker::after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--pf-t--global--color--status--danger--default, #c9190b);
+}
+
+/* ── Now Line (inside swimlanes) ── */
+.tl-now-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: color-mix(in srgb, var(--pf-t--global--color--status--danger--default, #c9190b) 60%, transparent);
+  z-index: 0;
+  pointer-events: none;
+  border-left: 1px dashed var(--pf-t--global--color--status--danger--default, #c9190b);
+}
+
+/* ── Swimlane ── */
+.tl-swimlane {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+  transition: box-shadow 0.2s ease;
+}
+
+.tl-swimlane:hover {
+  box-shadow: 0 2px 8px color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.tl-swimlane__header {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.tl-swimlane__header:hover {
+  filter: brightness(0.97);
+}
+
+.tl-swimlane__toggle {
+  display: flex;
+  align-items: center;
+  color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.tl-swimlane__checkbox {
   flex-shrink: 0;
 }
 
-.workshop-bar .pf-v5-c-check__input {
+.tl-swimlane__icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.tl-swimlane__count {
+  margin-left: auto;
+}
+
+/* Status-specific swimlane styling */
+.tl-swimlane--running .tl-swimlane__header {
+  background: color-mix(in srgb, var(--pf-t--global--color--status--success--default, #3e8635) 10%, var(--pf-t--global--background--color--primary--default, #fff));
+}
+.tl-swimlane--failed .tl-swimlane__header {
+  background: color-mix(in srgb, var(--pf-t--global--color--status--danger--default, #c9190b) 10%, var(--pf-t--global--background--color--primary--default, #fff));
+}
+.tl-swimlane--upcoming .tl-swimlane__header {
+  background: color-mix(in srgb, var(--pf-t--global--color--status--info--default, #06c) 8%, var(--pf-t--global--background--color--primary--default, #fff));
+}
+.tl-swimlane--stopped .tl-swimlane__header {
+  background: color-mix(in srgb, var(--pf-t--global--color--status--warning--default, #f0ab00) 10%, var(--pf-t--global--background--color--primary--default, #fff));
+}
+
+.tl-swimlane__body {
+  position: relative;
+  min-height: 60px;
+  padding: 0 8px;
+  background: var(--pf-t--global--background--color--primary--default, #fff);
+  border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+.tl-swimlane__row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 40px;
+}
+
+/* ── Workshop Bar ── */
+.tl-bar {
+  position: absolute;
+  height: 36px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.12s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.tl-bar:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1);
+  filter: brightness(1.08);
+  z-index: 1;
+}
+
+.tl-bar:active {
+  transform: translateY(0);
+  filter: brightness(0.95);
+}
+
+.tl-bar--selected {
+  outline: 2px solid var(--pf-t--global--color--brand--default, #06c);
+  outline-offset: 1px;
+}
+
+/* Status colors */
+.tl-bar--running {
+  background: linear-gradient(135deg, var(--pf-t--global--color--status--success--default, #3e8635), color-mix(in srgb, var(--pf-t--global--color--status--success--default, #3e8635) 80%, #000));
+}
+.tl-bar--failed {
+  background: linear-gradient(135deg, var(--pf-t--global--color--status--danger--default, #c9190b), color-mix(in srgb, var(--pf-t--global--color--status--danger--default, #c9190b) 80%, #000));
+}
+.tl-bar--upcoming {
+  background: linear-gradient(135deg, var(--pf-t--global--color--status--info--default, #06c), color-mix(in srgb, var(--pf-t--global--color--status--info--default, #06c) 80%, #000));
+}
+.tl-bar--stopped {
+  background: linear-gradient(135deg, var(--pf-t--global--color--status--warning--default, #f0ab00), color-mix(in srgb, var(--pf-t--global--color--status--warning--default, #f0ab00) 80%, #000));
+  color: #151515;
+}
+
+/* ── Urgency States ── */
+.tl-bar--urgency-critical {
+  animation: urgency-pulse 1.5s ease-in-out infinite;
+  box-shadow: 0 0 0 2px rgba(201, 25, 11, 0.6), 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.tl-bar--urgency-warning {
+  box-shadow: 0 0 0 2px rgba(240, 171, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+@keyframes urgency-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 2px rgba(201, 25, 11, 0.6), 0 1px 3px rgba(0, 0, 0, 0.12);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(201, 25, 11, 0.3), 0 0 12px rgba(201, 25, 11, 0.2);
+  }
+}
+
+.tl-bar__checkbox {
+  flex-shrink: 0;
+}
+
+.tl-bar__checkbox .pf-v6-c-check__input,
+.tl-bar__checkbox .pf-v5-c-check__input {
   cursor: pointer;
 }
 
-/* Workshop Bar Text */
-.workshop-bar span {
-  color: white;
-  font-size: 12px;
+.tl-bar__name {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  min-width: 0;
 }
 
-/* Responsive breakpoints */
-@media (max-width: 1200px) {
-  .timeline-grid {
-    font-size: 10px;
-  }
+.tl-bar__details {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
 
-  .workshop-bar {
-    height: 28px;
-    font-size: 11px;
+/* ── Bar badges ── */
+.tl-bar__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  backdrop-filter: brightness(0.85) saturate(1.2);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.tl-bar--stopped .tl-bar__badge {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.tl-bar__badge--ns {
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  font-style: italic;
+}
+
+.tl-bar__badge--multi {
+  background: rgba(255, 255, 255, 0.35);
+  font-weight: 700;
+}
+
+.tl-bar__badge--seats-full {
+  background: rgba(255, 255, 255, 0.4);
+  animation: pulse-badge 2s ease-in-out infinite;
+}
+
+.tl-bar__badge--fail {
+  background: rgba(255, 0, 0, 0.3);
+}
+
+.tl-bar__badge--urgency {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 9px;
+}
+
+.tl-bar__badge--urgency-critical {
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.tl-bar__badge--urgency-warning {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+@keyframes pulse-badge {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* ── Tooltip ── */
+.tl-bar-tooltip {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.tl-bar-tooltip-name {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 2px;
+}
+
+.tl-bar-tooltip-meta {
+  font-size: 11px;
+  opacity: 0.7;
+  margin-bottom: 6px;
+  font-family: monospace;
+}
+
+.tl-bar-tooltip-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tl-bar-tooltip-table td {
+  padding: 2px 0;
+}
+
+.tl-bar-tooltip-table td:first-child {
+  font-weight: 500;
+  padding-right: 12px;
+  white-space: nowrap;
+  opacity: 0.8;
+}
+
+.tl-tooltip-critical {
+  color: #ff6b6b;
+  font-weight: 600;
+}
+
+.tl-tooltip-warning {
+  color: #ffd43b;
+  font-weight: 600;
+}
+
+.tl-tooltip-password {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  user-select: all;
+}
+
+/* ── Responsive ── */
+@container (max-width: 900px) {
+  .tl-bar__details {
+    display: none;
+  }
+  .tl-date-cell {
+    min-width: 50px;
+  }
+  .tl-date-cell__dow {
+    display: none;
   }
 }
 
 @media (max-width: 768px) {
-  .timeline-container {
+  .tl-container {
     display: none;
   }
-
-  .timeline-mobile-message {
+  .tl-mobile-message {
     text-align: center;
     padding: 32px;
-    color: var(--pf-v5-global--Color--200);
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
   }
 }
 
-/* Date grid cells */
-.timeline-grid > div {
-  min-width: 80px;
+/* ── Scrollbar ── */
+.tl-container::-webkit-scrollbar {
+  height: 6px;
 }
-
-/* Today indicator */
-.timeline-grid-today {
-  background-color: var(--pf-v5-global--palette--blue-50);
+.tl-container::-webkit-scrollbar-track {
+  background: transparent;
 }
-
-/* Overlapping bar positioning */
-.timeline-swimlane-body > div {
-  margin-bottom: 8px;
+.tl-container::-webkit-scrollbar-thumb {
+  background: var(--pf-t--global--border--color--default, #d2d2d2);
+  border-radius: 3px;
 }
-
-/* Empty state styling */
-.timeline-swimlane-body .pf-v5-c-empty-state {
-  padding: 20px;
-}
-
-/* Scrollbar styling */
-.timeline-container::-webkit-scrollbar {
-  height: 8px;
-}
-
-.timeline-container::-webkit-scrollbar-track {
-  background: var(--pf-v5-global--BackgroundColor--200);
-  border-radius: 4px;
-}
-
-.timeline-container::-webkit-scrollbar-thumb {
-  background: var(--pf-v5-global--Color--200);
-  border-radius: 4px;
-}
-
-.timeline-container::-webkit-scrollbar-thumb:hover {
-  background: var(--pf-v5-global--Color--300);
+.tl-container::-webkit-scrollbar-thumb:hover {
+  background: var(--pf-t--global--text--color--subtle, #6a6e73);
 }

--- a/catalog/ui/src/app/components/ConditionalWrapper.tsx
+++ b/catalog/ui/src/app/components/ConditionalWrapper.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 type ConditionalWrapperProps = {
-  children: JSX.Element;
+  children: ReactElement;
   condition: boolean;
-  wrapper: (children: JSX.Element) => JSX.Element;
+  wrapper: (children: ReactElement) => ReactElement;
 };
 const ConditionalWrapper: React.FC<ConditionalWrapperProps> = ({ condition, wrapper, children }) =>
   condition ? React.cloneElement(wrapper(children)) : children;

--- a/catalog/ui/src/app/components/Label.tsx
+++ b/catalog/ui/src/app/components/Label.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
-const Label: React.FC<{ tooltipDescription?: JSX.Element; children: React.ReactNode }> = ({
+const Label: React.FC<{ tooltipDescription?: ReactElement; children: React.ReactNode }> = ({
   children,
   tooltipDescription = null,
 }) =>

--- a/catalog/ui/webpack.common.js
+++ b/catalog/ui/webpack.common.js
@@ -11,6 +11,7 @@ module.exports = () => {
   return {
     optimization: {
       sideEffects: true,
+      usedExports: true,
     },
     module: {
       rules: [

--- a/catalog/ui/webpack.dev.js
+++ b/catalog/ui/webpack.dev.js
@@ -25,7 +25,7 @@ module.exports = merge(common('development'), {
     proxy: [
       {
         context: ['/api'],
-        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
+        target: 'http://localhost:8080',
         secure: false,
         changeOrigin: true,
         headers: {
@@ -34,7 +34,7 @@ module.exports = merge(common('development'), {
       },
       {
         context: ['/apis'],
-        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
+        target: 'http://localhost:8080',
         secure: false,
         changeOrigin: true,
         headers: {
@@ -43,7 +43,7 @@ module.exports = merge(common('development'), {
       },
       {
         context: ['/auth'],
-        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
+        target: 'http://localhost:8080',
         secure: false,
         changeOrigin: true,
         headers: {

--- a/catalog/ui/webpack.dev.js
+++ b/catalog/ui/webpack.dev.js
@@ -25,7 +25,7 @@ module.exports = merge(common('development'), {
     proxy: [
       {
         context: ['/api'],
-        target: 'http://localhost:8080',
+        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
         secure: false,
         changeOrigin: true,
         headers: {
@@ -34,7 +34,7 @@ module.exports = merge(common('development'), {
       },
       {
         context: ['/apis'],
-        target: 'http://localhost:8080',
+        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
         secure: false,
         changeOrigin: true,
         headers: {
@@ -43,7 +43,7 @@ module.exports = merge(common('development'), {
       },
       {
         context: ['/auth'],
-        target: 'http://localhost:8080',
+        target: 'https://admin-babylon.apps.babydev.dev.open.redhat.com',
         secure: false,
         changeOrigin: true,
         headers: {


### PR DESCRIPTION
## Summary

Add a timeline calendar view to the Admin Ops page that displays workshops as horizontal bars grouped by status in swimlanes, providing a Gantt-chart-like view optimized for understanding workshop scheduling and duration at a glance.

**Key features implemented:**
- **TimelineControls component**: Date presets (Today, This Week, Next Week, This Month) and custom DatePicker
- **WorkshopBar component**: Clickable horizontal bars with checkboxes for bulk operations, color-coded by status
- **TimelineSwimlane component**: Status-grouped lanes (Running/Failed/Upcoming/Stopped) with collapse/expand
- **WorkshopTimeline component**: Main container with date grid, swimlanes, and localStorage persistence
- **Ops.tsx integration**: Timeline toggle alongside existing table/calendar views
- **CSS styles**: Complete styling for timeline, swimlanes, bars, and responsive breakpoints

**Design highlights:**
- **Swimlane organization**: Workshops grouped by status (Running, Failed, Upcoming, Stopped) rather than by date
- **Status-based colors**: Running=green, Failed=red, Upcoming=blue, Stopped=gray
- **Date navigation**: Preset buttons for common ranges plus custom date picker
- **Bulk operations support**: Checkboxes on bars integrate with existing bulk operations modal
- **Filter compatibility**: All existing filters (search, status, stage, owner, etc.) work with timeline view
- **Selection consistency**: Selection state preserved when switching between list/calendar/timeline views

**Implementation details:**
- Workshops rendered as horizontal bars with width proportional to duration
- Overlapping workshops stack vertically within swimlanes
- Today indicator highlights current date in grid
- Default expansion: Running and Failed swimlanes expanded, others collapsed
- Date range persisted in localStorage (`opsTimelineDateRange`)
- Responsive design: timeline disabled on mobile with fallback message

## Test plan

- [x] TypeScript compiles with no errors
- [x] All timeline components created and imported
- [x] Timeline view accessible via toggle in Ops page
- [x] Workshops grouped by status (Running/Failed/Upcoming/Stopped)
- [ ] Click workshop bar navigates to workshop detail page
- [ ] Click checkbox selects workshop for bulk operations
- [ ] Date preset buttons update view range correctly
- [ ] Custom date picker updates view
- [ ] All existing filters work with timeline view
- [ ] Selection state preserved when switching views
- [ ] Swimlane collapse/expand works
- [ ] Overlapping workshops stack correctly
- [ ] Today indicator shows on current date
- [ ] Bulk operations modal works with timeline-selected workshops

## Related

- Design spec: `docs/superpowers/specs/2026-06-10-ops-timeline-calendar-design.md`
- Implementation plan: `docs/superpowers/plans/2026-06-10-ops-timeline-calendar.md`
- Part of ops improvements series (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)