### PR TITLE
Potential fix for code scanning alert no. 116: Clear-text logging of sensitive information

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -240,7 +240,7 @@ class WebhookServer:
             cache_key = f"{agnosticv_repo.namespace}/{webhook_secret_name}"
             if cache_key in self.webhook_secret_cache:
                 del self.webhook_secret_cache[cache_key]
-                self.logger.debug(f"Cleared webhook secret cache for {cache_key}")
+                self.logger.debug("Cleared webhook secret cache entry")
         else:
             # Clear entire cache
             self.webhook_secret_cache.clear()


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/116](https://github.com/redhat-cop/babylon/security/code-scanning/116)

General fix: avoid logging raw secret-related identifiers; log a constant message or a redacted/derived non-reversible token instead.

Best fix here (minimal functional impact): change the debug log in `clear_webhook_secret_cache` so it no longer includes `cache_key` (which contains `webhook_secret_name`). Keep the behavior unchanged (cache entry still deleted), while using a safe generic log message.

File/region to change:
- `agnosticv-operator/operator/webhook_server.py`
- In method `clear_webhook_secret_cache`, around lines 240–244.
- Replace `self.logger.debug(f"Cleared webhook secret cache for {cache_key}")` with a non-sensitive message like `self.logger.debug("Cleared webhook secret cache entry")`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
