### PR TITLE
Potential fix for code scanning alert no. 119: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -111,7 +111,11 @@ class WebhookServer:
             repo_url = repository.get('clone_url', '')
             
             if not repo_full_name or not repo_url:
-                self.logger.warning(f"Missing required repository fields: full_name={repo_full_name}, clone_url={repo_url}")
+                safe_repo_full_name = (repo_full_name or "").replace('\r', '').replace('\n', '')
+                safe_repo_url = (repo_url or "").replace('\r', '').replace('\n', '')
+                self.logger.warning(
+                    f"Missing required repository fields: full_name={safe_repo_full_name}, clone_url={safe_repo_url}"
+                )
                 return web.json_response({
                     "error": "Missing required repository fields"
                 }, status=400)


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/119](https://github.com/redhat-cop/babylon/security/code-scanning/119)

To fix log injection, sanitize any user-controlled data before writing it to logs by stripping carriage return and newline characters (at minimum `\r` and `\n`).  
The best minimal fix here is to sanitize `repo_full_name` and `repo_url` right before the warning log at line 114, and use those sanitized values in the log message. This preserves functionality while preventing forged multi-line log entries.

Edit only `agnosticv-operator/operator/webhook_server.py` in `handle_github_webhook`, specifically the block handling missing repository fields (`if not repo_full_name or not repo_url:`).  
No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
