### PR TITLE
Potential fix for code scanning alert no. 123: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -366,7 +366,13 @@ class WebhookServer:
         base_ref = pull_request.get('base', {}).get('ref', '')
         head_sha = pull_request.get('head', {}).get('sha', '')
         
-        self.logger.info(f"PR webhook: repo={repo_full_name}, action={action}, PR#{pr_number}, head={head_ref}, base={base_ref}")
+        safe_repo_full_name = self._sanitize_for_log(repo_full_name)
+        safe_action = self._sanitize_for_log(action)
+        safe_head_ref = self._sanitize_for_log(head_ref)
+        safe_base_ref = self._sanitize_for_log(base_ref)
+        self.logger.info(
+            f"PR webhook: repo={safe_repo_full_name}, action={safe_action}, PR#{pr_number}, head={safe_head_ref}, base={safe_base_ref}"
+        )
         
         # Debug log for closed PRs to troubleshoot merge detection
         if action == 'closed':


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/123](https://github.com/redhat-cop/babylon/security/code-scanning/123)

The best fix is to sanitize all user-controlled values **immediately before logging**, removing CR/LF characters (and safely stringifying non-string values). This prevents forged multi-line log entries without changing runtime behavior of webhook processing.

In `agnosticv-operator/operator/webhook_server.py`, update the log call around line 369 in `handle_pull_request_event` to use the existing `_sanitize_for_log` helper for each interpolated user-influenced value (`repo_full_name`, `action`, `head_ref`, `base_ref`). Keep `pr_number` as-is since it is validated integer data. This is the least invasive fix and consistent with existing code style (there is already a sanitizer method in this class).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
