### PR TITLE
feat(api): add dedicated token for shared cluster manager endpoints

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -32,6 +32,7 @@ ratings_api = os.environ.get('RATINGS_API', 'http://babylon-ratings.babylon-rati
 reporting_api = os.environ.get('SALESFORCE_API', 'http://reporting-api.demo-reporting.svc.cluster.local:8080')
 sandbox_api = os.environ.get('SANDBOX_API', 'http://sandbox-api.babylon-sandbox-api.svc.cluster.local:8080')
 sandbox_api_authorization_token = os.environ.get('SANDBOX_AUTHORIZATION_TOKEN')
+shared_cluster_manager_token = os.environ.get('SHARED_CLUSTER_MANAGER_TOKEN')
 reporting_api_authorization_token = os.environ.get('SALESFORCE_AUTHORIZATION_TOKEN')
 response_cache = {}
 response_cache_clean_interval = int(os.environ.get('RESPONSE_CACHE_CLEAN_INTERVAL', 60))
@@ -801,7 +802,7 @@ async def sandbox_cluster_placements(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:
@@ -826,7 +827,7 @@ async def sandbox_cluster_config(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:
@@ -851,7 +852,7 @@ async def sandbox_cluster_enable(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:
@@ -876,7 +877,7 @@ async def sandbox_cluster_disable(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:
@@ -901,7 +902,7 @@ async def sandbox_cluster_offboard(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:
@@ -978,7 +979,7 @@ async def sandbox_onboard(request):
 
     async with aiohttp.ClientSession() as session:
         login_headers = {
-            "Authorization": f"Bearer {sandbox_api_authorization_token}"
+            "Authorization": f"Bearer {shared_cluster_manager_token}"
         }
         async with session.get(f"{sandbox_api}/api/v1/login", headers=login_headers) as login_resp:
             if login_resp.status != 200:

--- a/catalog/helm/templates/_helpers.tpl
+++ b/catalog/helm/templates/_helpers.tpl
@@ -227,3 +227,10 @@ Sandbox API secret name
 {{- define "babylonCatalog.sandboxApiSecretName" -}}
   {{- .Values.sandboxApi.secretName }}
 {{- end -}}
+
+{{/*
+Shared Cluster Manager secret name
+*/}}
+{{- define "babylonCatalog.sharedClusterManagerSecretName" -}}
+  {{- .Values.sharedClusterManager.secretName }}
+{{- end -}}

--- a/catalog/helm/templates/api/deployment.yaml
+++ b/catalog/helm/templates/api/deployment.yaml
@@ -51,6 +51,11 @@ spec:
             secretKeyRef:
               name: {{ include "babylonCatalog.sandboxApiSecretName" . }}
               key: sandbox-api-token
+        - name: SHARED_CLUSTER_MANAGER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "babylonCatalog.sharedClusterManagerSecretName" . }}
+              key: shared-cluster-manager-token
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/catalog/helm/templates/api/shared-cluster-manager-secret.yaml
+++ b/catalog/helm/templates/api/shared-cluster-manager-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.sharedClusterManager.deploy }}
+apiVersion: bitwarden-k8s-secrets-manager.demo.redhat.com/v1
+kind: BitwardenSyncSecret
+metadata:
+  name: {{ .Values.sharedClusterManager.secretName | default "sandbox-api-shared-cluster-manager" }}
+  namespace: {{ include "babylonCatalog.namespaceName" . }}
+spec:
+  data:
+    shared-cluster-manager-token:
+      secret: sandbox_api_shared-cluster-manager_login_token
+{{- end }}

--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -127,3 +127,7 @@ salesforceApi:
 sandboxApi:
   deploy: true
   secretName: sandbox-api
+
+sharedClusterManager:
+  deploy: true
+  secretName: sandbox-api-shared-cluster-manager

--- a/helm/templates/catalog/interfaces/api/deployment.yaml
+++ b/helm/templates/catalog/interfaces/api/deployment.yaml
@@ -45,6 +45,11 @@ spec:
             secretKeyRef:
               name: sandbox-api
               key: sandbox-api-token
+        - name: SHARED_CLUSTER_MANAGER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sandbox-api-shared-cluster-manager
+              key: shared-cluster-manager-token
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/helm/templates/catalog/interfaces/api/shared-cluster-manager-secret.yaml
+++ b/helm/templates/catalog/interfaces/api/shared-cluster-manager-secret.yaml
@@ -1,0 +1,12 @@
+{{- range $namespace, $interface := .Values.catalog.interfaces }}
+---
+apiVersion: bitwarden-k8s-secrets-manager.demo.redhat.com/v1
+kind: BitwardenSyncSecret
+metadata:
+  name: sandbox-api-shared-cluster-manager
+  namespace: {{ $namespace }}
+spec:
+  data:
+    shared-cluster-manager-token:
+      secret: sandbox_api_shared-cluster-manager_login_token
+{{- end }}


### PR DESCRIPTION
Use a separate Bitwarden-managed token (sandbox_api_shared-cluster-manager_login_token) for ocp-shared-cluster-configurations endpoints instead of the general sandbox API token.