### PR TITLE
feat(ui): populate Placements and Sandbox API columns on shared clusters admin page

### DIFF
--- a/catalog/ui/src/app/Admin/SharedClusters.tsx
+++ b/catalog/ui/src/app/Admin/SharedClusters.tsx
@@ -17,6 +17,7 @@ import {
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 import { apiPaths, deleteResourceClaim, fetcher, silentFetcher } from '@app/api';
 import { ResourceClaim, ResourceClaimList } from '@app/types';
@@ -107,13 +108,102 @@ function keywordMatch(r: ResourceClaim, keyword: string): boolean {
 }
 
 const PlacementsCell: React.FC<{ clusterName: string }> = ({ clusterName }) => {
+  const { data: placementsData } = useSWR(
+    clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
+    silentFetcher,
+    { shouldRetryOnError: false, suspense: false },
+  );
+  const { data: configData } = useSWR(
+    clusterName ? apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName }) : null,
+    silentFetcher,
+    { shouldRetryOnError: false, suspense: false },
+  );
+  const count = placementsData?.placements?.length ?? 0;
+  const max = configData?.max_placements;
+  if (!placementsData?.placements && !configData) return <span className="shared-clusters-muted">-</span>;
+  if (max != null) return <span>{count} / {max}</span>;
+  return <span>{count}</span>;
+};
+
+const SandboxApiCell: React.FC<{ clusterName: string }> = ({ clusterName }) => {
   const { data } = useSWR(
     clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
     silentFetcher,
     { shouldRetryOnError: false, suspense: false },
   );
-  if (!data?.placements) return <span className="shared-clusters-muted">-</span>;
-  return <span>{data.placements.length}</span>;
+  if (data === undefined) return <span className="shared-clusters-muted">-</span>;
+  if (data?.placements) {
+    return (
+      <span className="shared-clusters-onboarded">
+        <CheckCircleIcon /> Onboarded
+      </span>
+    );
+  }
+  return <span className="shared-clusters-not-onboarded">Not onboarded</span>;
+};
+
+const GroupSandboxCells: React.FC<{ clusters: ResourceClaim[] }> = ({ clusters }) => {
+  const clusterNames = useMemo(
+    () => clusters.map((c) => c.status?.resourceHandle?.name).filter(Boolean),
+    [clusters],
+  );
+  const sortedKey = useMemo(() => clusterNames.slice().sort().join(','), [clusterNames]);
+
+  const { data } = useSWR(
+    sortedKey ? `group-sandbox:${sortedKey}` : null,
+    async () => {
+      const results = await Promise.all(
+        clusterNames.map(async (name) => {
+          const [placementsRes, configRes] = await Promise.allSettled([
+            silentFetcher(apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName: name })),
+            silentFetcher(apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName: name })),
+          ]);
+          const placements = placementsRes.status === 'fulfilled' ? placementsRes.value : null;
+          const config = configRes.status === 'fulfilled' ? configRes.value : null;
+          return {
+            count: placements?.placements?.length ?? 0,
+            max: config?.max_placements ?? null,
+            isOnboarded: !!placements?.placements,
+          };
+        }),
+      );
+      return results;
+    },
+    { shouldRetryOnError: false, suspense: false },
+  );
+
+  if (!data) {
+    return (
+      <>
+        <td className="shared-clusters-muted">-</td>
+        <td className="shared-clusters-muted">-</td>
+      </>
+    );
+  }
+
+  const totalCurrent = data.reduce((sum, d) => sum + d.count, 0);
+  const totalMax = data.reduce((sum, d) => sum + (d.max ?? 0), 0);
+  const hasMax = data.some((d) => d.max != null);
+  const onboardedCount = data.filter((d) => d.isOnboarded).length;
+  const totalCount = data.length;
+  const allOnboarded = onboardedCount === totalCount;
+
+  return (
+    <>
+      <td>
+        {hasMax ? `${totalCurrent} / ${totalMax}` : totalCurrent}
+      </td>
+      <td>
+        <span className={allOnboarded ? 'shared-clusters-onboarded' : 'shared-clusters-not-onboarded'}>
+          {allOnboarded ? (
+            <><CheckCircleIcon /> Onboarded</>
+          ) : (
+            `${onboardedCount}/ ${totalCount} onboarded`
+          )}
+        </span>
+      </td>
+    </>
+  );
 };
 
 const SharedClusters: React.FC = () => {
@@ -364,8 +454,7 @@ const SharedClusters: React.FC = () => {
                             <div>{statusSummary}</div>
                           </div>
                         </td>
-                        <td className="shared-clusters-muted">-</td>
-                        <td className="shared-clusters-muted">-</td>
+                        <GroupSandboxCells clusters={group.clusters} />
                         <td></td>
                         <td></td>
                       </tr>
@@ -390,7 +479,9 @@ const SharedClusters: React.FC = () => {
                               <td>
                                 <PlacementsCell clusterName={cluster.status?.resourceHandle?.name || ''} />
                               </td>
-                              <td className="shared-clusters-muted">-</td>
+                              <td>
+                                <SandboxApiCell clusterName={cluster.status?.resourceHandle?.name || ''} />
+                              </td>
                               <td>
                                 <TimeInterval toTimestamp={cluster.metadata.creationTimestamp} />
                               </td>

--- a/catalog/ui/src/app/Admin/admin.css
+++ b/catalog/ui/src/app/Admin/admin.css
@@ -136,6 +136,19 @@
   text-decoration: underline;
 }
 
+.shared-clusters-onboarded {
+  color: var(--pf-t--global--color--status--success--default);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.shared-clusters-not-onboarded {
+  color: var(--pf-t--global--color--status--warning--default);
+  white-space: nowrap;
+}
+
 /* Dark mode */
 :root.pf-v6-theme-dark .shared-clusters-table-wrap thead th {
   border-bottom-color: color-mix(in srgb, var(--pf-t--global--border--color--default) 70%, white);

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -90,6 +90,7 @@ import {
   namespaceToServiceNamespaceMapper,
   isLabDeveloper,
   DEMO_DOMAIN,
+  extractErrorMessage,
   getWhiteGloved,
   parseSalesforceItems,
 } from '@app/util';
@@ -118,6 +119,7 @@ import ServiceItemStatus from './ServiceItemStatus';
 import InfoTab from './InfoTab';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import LockIcon from '@patternfly/react-icons/dist/js/icons/lock-icon';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import useDebounceState from '@app/utils/useDebounceState';
 import SalesforceItemsList from '@app/components/SalesforceItemsList';
@@ -369,6 +371,7 @@ const ServicesItemComponent: React.FC<{
   const clusterName = resourceClaim.status?.resourceHandle?.name || '';
   const {
     data: placementsData,
+    isLoading: placementsLoading,
     mutate: mutatePlacements,
   } = useSWR(
     isSharedClusterItem && clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
@@ -385,9 +388,13 @@ const ServicesItemComponent: React.FC<{
     { shouldRetryOnError: false, suspense: false },
   );
   const isClusterEnabled = clusterConfigData?.valid === true;
+  const isClusterLocked = clusterConfigData?.settings?.locked === true;
+  const clusterLockMessage = clusterConfigData?.settings?.lock_message as string | undefined;
   const [onboardLoading, setOnboardLoading] = useState(false);
   const [toggleLoading, setToggleLoading] = useState(false);
   const [offboardLoading, setOffboardLoading] = useState(false);
+  const [sandboxError, setSandboxError] = useState<string | null>(null);
+  const [sandboxInfo, setSandboxInfo] = useState<string | null>(null);
 
   const [serviceAlias, setServiceAlias] = useState(
     resourceClaim.metadata.annotations?.[`${DEMO_DOMAIN}/service-alias`] || '',
@@ -1236,53 +1243,89 @@ const ServicesItemComponent: React.FC<{
                     <DescriptionListGroup>
                       <DescriptionListTerm>Sandbox API Status</DescriptionListTerm>
                       <DescriptionListDescription>
-                        {isOnboarded ? (
+                        {placementsLoading ? (
+                          <Spinner size="md" />
+                        ) : isOnboarded ? (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--sm)' }}>
                             <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
                               <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
                               Onboarded — {isClusterEnabled ? 'Enabled' : 'Disabled'}
+                              {isClusterLocked ? (
+                                <Tooltip content={clusterLockMessage || 'Cluster configuration is locked'}>
+                                  <LockIcon />
+                                </Tooltip>
+                              ) : null}
                             </span>
+                            {sandboxError ? (
+                              <Alert variant="danger" isInline isPlain title={sandboxError} />
+                            ) : null}
+                            {sandboxInfo ? (
+                              <Alert variant="info" isInline isPlain title={sandboxInfo} />
+                            ) : null}
                             <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)' }}>
-                              <Button
-                                variant={isClusterEnabled ? 'secondary' : 'primary'}
-                                isDanger={isClusterEnabled}
-                                isLoading={toggleLoading}
-                                isDisabled={toggleLoading || offboardLoading || !clusterConfigData}
-                                onClick={async () => {
-                                  setToggleLoading(true);
-                                  try {
-                                    if (isClusterEnabled) {
-                                      await disableSandboxCluster(clusterName);
-                                    } else {
-                                      await enableSandboxCluster(clusterName);
-                                    }
-                                    mutateClusterConfig();
-                                  } finally {
-                                    setToggleLoading(false);
-                                  }
-                                }}
+                              <Tooltip
+                                content={isClusterLocked ? (clusterLockMessage || 'Cluster configuration is locked') : ''}
+                                trigger={isClusterLocked ? 'mouseenter focus' : 'manual'}
                               >
-                                {isClusterEnabled ? 'Disable' : 'Enable'}
-                              </Button>
-                              {!isClusterEnabled ? (
                                 <Button
-                                  variant="secondary"
-                                  isDanger
-                                  isLoading={offboardLoading}
-                                  isDisabled={offboardLoading || toggleLoading}
+                                  variant={isClusterEnabled ? 'secondary' : 'primary'}
+                                  isDanger={isClusterEnabled}
+                                  isLoading={toggleLoading}
+                                  isDisabled={toggleLoading || offboardLoading || !clusterConfigData || isClusterLocked}
                                   onClick={async () => {
-                                    setOffboardLoading(true);
+                                    setToggleLoading(true);
+                                    setSandboxError(null);
+                                    setSandboxInfo(null);
                                     try {
-                                      await offboardSandboxCluster(clusterName);
-                                      mutatePlacements();
+                                      if (isClusterEnabled) {
+                                        await disableSandboxCluster(clusterName);
+                                      } else {
+                                        await enableSandboxCluster(clusterName);
+                                      }
                                       mutateClusterConfig();
+                                    } catch (err) {
+                                      const message = await extractErrorMessage(err, `Failed to ${isClusterEnabled ? 'disable' : 'enable'} cluster`);
+                                      setSandboxError(message);
                                     } finally {
-                                      setOffboardLoading(false);
+                                      setToggleLoading(false);
                                     }
                                   }}
                                 >
-                                  Offboard
+                                  {isClusterEnabled ? 'Disable' : 'Enable'}
                                 </Button>
+                              </Tooltip>
+                              {!isClusterEnabled ? (
+                                <Tooltip
+                                  content={isClusterLocked ? (clusterLockMessage || 'Cluster configuration is locked') : ''}
+                                  trigger={isClusterLocked ? 'mouseenter focus' : 'manual'}
+                                >
+                                  <Button
+                                    variant="secondary"
+                                    isDanger
+                                    isLoading={offboardLoading}
+                                    isDisabled={offboardLoading || toggleLoading || isClusterLocked}
+                                    onClick={async () => {
+                                      setOffboardLoading(true);
+                                      setSandboxError(null);
+                                      setSandboxInfo(null);
+                                      try {
+                                        const result = await offboardSandboxCluster(clusterName) as { request_id?: string; status?: string; message?: string };
+                                        if (result?.request_id && result?.status !== 'success') {
+                                          setSandboxInfo(result.message || 'Offboarding in progress. The cluster will be removed once cleanup completes.');
+                                        }
+                                        mutatePlacements();
+                                        mutateClusterConfig();
+                                      } catch (err) {
+                                        const message = await extractErrorMessage(err, 'Failed to offboard cluster');
+                                        setSandboxError(message);
+                                      } finally {
+                                        setOffboardLoading(false);
+                                      }
+                                    }}
+                                  >
+                                    Offboard
+                                  </Button>
+                                </Tooltip>
                               ) : null}
                             </div>
                           </div>
@@ -1296,6 +1339,9 @@ const ServicesItemComponent: React.FC<{
                             >
                               <p>Tenants will not be able to discover or request placements on this cluster until it is onboarded.</p>
                             </Alert>
+                            {sandboxError ? (
+                              <Alert variant="danger" isInline isPlain title={sandboxError} />
+                            ) : null}
                             <Button
                               style={{ alignSelf: 'flex-start' }}
                               variant="primary"
@@ -1303,9 +1349,14 @@ const ServicesItemComponent: React.FC<{
                               isDisabled={onboardLoading}
                               onClick={async () => {
                                 setOnboardLoading(true);
+                                setSandboxError(null);
+                                setSandboxInfo(null);
                                 try {
                                   await onboardSandboxApi(clusterName);
                                   mutatePlacements();
+                                } catch (err) {
+                                  const message = await extractErrorMessage(err, 'Failed to onboard cluster');
+                                  setSandboxError(message);
                                 } finally {
                                   setOnboardLoading(false);
                                 }

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -1223,7 +1223,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListDescription>
                   </DescriptionListGroup>
 
-                  {isSharedClusterItem ? (
+                  {isSharedClusterItem && clusterName ? (
                     <DescriptionListGroup>
                       <DescriptionListTerm>Active Placements</DescriptionListTerm>
                       <DescriptionListDescription>
@@ -1232,7 +1232,7 @@ const ServicesItemComponent: React.FC<{
                     </DescriptionListGroup>
                   ) : null}
 
-                  {isSharedClusterItem ? (
+                  {isSharedClusterItem && clusterName ? (
                     <DescriptionListGroup>
                       <DescriptionListTerm>Sandbox API Status</DescriptionListTerm>
                       <DescriptionListDescription>

--- a/catalog/ui/src/app/util.ts
+++ b/catalog/ui/src/app/util.ts
@@ -546,12 +546,21 @@ export function getFirstSalesforceItem(annotations: Record<string, string>): Sal
 export function upsertSalesforceItem(annotations: Record<string, string>, newItem: SalesforceItem): void {
   const items = parseSalesforceItems(annotations);
   const existingIndex = items.findIndex(item => item.type === newItem.type);
-  
+
   if (existingIndex >= 0) {
     items[existingIndex] = newItem;
   } else {
     items.push(newItem);
   }
-  
+
   setSalesforceItems(annotations, items);
+}
+
+export async function extractErrorMessage(err: unknown, fallback: string): Promise<string> {
+  try {
+    const body = await (err as Response).json();
+    return body?.message || fallback;
+  } catch {
+    return fallback;
+  }
 }


### PR DESCRIPTION


Replace placeholder dashes with live data from the Sandbox API:
- PlacementsCell now shows "current / max" by fetching both placements and cluster config endpoints
- SandboxApiCell shows onboarded status with green/orange indicators
- GroupSandboxCells aggregates placements totals and onboarded counts for group header rows
- Add guard for clusterName in ServicesItem shared cluster sections