### PR TITLE
feat: handle workshopUiEnabledByDefault in operator and UI

### DIFF
--- a/agnosticv-operator/operator/agnosticvcomponent.py
+++ b/agnosticv-operator/operator/agnosticvcomponent.py
@@ -309,6 +309,10 @@ class AgnosticVComponent(KopfObject):
         return self.catalog_meta.get('workshopUiDisabled', False)
 
     @property
+    def catalog_workshop_ui_enabled_by_default(self):
+        return self.catalog_meta.get('workshopUiEnabledByDefault', False)
+
+    @property
     def catalog_workshop_ui_max_instances(self):
         return self.catalog_meta.get('workshopUiMaxInstances', 30)
 
@@ -747,6 +751,8 @@ class AgnosticVComponent(KopfObject):
                 definition['spec']['workshopUiDisabled'] = True
             else:
                 definition['spec']['workshopUiMaxInstances'] = self.catalog_workshop_ui_max_instances
+                if self.catalog_workshop_ui_enabled_by_default:
+                    definition['spec']['workshopUiEnabledByDefault'] = True
 
         return definition
 

--- a/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
@@ -167,6 +167,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
       user: { groups, roles, isAdmin },
       purposeOpts,
       sfdc_enabled,
+      workshop: workshopInitialProps,
     }),
   );
   let maxAutoDestroyTime = Math.min(

--- a/catalog/ui/src/app/Catalog/CatalogItemFormReducer.ts
+++ b/catalog/ui/src/app/Catalog/CatalogItemFormReducer.ts
@@ -284,6 +284,7 @@ function reduceFormStateInit(
   { isAdmin, groups, roles },
   purposeOpts: TPurposeOpts,
   sfdc_enabled: boolean,
+  workshopInitialProps?: WorkshopProps,
 ): FormState {
   const formGroups: FormStateParameterGroup[] = [];
   const parameters: { [name: string]: FormStateParameter } = {};
@@ -341,7 +342,7 @@ function reduceFormStateInit(
     serviceNamespace: serviceNamespace,
     termsOfServiceAgreed: false,
     termsOfServiceRequired: catalogItem.spec.termsOfService ? true : false,
-    workshop: null,
+    workshop: catalogItem.spec.workshopUiEnabledByDefault && workshopInitialProps ? workshopInitialProps : null,
     selfPacedLab: null,
     error: '',
     useAutoDetach: true,
@@ -517,6 +518,7 @@ export function reduceFormState(state: FormState, action: FormStateAction): Form
         action.user,
         action.purposeOpts,
         action.sfdc_enabled,
+        action.workshop,
       );
     case 'initDates':
       return {

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -185,6 +185,7 @@ export interface CatalogItemSpec {
     stopComplete?: MessageTemplate;
   };
   workshopUiDisabled?: boolean;
+  workshopUiEnabledByDefault?: boolean;
   workshopUiMaxInstances?: number;
   workshopUserMode?: string;
   parameters?: CatalogItemSpecParameter[];

--- a/helm/crds/catalogitems.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/catalogitems.babylon.gpte.redhat.com.yaml
@@ -545,6 +545,10 @@ spec:
                 description: >-
                   Boolean flag to indicate if the catalog item shoud not support the ability to enable the Workshop User Interface.
                 type: boolean
+              workshopUiEnabledByDefault:
+                description: >-
+                  Boolean flag to indicate if the Workshop User Interface toggle should be enabled by default in the order form.
+                type: boolean
               workshopUiMaxInstances:
                 description: >-
                   Maximum number of instances supported in a single the workshop. 0 means no limit.


### PR DESCRIPTION
Add support for the new workshopUiEnabledByDefault catalog property:
- CRD: add field to CatalogItem spec
- Operator: propagate the flag from agnosticv metadata to CatalogItem
- UI: initialize the workshop toggle as enabled when the flag is set