### PR TITLE
Potential fix for code scanning alert no. 120: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -119,10 +119,11 @@ class WebhookServer:
             # Find matching AgnosticVRepo(s) for signature verification
             agnosticv_repos = await self.find_matching_repos(repo_full_name, repo_url, event_type, payload)
             if not agnosticv_repos:
-                self.logger.debug(f"No matching AgnosticVRepo found for {repo_full_name}")
+                safe_repo_full_name = (repo_full_name or "").replace('\r', '').replace('\n', '')
+                self.logger.debug(f"No matching AgnosticVRepo found for {safe_repo_full_name}")
                 return web.json_response({
                     "status": "ignored",
-                    "reason": f"No matching AgnosticVRepo found for {repo_full_name}"
+                    "reason": f"No matching AgnosticVRepo found for {safe_repo_full_name}"
                 }, status=200)
             
             # Process based on event type


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/120](https://github.com/redhat-cop/babylon/security/code-scanning/120)

To fix log injection, sanitize untrusted values before including them in log messages by removing `\r` and `\n` (and optionally applying the same sanitization consistently to all logged user-derived fields).

Best minimal fix without changing behavior:
- In `agnosticv-operator/operator/webhook_server.py`, inside `handle_github_webhook`, sanitize `repo_full_name` before logging at line 122.
- Keep business logic unchanged (matching, branching, responses stay the same).
- Only change the logged value to a safe version.

Specifically:
- Add a local variable (e.g., `safe_repo_full_name = (repo_full_name or "").replace('\r', '').replace('\n', '')`) right before the debug log.
- Use `safe_repo_full_name` in both the debug log and the `"reason"` response string in that same block for consistency.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
