### PR TITLE
feat(ui): replace estimated hourly cost with visual cost tier indicator

### DIFF
--- a/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
@@ -54,7 +54,6 @@ import {
   getRating,
   CUSTOM_LABELS,
   sortLabels,
-  formatCurrency,
   getLastSuccessfulProvisionTime,
   convertToGitHubUrl,
   getStatus,
@@ -65,6 +64,7 @@ import CatalogItemHealthDisplay from './CatalogItemHealthDisplay';
 import useHelpLink from '@app/utils/useHelpLink';
 import useSWRImmutable from 'swr/immutable';
 import UptimeDisplay from '@app/components/UptimeDisplay';
+import CostTierDisplay from '@app/components/CostTierDisplay';
 import { StarIcon } from '@patternfly/react-icons/dist/js/icons/star-icon';
 import { OutlinedStarIcon } from '@patternfly/react-icons/dist/js/icons/outlined-star-icon';
 
@@ -388,20 +388,9 @@ const CatalogItemDetails: React.FC<{ catalogItem: CatalogItem; onClose: () => vo
 
               {metrics?.medianRuntimeCostByHour ? (
                 <DescriptionListGroup className="catalog-item-details__estimated-cost">
-                  <DescriptionListTerm>
-                    Estimated Hourly Cost
-                    <Tooltip content="Estimated hourly cost if not stopped.">
-                      <InfoAltIcon
-                        style={{
-                          paddingTop: 'var(--pf-t--global--spacer--xs)',
-                          marginLeft: 'var(--pf-t--global--spacer--xs)',
-                          width: 'var(--pf-t--global--icon--size--font--xs)',
-                        }}
-                      />
-                    </Tooltip>
-                  </DescriptionListTerm>
+                  <DescriptionListTerm>Cost</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {formatCurrency(metrics?.medianLifetimeCostByHour * 1.1)}
+                    <CostTierDisplay hourlyCost={metrics.medianLifetimeCostByHour * 1.1} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               ) : null}

--- a/catalog/ui/src/app/Catalog/catalog-item-details.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-details.css
@@ -61,6 +61,7 @@
   text-transform: capitalize;
 }
 
+.catalog-item-details__estimated-cost .pf-v6-c-description-list__text,
 .catalog-item-details__estimated-time .pf-v6-c-description-list__text,
 .catalog-item-details__last-update .pf-v6-c-description-list__text,
 .catalog-item-details__last-provision .pf-v6-c-description-list__text {

--- a/catalog/ui/src/app/Catalog/catalog-utils.ts
+++ b/catalog/ui/src/app/Catalog/catalog-utils.ts
@@ -51,6 +51,14 @@ export function getRating(catalogItem: CatalogItem): { ratingScore: number; tota
   }
   return null;
 }
+export type CostTier = 1 | 2 | 3;
+
+export function getCostTier(hourlyCost: number): CostTier {
+  if (hourlyCost <= 0.5) return 1;
+  if (hourlyCost <= 1.5) return 2;
+  return 3;
+}
+
 export function formatCurrency(value: number) {
   if (isNaN(value)) return null;
   const currencyFormatter = new Intl.NumberFormat('en-US', {

--- a/catalog/ui/src/app/components/CostTierDisplay.tsx
+++ b/catalog/ui/src/app/components/CostTierDisplay.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { getCostTier, formatCurrency } from '@app/Catalog/catalog-utils';
+
+import './cost-tier-display.css';
+
+const tierLabels = ['Low', 'Medium', 'High'];
+
+const CostTierDisplay: React.FC<{ hourlyCost: number }> = ({ hourlyCost }) => {
+  const tier = getCostTier(hourlyCost);
+  const formattedCost = formatCurrency(hourlyCost);
+
+  return (
+    <Tooltip
+      content={
+        <div>
+          <div>{formattedCost}/hr</div>
+          <div>Cost level: {tierLabels[tier - 1]}</div>
+        </div>
+      }
+    >
+      <span className="cost-tier-display" tabIndex={0}>
+        {[1, 2, 3].map((level) => (
+          <span
+            key={level}
+            className={`cost-tier-display__sign ${
+              level <= tier ? 'cost-tier-display__sign--active' : 'cost-tier-display__sign--inactive'
+            }`}
+          >
+            $
+          </span>
+        ))}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default CostTierDisplay;

--- a/catalog/ui/src/app/components/cost-tier-display.css
+++ b/catalog/ui/src/app/components/cost-tier-display.css
@@ -1,0 +1,20 @@
+.cost-tier-display {
+  display: inline-flex;
+  gap: 1px;
+  cursor: default;
+}
+
+.cost-tier-display__sign {
+  font-size: var(--pf-t--global--font--size--md);
+  line-height: 1;
+}
+
+.cost-tier-display__sign--active {
+  color: var(--pf-t--color--red--50, #ee0000);
+  font-weight: var(--pf-t--global--font--weight--400);
+}
+
+.cost-tier-display__sign--inactive {
+  color: var(--pf-t--color--gray--60);
+  opacity: 0.4;
+}


### PR DESCRIPTION
Show $, $$, or $$$ instead of a raw dollar amount on the catalog item details sidebar, making it easier to gauge cost at a glance. The exact hourly cost is still available in a tooltip on hover.

Tier thresholds (based on catalog distribution):
  $   ≤ $0.50/hr
  $$  ≤ $1.50/hr
  $$$ > $1.50/hr