### PR TITLE
Potential fix for code scanning alert no. 117: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -74,8 +74,12 @@ class WebhookServer:
             
             # Read payload
             payload_body = await request.read()
+
+            # Sanitize user-controlled header values before logging to prevent log injection
+            safe_event_type = (event_type or "").replace('\r', '').replace('\n', '')
+            safe_delivery_id = (delivery_id or "").replace('\r', '').replace('\n', '')
             
-            self.logger.info(f"Received GitHub webhook: event={event_type}, delivery={delivery_id}")
+            self.logger.info(f"Received GitHub webhook: event={safe_event_type}, delivery={safe_delivery_id}")
             
             # Only handle push and pull_request events
             if event_type not in ['push', 'pull_request']:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/117](https://github.com/redhat-cop/babylon/security/code-scanning/117)

To fix log injection safely without changing behavior, sanitize any user-controlled values before writing them to logs, specifically removing carriage return and newline characters (and ideally replacing missing values with stable placeholders).  

Best targeted fix in `agnosticv-operator/operator/webhook_server.py`:
- In `handle_github_webhook` around lines 71–79, keep raw header values for logic.
- Introduce sanitized logging variables for `event_type` and `delivery_id` before the `self.logger.info(...)` call.
- Replace `\r` and `\n` in those values (after converting `None` to a safe string like empty or `"<missing>"`), and log only sanitized values.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
