### PR TITLE
chore: bump component versions

### DIFF
--- a/agnosticv-operator/helm/Chart.yaml
+++ b/agnosticv-operator/helm/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: babylon-agnosticv-operator
 description: Operator for managing babylon configuraion from AgnosticV repositories
 type: application
-version: 2.6.1
-appVersion: 2.6.1
+version: 2.6.2
+appVersion: 2.6.2

--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -15,7 +15,7 @@ api:
     threads: 1
   image:
     #override:
-    tag: v1.2.5
+    tag: v1.2.6
     repository: quay.io/redhat-gpte/babylon-catalog-api
     pullPolicy: IfNotPresent
   imagePullSecrets: []
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.0
+    tag: v0.35.1
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,7 +23,7 @@ agnosticv:
   operator:
     image:
       repository: quay.io/rhpds/babylon-agnosticv-operator
-      tag: v2.6.1
+      tag: v2.6.2
       pullPolicy: IfNotPresent
     resources:
       limits:
@@ -98,7 +98,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-api
-        tag: v1.2.5
+        tag: v1.2.6
       loggingLevel: INFO
       replicaCount: 1
       resources:
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.0
+        tag: v0.35.1
       replicaCount: 1
       resources:
         requests:
@@ -181,7 +181,7 @@ notifier:
   image:
     repository: quay.io/rhpds/babylon-notifier
     pullPolicy: IfNotPresent
-    tag: v0.9.4
+    tag: v0.9.5
   namespace:
     create: true
     name: babylon-notifier
@@ -244,7 +244,7 @@ workshopManager:
   image:
     repository: quay.io/rhpds/babylon-workshop-manager
     pullPolicy: IfNotPresent
-    tag: v0.10.6
+    tag: v0.10.7
   namespace:
     create: true
     name: babylon-workshop-manager
@@ -265,7 +265,7 @@ selfpacedlabManager:
   image:
     repository: quay.io/rhpds/babylon-selfpacedlab-manager
     pullPolicy: IfNotPresent
-    tag: v0.0.1
+    tag: v0.0.2
   namespace:
     create: true
     name: babylon-selfpacedlab-manager
@@ -315,7 +315,7 @@ ratings:
   image:
     repository: quay.io/redhat-gpte/babylon-ratings
     pullPolicy: Always
-    tag: v1.0.11
+    tag: v1.0.12
   resources:
     limits:
       cpu: "1"

--- a/notifier/helm/Chart.yaml
+++ b/notifier/helm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.4
+version: 0.9.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.9.4
+appVersion: 0.9.5

--- a/ratings/helm/Chart.yaml
+++ b/ratings/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: babylon-ratings
 description: A Helm chart for the babylon ratings component.
 type: application
-version: 1.0.11
-appVersion: 1.0.11
+version: 1.0.12
+appVersion: 1.0.12

--- a/selfpacedlab-manager/helm/Chart.yaml
+++ b/selfpacedlab-manager/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: babylon-selfpacedlab-manager
 description: A Helm chart for the babylon self-paced lab manager component.
 type: application
-version: v0.1.0
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2

--- a/workshop-manager/helm/Chart.yaml
+++ b/workshop-manager/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: babylon-workshop-manager
 description: A Helm chart for the babylon lab ui manager component.
 type: application
-version: v0.10.5
-appVersion: v0.10.5
+version: 0.10.7
+appVersion: 0.10.7


### PR DESCRIPTION
- UI: v0.35.0 → v0.35.1
- API: v1.2.5 → v1.2.6
- Notifier: v0.9.4 → v0.9.5
- AgnosticV Operator: v2.6.1 → v2.6.2
- Workshop Manager: v0.10.6 → v0.10.7
- Ratings: v1.0.11 → v1.0.12
- Selfpaced Labs Manager: v0.0.1 → v0.0.2