### PR TITLE
Potential fix for code scanning alert no. 118: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -83,7 +83,7 @@ class WebhookServer:
             
             # Only handle push and pull_request events
             if event_type not in ['push', 'pull_request']:
-                self.logger.debug(f"Ignoring unsupported event: {event_type}")
+                self.logger.debug(f"Ignoring unsupported event: {safe_event_type}")
                 return web.json_response({
                     "status": "ignored",
                     "reason": f"Event type '{event_type}' not supported"


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/118](https://github.com/redhat-cop/babylon/security/code-scanning/118)

General fix: sanitize any user-controlled value before writing it to logs, at minimum stripping carriage return and newline characters (`\r`, `\n`) to prevent log forging.

Best fix here (without changing behavior): reuse the already-sanitized variable `safe_event_type` (created at lines 79–80) for the debug log at line 86. This preserves existing control flow (the `if event_type not in [...]` check still uses the original value) while ensuring the log message is safe.

File to change:
- `agnosticv-operator/operator/webhook_server.py`
  - In `handle_github_webhook`, replace the debug log line in the unsupported-event branch to log `safe_event_type` instead of `event_type`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
