### PR TITLE
fix(notifier): enable SSL certificate validation on deployer API calls

### DIFF
--- a/notifier/operator/operator.py
+++ b/notifier/operator/operator.py
@@ -398,7 +398,6 @@ async def get_deployer_log(deployer_job, logger):
                 f"https://{hostname}/api/v2/jobs/{deployer_job.job_id}/stdout/?format=txt",
                 auth = aiohttp.BasicAuth(user, password),
                 raise_for_status = True,
-                verify_ssl = False,
             ) as response:
                 return await response.text()
     except Exception as err:


### PR DESCRIPTION
Remove `verify_ssl = False` from the aiohttp session.get() call in get_deployer_log(). SSL verification is now enabled (the default), preventing potential MITM attacks when fetching deployer job logs.

Resolves SonarQube python:S4830.