### PR TITLE
Potential fix for code scanning alert no. 121: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -284,7 +284,10 @@ class WebhookServer:
             self.logger.warning(f"Invalid commits field type: {type(commits)}")
             commits = []  # Use empty list as fallback
         
-        self.logger.info(f"Push webhook: repo={repo_full_name}, branch={branch_name}, commits={len(commits)}")
+        # Sanitize user-controlled values before logging to prevent log injection
+        safe_repo_full_name = (repo_full_name or '').replace('\r', '').replace('\n', '')
+        safe_branch_name = (branch_name or '').replace('\r', '').replace('\n', '')
+        self.logger.info(f"Push webhook: repo={safe_repo_full_name}, branch={safe_branch_name}, commits={len(commits)}")
         
         results = []
         for agnosticv_repo in agnosticv_repos:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/121](https://github.com/redhat-cop/babylon/security/code-scanning/121)

General fix: sanitize any user-controlled values before writing them to logs, especially by removing `\r` and `\n` to prevent log entry splitting/forgery.

Best minimal fix in `agnosticv-operator/operator/webhook_server.py`:
- In `handle_push_event` (around lines 278–287), sanitize `branch_name` and `repo_full_name` before the `self.logger.info(...)` call.
- Keep behavior unchanged for processing logic (branch matching, update triggering, etc.) by only using sanitized values for logging output, not for control flow.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
