### PR TITLE
Bump babylon_anarchy_governor to v0.32.5

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,7 +65,7 @@ anarchy:
     sources:
       babylon_anarchy_governor:
         src: https://github.com/rhpds/babylon_anarchy_governor.git
-        version: v0.32.4
+        version: v0.32.5
   api:
     group: anarchy.gpte.redhat.com
     version: v1


### PR DESCRIPTION
Add controller-scheduler integration for intelligent controller selection based on real-time Prometheus metrics (capacity, failure rate, availability, pending jobs) with fallback to existing random/balance/first-available logic.