### PR TITLE
Potential fix for code scanning alert no. 127: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -396,7 +396,11 @@ class WebhookServer:
             webhook_secret = await self.get_webhook_secret(agnosticv_repo)
             self.logger.debug(f"PR webhook secret check for {agnosticv_repo.name}: secret_configured={webhook_secret is not None}")
             if not self.verify_github_signature(payload_body, signature, webhook_secret):
-                self.logger.warning(f"Invalid PR webhook signature for {agnosticv_repo.name}: signature={signature[:20]}..." if signature else "No signature provided")
+                safe_signature_preview = self._sanitize_for_log(signature)[:20] if signature else None
+                self.logger.warning(
+                    f"Invalid PR webhook signature for {agnosticv_repo.name}: signature={safe_signature_preview}..."
+                    if safe_signature_preview else "No signature provided"
+                )
                 continue
             
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/127](https://github.com/redhat-cop/babylon/security/code-scanning/127)

The best fix is to sanitize any user-controlled value before writing it to logs, specifically removing line-break/control characters that can break log boundaries. Since this file already has a `_sanitize_for_log` helper (line 460+), the least disruptive and most consistent approach is to use that helper at the logging sink.

In `agnosticv-operator/operator/webhook_server.py`, update the warning log at line ~399 inside `handle_pull_request_event` so it logs a sanitized and truncated signature preview, instead of raw `signature[:20]`. This preserves current behavior (still logs whether a signature exists and provides a short prefix for debugging) while preventing log injection.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
