### PR TITLE
ci: standardize SonarQube pipeline and add test stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,46 +1,35 @@
 ---
+include:
+  - project: enterprise-pipelines/gitlab-ci/includes
+    file: SAST/sonarqube.yml
+
 stages:
+  - test
   - static-analysis
 
-.static-analysis:
-  stage: static-analysis
-  interruptible: true
-  needs: []
-
-sonarqube-check:
-  extends: .static-analysis
-  image: images.paas.redhat.com/alm/sonar-scanner-alpine:latest
+test-catalog-ui:
+  stage: test
+  image: node:22-slim
   variables:
-    LANG: "en_US.UTF-8"
-    GIT_DEPTH: "0" # Tells git to fetch all the branches of the project, required by the analysis task
-    SONAR_HOST_URL: https://sonarqube.corp.redhat.com
-    SONAR_SCM_PROVIDER: git
-    SONAR_SCANNER_OPTS: "-Xmx512m"
-    SONAR_USER_HOME: /tmp/.sonar
-    KUBERNETES_MEMORY_REQUEST: "512Mi"
-    KUBERNETES_MEMORY_LIMIT: "4Gi"
-    KUBERNETES_EPHEMERAL_STORAGE_REQUEST: "512Mi"
-    KUBERNETES_EPHEMERAL_STORAGE_LIMIT: "1Gi"
-  cache:
-    key: "${CI_JOB_NAME}"
+    NODE_OPTIONS: "--max-old-space-size=3072"
+    KUBERNETES_MEMORY_REQUEST: "2Gi"
+    KUBERNETES_MEMORY_LIMIT: "8Gi"
+  script:
+    - corepack enable
+    - cd catalog/ui
+    - pnpm install --frozen-lockfile
+    - npx jest --maxWorkers=2
+  artifacts:
     paths:
-      - "${SONAR_USER_HOME}/cache"
-  script: 
-    - >
-      set -x; sonar-scanner -Dsonar.python.version="3.9, 3.11, 3.12"
-      ${SONAR_SETTINGS:+-Dproject.settings="$SONAR_SETTINGS"}
-      ${SONAR_QUALITY_GATE_WAIT:+-Dsonar.qualitygate.wait="$SONAR_QUALITY_GATE_WAIT"}
-      ${SONAR_SOURCE_ENCODING:+-Dsonar.sourceEncoding="$SONAR_SOURCE_ENCODING"}
-      ${SONAR_PROJECT_KEY:+-Dsonar.projectKey="$SONAR_PROJECT_KEY"}
-      ${SONAR_PROJECT_NAME:+-Dsonar.projectName="$SONAR_PROJECT_NAME"}
-      ${SONAR_PROJECT_VERSION:+-Dsonar.projectVersion="$SONAR_PROJECT_VERSION"}
-      ${SONAR_SOURCES:+-Dsonar.sources="$SONAR_SOURCES"}
-      ${SONAR_EXCLUSIONS:+-Dsonar.exclusions="$SONAR_EXCLUSIONS"}
-      ${SONAR_SCM_PROVIDER:+-Dsonar.scm.provider="$SONAR_SCM_PROVIDER"}
-      ${CI_MERGE_REQUEST_IID:+-Dsonar.pullrequest.key="$CI_MERGE_REQUEST_IID"}
-      ${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME:+-Dsonar.pullrequest.branch="$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"}
-      ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:+-Dsonar.pullrequest.base="$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"}
-  timeout: 15 minutes
-  allow_failure: true
+      - catalog/ui/coverage/clover.xml
+    expire_in: 1 hour
+  tags:
+    - itup-alm-x86
+
+sonarqube:
+  variables:
+    SONAR_PROJECT_KEY: "com.redhat.rhpds.redhat-cop.babylon"
+  needs:
+    - test-catalog-ui
   tags:
     - itup-alm-x86

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,20 @@
 sonar.projectKey=com.redhat.rhpds.redhat-cop.babylon
 sonar.qualitygate.wait=true
+sonar.python.version=3.12
+
+# Test file patterns (analyzed with test-specific rules, separated from production metrics)
+sonar.test.inclusions=\
+  **/tests/**/*.py,\
+  **/test_*.py,\
+  **/conftest.py,\
+  **/unittest-*.py,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  **/*.test.ts,\
+  **/*.test.tsx
+
+# New Code definition: compare against main branch
+sonar.newCode.referenceBranch=main
+
+# Coverage reports
+sonar.javascript.lcov.reportPaths=catalog/ui/coverage/clover.xml


### PR DESCRIPTION
## Summary
- Replace inline sonar-scanner job with the shared `enterprise-pipelines/gitlab-ci/includes/SAST/sonarqube.yml` template
- Add test stage with `test-catalog-ui` job (jest with `--maxWorkers=2` and coverage reporting)
- Configure `sonar-project.properties` with test inclusions, coverage paths, and `sonar.newCode.referenceBranch=main`