### PR TITLE
Bump babylon-anarchy-governor version to v0.32.6

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,7 +65,7 @@ anarchy:
     sources:
       babylon_anarchy_governor:
         src: https://github.com/rhpds/babylon_anarchy_governor.git
-        version: v0.32.5
+        version: v0.32.6
   api:
     group: anarchy.gpte.redhat.com
     version: v1


### PR DESCRIPTION
Bumping `babylon-anarchy-governor` version to v0.32.6. This version adds support for RosaSandbox placements.