### PR TITLE
fix: clean up selfpacedlab-manager caches on delete to prevent OOM

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -272,10 +272,10 @@ selfpacedlabManager:
   resources:
     limits:
       cpu: "1"
-      memory: 512Mi
+      memory: 1Gi
     requests:
       cpu: 100m
-      memory: 512Mi
+      memory: 1Gi
   selfpacedlabBaseUrl: ""
 
 admin:

--- a/selfpacedlab-manager/helm/values.yaml
+++ b/selfpacedlab-manager/helm/values.yaml
@@ -17,10 +17,10 @@ serviceAccount:
 resources:
   limits:
     cpu: "1"
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 1Gi
 
 nodeSelector: {}
 

--- a/selfpacedlab-manager/operator/selfpacedlab.py
+++ b/selfpacedlab-manager/operator/selfpacedlab.py
@@ -111,6 +111,7 @@ class SelfPacedLab(CachedKopfObject):
             logger.info(f"Handling delete for {self}")
             await self.delete_all_selfpacedlab_provision_items(logger=logger)
             await self.delete_all_resource_claims(logger=logger)
+            self.cache.pop(self.cache_key, None)
 
     async def handle_resume(self, logger):
         async with self.lock:

--- a/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
+++ b/selfpacedlab-manager/operator/selfpacedlabprovisionitem.py
@@ -269,6 +269,7 @@ class SelfPacedLabProvisionItem(CachedKopfObject):
         async with self.lock:
             logger.info(f"Handling delete for {self}")
             await self.delete_all_resource_claims(logger=logger)
+            self.cache.pop(self.cache_key, None)
 
     async def handle_resume(self, logger):
         async with self.lock:

--- a/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
+++ b/selfpacedlab-manager/operator/selfpacedlabuserassignment.py
@@ -170,6 +170,7 @@ class SelfPacedLabUserAssignment(CachedKopfObject):
     async def handle_delete(self, logger):
         async with self.lock:
             logger.info(f"Handling delete for {self}")
+            self.cache.pop(self.cache_key, None)
 
     async def handle_update(self, logger):
         async with self.lock:


### PR DESCRIPTION
When objects are deleted externally (by users, garbage collection, etc.), the kopf.on.delete handler processes the event but never removes the object from the in-memory cache. This causes unbounded memory growth as deleted objects accumulate, eventually OOMKilling the pod.

Add cache.pop() in handle_delete for SelfPacedLab, SelfPacedLabProvisionItem, and SelfPacedLabUserAssignment — matching the cleanup already done in CachedKopfObject.delete() for operator-initiated deletes.