### PR TITLE
fix: resolve notifier OOMKilled by eliminating memory leak in scheduled tasks

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -207,10 +207,10 @@ notifier:
   resources:
     limits:
       cpu: "1"
-      memory: 640Mi
+      memory: 1Gi
     requests:
       cpu: 100m
-      memory: 640Mi
+      memory: 1Gi
 
 resourceBroker:
   api:

--- a/notifier/helm/values.yaml
+++ b/notifier/helm/values.yaml
@@ -61,10 +61,10 @@ smtp:
 resources:
   limits:
     cpu: "1"
-    memory: 640Mi
+    memory: 1Gi
   requests:
     cpu: 100m
-    memory: 640Mi
+    memory: 1Gi
 
 nodeSelector: {}
 

--- a/notifier/operator/operator.py
+++ b/notifier/operator/operator.py
@@ -310,7 +310,7 @@ async def cancel_workshop_tasks(workshop, logger):
         except asyncio.CancelledError:
             pass
 
-def create_retirement_task(logger, catalog_item, resource_claim, **kwargs):
+def create_retirement_task(logger, catalog_item, resource_claim, email_addresses, **_):
     retirement_timestamp = resource_claim.retirement_timestamp
     if not retirement_timestamp:
         return
@@ -325,14 +325,13 @@ def create_retirement_task(logger, catalog_item, resource_claim, **kwargs):
         retirement_tasks[resource_claim.uid] = asyncio.create_task(
             notify_retirement_scheduled_after(
                 interval = notification_interval,
-                logger = kopf.LocalObjectLogger(body=resource_claim.definition, settings=kopf.OperatorSettings()),
-                catalog_item = catalog_item,
-                resource_claim = resource_claim,
-                **kwargs,
+                resource_claim_name = resource_claim.name,
+                resource_claim_namespace = resource_claim.namespace,
+                email_addresses = email_addresses,
             )
         )
 
-def create_stop_task(logger, resource_claim, **kwargs):
+def create_stop_task(logger, resource_claim, email_addresses, **_):
     stop_timestamp = resource_claim.stop_timestamp
     if not stop_timestamp:
         return
@@ -344,13 +343,13 @@ def create_stop_task(logger, resource_claim, **kwargs):
         stop_tasks[resource_claim.uid] = asyncio.create_task(
             notify_stop_scheduled_after(
                 interval = notification_interval,
-                logger = kopf.LocalObjectLogger(body=resource_claim.definition, settings=kopf.OperatorSettings()),
-                resource_claim = resource_claim,
-                **kwargs,
+                resource_claim_name = resource_claim.name,
+                resource_claim_namespace = resource_claim.namespace,
+                email_addresses = email_addresses,
             )
         )
 
-def create_workshop_retirement_task(logger, workshop, **kwargs):
+def create_workshop_retirement_task(logger, workshop, email_addresses, **_):
     retirement_timestamp = workshop.lifespan_end
     if not retirement_timestamp:
         return
@@ -365,9 +364,9 @@ def create_workshop_retirement_task(logger, workshop, **kwargs):
         workshop_retirement_tasks[workshop.uid] = asyncio.create_task(
             notify_workshop_retirement_scheduled_after(
                 interval = notification_interval,
-                logger = kopf.LocalObjectLogger(body=workshop.definition, settings=kopf.OperatorSettings()),
-                workshop = workshop,
-                **kwargs,
+                workshop_name = workshop.name,
+                workshop_namespace = workshop.namespace,
+                email_addresses = email_addresses,
             )
         )
 
@@ -753,12 +752,31 @@ async def notify_ready(catalog_item, catalog_namespace, email_addresses, logger,
         to = email_addresses,
     )
 
-async def notify_retirement_scheduled_after(interval, resource_claim, **kwargs):
+async def notify_retirement_scheduled_after(interval, resource_claim_name, resource_claim_namespace, email_addresses):
+    logger = logging.getLogger(f"notify.retirement.{resource_claim_namespace}.{resource_claim_name}")
     try:
         await asyncio.sleep(interval)
-        await resource_claim.refetch()
-        if not resource_claim.ignore:
-            await notify_retirement_scheduled(resource_claim=resource_claim, **kwargs)
+
+        resource_claim = await ResourceClaim.get(resource_claim_name, resource_claim_namespace)
+        if not resource_claim or resource_claim.ignore:
+            return
+
+        catalog_item = await CatalogItem.get(
+            name=resource_claim.catalog_item_name,
+            namespace=resource_claim.catalog_item_namespace,
+        )
+        if not catalog_item:
+            return
+
+        catalog_namespace = await CatalogNamespace.get(resource_claim.catalog_item_namespace)
+
+        await notify_retirement_scheduled(
+            resource_claim=resource_claim,
+            catalog_item=catalog_item,
+            catalog_namespace=catalog_namespace,
+            email_addresses=email_addresses,
+            logger=logger,
+        )
     except asyncio.CancelledError:
         pass
 
@@ -775,12 +793,31 @@ async def notify_retirement_scheduled(catalog_item, catalog_namespace, email_add
         template = "retirement-scheduled",
     )
 
-async def notify_stop_scheduled_after(interval, resource_claim, **kwargs):
+async def notify_stop_scheduled_after(interval, resource_claim_name, resource_claim_namespace, email_addresses):
+    logger = logging.getLogger(f"notify.stop.{resource_claim_namespace}.{resource_claim_name}")
     try:
         await asyncio.sleep(interval)
-        await resource_claim.refetch()
-        if not resource_claim.ignore:
-            await notify_stop_scheduled(resource_claim=resource_claim, **kwargs)
+
+        resource_claim = await ResourceClaim.get(resource_claim_name, resource_claim_namespace)
+        if not resource_claim or resource_claim.ignore:
+            return
+
+        catalog_item = await CatalogItem.get(
+            name=resource_claim.catalog_item_name,
+            namespace=resource_claim.catalog_item_namespace,
+        )
+        if not catalog_item:
+            return
+
+        catalog_namespace = await CatalogNamespace.get(resource_claim.catalog_item_namespace)
+
+        await notify_stop_scheduled(
+            resource_claim=resource_claim,
+            catalog_item=catalog_item,
+            catalog_namespace=catalog_namespace,
+            email_addresses=email_addresses,
+            logger=logger,
+        )
     except asyncio.CancelledError:
         pass
 
@@ -887,12 +924,20 @@ async def notify_workshop_ready(email_addresses, logger, workshop):
         workshop = workshop,
     )
 
-async def notify_workshop_retirement_scheduled_after(interval, workshop, **kwargs):
+async def notify_workshop_retirement_scheduled_after(interval, workshop_name, workshop_namespace, email_addresses):
+    logger = logging.getLogger(f"notify.workshop.retirement.{workshop_namespace}.{workshop_name}")
     try:
         await asyncio.sleep(interval)
-        await workshop.refetch()
-        if not workshop.ignore:
-            await notify_workshop_retirement_scheduled(workshop=workshop, **kwargs)
+
+        workshop = await Workshop.get(workshop_name, workshop_namespace)
+        if not workshop or workshop.ignore:
+            return
+
+        await notify_workshop_retirement_scheduled(
+            workshop=workshop,
+            email_addresses=email_addresses,
+            logger=logger,
+        )
     except asyncio.CancelledError:
         pass
 

--- a/notifier/operator/resource_claim.py
+++ b/notifier/operator/resource_claim.py
@@ -1,3 +1,4 @@
+import kubernetes_asyncio
 import re
 
 from pydantic.v1.utils import deep_update
@@ -26,6 +27,23 @@ class DeployerJob:
         return self.definition.get('startTimestamp')
 
 class ResourceClaim:
+    @classmethod
+    async def get(cls, name, namespace):
+        try:
+            definition = await Babylon.custom_objects_api.get_namespaced_custom_object(
+                group=Babylon.resource_broker_domain,
+                name=name,
+                namespace=namespace,
+                plural='resourceclaims',
+                version=Babylon.resource_broker_api_version,
+            )
+            return ResourceClaim(definition=definition)
+        except kubernetes_asyncio.client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            else:
+                raise
+
     def __init__(self, definition):
         self.definition = definition
 


### PR DESCRIPTION


Scheduled notification tasks (retirement, stop, workshop retirement) were holding full Kubernetes object definitions in memory for hours/days while sleeping. With many active ResourceClaims, this caused unbounded memory growth past the 640Mi limit. Now tasks capture only lightweight identifiers and refetch objects when the timer fires. Memory limit bumped to 1Gi as additional headroom.