### PR TITLE
Fix critical shell-quote vulnerability (CVE, CVSS 9.2)

### DIFF
--- a/catalog/ui/package.json
+++ b/catalog/ui/package.json
@@ -83,6 +83,11 @@
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^6.0.1"
   },
+  "pnpm": {
+    "overrides": {
+      "shell-quote": ">=1.8.4"
+    }
+  },
   "dependencies": {
     "@lexical/code": "^0.44.0",
     "@lexical/html": "^0.44.0",

--- a/catalog/ui/pnpm-lock.yaml
+++ b/catalog/ui/pnpm-lock.yaml
@@ -4845,8 +4845,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -10156,7 +10156,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -11283,7 +11283,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
Override shell-quote to >=1.8.4 via pnpm.overrides to resolve Dependabot alert #412. The transitive dependency (via launch-editor) could not be updated by Dependabot automatically.