### PR TITLE
fix(notifier): handle string provision_message_body to prevent empty email body

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -181,7 +181,7 @@ notifier:
   image:
     repository: quay.io/rhpds/babylon-notifier
     pullPolicy: IfNotPresent
-    tag: v0.9.5
+    tag: v0.9.6
   namespace:
     create: true
     name: babylon-notifier

--- a/notifier/helm/Chart.yaml
+++ b/notifier/helm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.9.5
+appVersion: 0.9.6

--- a/notifier/operator/resource_claim.py
+++ b/notifier/operator/resource_claim.py
@@ -1,3 +1,4 @@
+import json
 import kubernetes_asyncio
 import re
 
@@ -221,8 +222,15 @@ class ResourceClaim:
         for status_resource in self.definition['status']['resources']:
             resource_state = status_resource['state']
             if resource_state['kind'] == 'AnarchySubject':
-                message_body.extend(resource_state['spec'].get('vars', {}).get('provision_message_body', []))
-        return message_body
+                raw = resource_state['spec'].get('vars', {}).get('provision_message_body', [])
+                if isinstance(raw, str):
+                    try:
+                        raw = json.loads(raw)
+                    except (json.JSONDecodeError, TypeError):
+                        raw = [raw]
+                if isinstance(raw, list):
+                    message_body.extend(raw)
+        return [m for m in message_body if isinstance(m, str) and m.strip()]
 
     @property
     def provision_messages(self):


### PR DESCRIPTION


When provision_message_body is a string (e.g. '[]') instead of a list, list.extend() iterates over its characters, producing ['[', ']'] which short-circuits the normal template rendering and shows empty brackets in the service-ready email. Parse strings as JSON and filter out empty entries so the email falls through to the provision_messages template.