### PR TITLE
fix(ui): set NODE_ENV=production for Docker build

### DIFF
--- a/catalog/ui/Dockerfile
+++ b/catalog/ui/Dockerfile
@@ -22,7 +22,7 @@ RUN npm install -g pnpm@11.1.2
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN pnpm install --frozen-lockfile
 COPY ./ ./
-RUN pnpm run build
+RUN NODE_ENV=production pnpm run build
 
 # Server image
 FROM registry.access.redhat.com/ubi8/nginx-118:latest


### PR DESCRIPTION
Babel preset-react with runtime: automatic checks NODE_ENV at build time to decide which JSX transform to emit. Without NODE_ENV=production, it emits jsxDEV calls (development runtime), causing 'Uncaught TypeError: (0, ce.jsxDEV) is not a function' in the production container because React production bundle does not export jsxDEV.

Setting NODE_ENV inline on the build command (not as an ENV) avoids breaking pnpm install, which would skip devDependencies if NODE_ENV were set to production during install.