### PR TITLE
fix(ui): update js-yaml imports for v5 compatibility

### DIFF
--- a/catalog/ui/src/app/Admin/AnarchyActionInstance.tsx
+++ b/catalog/ui/src/app/Admin/AnarchyActionInstance.tsx
@@ -17,7 +17,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiPaths, deleteAnarchyAction, fetcher } from '@app/api';
 import { selectedUidsReducer } from '@app/reducers';
 import { AnarchyAction, AnarchyRunList } from '@app/types';

--- a/catalog/ui/src/app/Admin/AnarchyGovernorInstance.tsx
+++ b/catalog/ui/src/app/Admin/AnarchyGovernorInstance.tsx
@@ -20,7 +20,7 @@ import {
   } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiPaths, deleteAnarchyGovernor, fetcher } from '@app/api';
 import { AnarchyGovernor, AnarchySubjectList } from '@app/types';
 import { ActionDropdown, ActionDropdownItem } from '@app/components/ActionDropdown';

--- a/catalog/ui/src/app/Admin/AnarchyRunInstance.tsx
+++ b/catalog/ui/src/app/Admin/AnarchyRunInstance.tsx
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiPaths, deleteAnarchyRun, fetcher, retryAnarchyRun } from '@app/api';
 import { AnarchyRun } from '@app/types';
 import { ActionDropdown, ActionDropdownItem } from '@app/components/ActionDropdown';

--- a/catalog/ui/src/app/Admin/AnarchySubjectInstance.tsx
+++ b/catalog/ui/src/app/Admin/AnarchySubjectInstance.tsx
@@ -20,7 +20,7 @@ import {
   } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import {
   apiPaths,
   deleteAnarchyAction,

--- a/catalog/ui/src/app/Admin/CreateResourcePoolFromResourceHandleModal.tsx
+++ b/catalog/ui/src/app/Admin/CreateResourcePoolFromResourceHandleModal.tsx
@@ -5,7 +5,7 @@ import { Checkbox, Form, FormGroup, NumberInput, TextArea, TextInput, Tooltip } 
 import { ResourceClaim, ResourceHandle } from '@app/types';
 import { createResourcePool, getResourcePool } from '@app/api';
 import { BABYLON_DOMAIN, FETCH_BATCH_LIMIT } from '@app/util';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import useMatchMutate from '@app/utils/useMatchMutate';
 
 const formFieldStyle: CSSProperties = {

--- a/catalog/ui/src/app/Admin/ResourceHandleInstance.tsx
+++ b/catalog/ui/src/app/Admin/ResourceHandleInstance.tsx
@@ -18,7 +18,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiPaths, deleteResourceHandle, fetcher } from '@app/api';
 import { BABYLON_DOMAIN, compareK8sObjects } from '@app/util';
 import { ResourceClaim, ResourceHandle } from '@app/types';

--- a/catalog/ui/src/app/Admin/ResourcePoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/ResourcePoolInstance.tsx
@@ -26,7 +26,7 @@ import {
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import {
   apiPaths,
   createResourcePoolScaling,

--- a/catalog/ui/src/app/Admin/ResourceProviderInstance.tsx
+++ b/catalog/ui/src/app/Admin/ResourceProviderInstance.tsx
@@ -16,7 +16,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiPaths, deleteResourceProvider, fetcher } from '@app/api';
 import { ResourceProvider, ResourceProviderList } from '@app/types';
 import { ActionDropdown, ActionDropdownItem } from '@app/components/ActionDropdown';

--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopDetail.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import useSWR, { mutate } from 'swr';
 import { DragDropSort, DragDropSortDragEndEvent } from '@patternfly/react-drag-drop';
 import {

--- a/catalog/ui/src/app/SelfPacedLab/SelfPacedLabContent.tsx
+++ b/catalog/ui/src/app/SelfPacedLab/SelfPacedLabContent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { renderContent } from '@app/util';
 import EditorViewer from '@app/components/Editor/EditorViewer';

--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation, Link, useParams } from 'react-router-dom';
 import { EditorState, LexicalEditor } from 'lexical';
 import { $generateHtmlFromNodes } from '@lexical/html';
 import MonacoEditor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import useSWR, { useSWRConfig } from 'swr';
 import {
   Breadcrumb,

--- a/catalog/ui/src/app/Services/ServiceItemStatus.tsx
+++ b/catalog/ui/src/app/Services/ServiceItemStatus.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import RedoIcon from '@patternfly/react-icons/dist/js/icons/redo-icon';
 import { BABYLON_DOMAIN } from '@app/util';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { AnarchySubject, ResourceClaim, ResourceClaimSpecResourceTemplate } from '@app/types';
 import LocalTimestamp from '@app/components/LocalTimestamp';
 

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import useSWR, { useSWRConfig } from 'swr';
 import {
   Breadcrumb,

--- a/catalog/ui/src/app/Workshop/WorkshopContent.tsx
+++ b/catalog/ui/src/app/Workshop/WorkshopContent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { renderContent } from '@app/util';
 import EditorViewer from '@app/components/Editor/EditorViewer';

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useLocation, Link, useParams } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import useSWR, { useSWRConfig } from 'swr';
 import {
   Alert,

--- a/catalog/ui/src/app/Workshops/WorkshopsItemProvisioningItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemProvisioningItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import {
   CodeBlock,
   CodeBlockCode,

--- a/catalog/ui/src/app/Workshops/WorkshopsItemUserAssignments.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemUserAssignments.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import {
   ActionGroup,
   Button,

--- a/catalog/ui/src/app/components/AnsibleRunLog.tsx
+++ b/catalog/ui/src/app/components/AnsibleRunLog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import './ansible-run-log.css';
 


### PR DESCRIPTION
js-yaml v5 removed its default export. Use namespace import instead.