### PR TITLE
fix: guard against null startDate in CatalogItemForm maxDestroyTimestamp

### DIFF
--- a/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
@@ -469,7 +469,7 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
           isAdmin
             ? null
             : formState.workshop
-              ? formState.startDate.getTime() - Date.now() + parseDuration('5d')
+              ? (formState.startDate ? formState.startDate.getTime() : Date.now()) - Date.now() + parseDuration('5d')
               : maxAutoDestroyTime
         }
         onConfirm={(dates: TDates) =>


### PR DESCRIPTION
formState.startDate can be null when currTime is not provided during initialization. Add null check consistent with other startDate usages in the same file to prevent TypeError at runtime.