### PR TITLE
Potential fix for code scanning alert no. 124: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -370,6 +370,7 @@ class WebhookServer:
             }, status=400)
 
         pr_state = pull_request.get('state', '')
+        safe_pr_state = self._sanitize_for_log(pr_state)
         head_ref = pull_request.get('head', {}).get('ref', '')
         base_ref = pull_request.get('base', {}).get('ref', '')
         head_sha = pull_request.get('head', {}).get('sha', '')
@@ -423,7 +424,7 @@ class WebhookServer:
                 elif action == 'closed':
                     # PR closed - remove from tracking (all repos, regardless of preloadPullRequests)
                     merged = pull_request.get('merged', False)
-                    self.logger.info(f"PR #{pr_number} closed: merged={merged}, state={pr_state}")
+                    self.logger.info(f"PR #{pr_number} closed: merged={merged}, state={safe_pr_state}")
                     await self.trigger_pr_cleanup(agnosticv_repo, pr_number, head_ref, merged)
                     results.append({
                         "repo": agnosticv_repo.name,


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/124](https://github.com/redhat-cop/babylon/security/code-scanning/124)

The fix is to sanitize `pr_state` before including it in log output, just as other fields are already sanitized in this file.  
Best minimal fix (no behavior change): in `handle_pull_request_event` (around lines 372–377 and 426), create a sanitized variable using existing helper `_sanitize_for_log`, and use that sanitized value in the log message.

Concretely in `agnosticv-operator/operator/webhook_server.py`:
- After `pr_state = pull_request.get('state', '')`, add `safe_pr_state = self._sanitize_for_log(pr_state)`.
- Replace `state={pr_state}` in the line-426 log with `state={safe_pr_state}`.

No new imports/dependencies are needed because `_sanitize_for_log` already exists in the class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
