### PR TITLE
Potential fix for code scanning alert no. 115: Clear-text logging of sensitive information

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -226,7 +226,7 @@ class WebhookServer:
                     'timestamp': current_time
                 }
                 
-                self.logger.debug(f"Cached webhook secret from Kubernetes secret {webhook_secret_name}")
+                self.logger.debug("Cached webhook secret from Kubernetes secret")
                 return decoded_secret
             return None
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/115](https://github.com/redhat-cop/babylon/security/code-scanning/115)

Best-practice fix: avoid logging sensitive identifiers directly. Keep the debug log but remove `webhook_secret_name` from the message (or replace with a generic statement), so functionality is unchanged while eliminating sensitive clear-text logging.

Single best change here: in `agnosticv-operator/operator/webhook_server.py`, update the debug statement at line 229 region to a constant message that does not include `webhook_secret_name`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
