### PR TITLE
Potential fix for code scanning alert no. 114: Clear-text logging of sensitive information

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -207,7 +207,7 @@ class WebhookServer:
         if cache_key in self.webhook_secret_cache:
             cached_entry = self.webhook_secret_cache[cache_key]
             if current_time - cached_entry['timestamp'] < self.cache_ttl:
-                self.logger.debug(f"Using cached webhook secret for {webhook_secret_name}")
+                self.logger.debug("Using cached webhook secret")
                 return cached_entry['secret']
             else:
                 # Cache expired, remove entry


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/114](https://github.com/redhat-cop/babylon/security/code-scanning/114)

To fix this without changing functionality, remove sensitive interpolation from the debug log at line 210 and replace it with a generic message that does not include `webhook_secret_name`.

Best single change:
- In `agnosticv-operator/operator/webhook_server.py`, inside `get_webhook_secret`, replace:
  - `self.logger.debug(f"Using cached webhook secret for {webhook_secret_name}")`
  with:
  - `self.logger.debug("Using cached webhook secret")`

No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
