### PR TITLE
Potential fix for code scanning alert no. 122: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -298,7 +298,7 @@ class WebhookServer:
         for agnosticv_repo in agnosticv_repos:
             # Check if this repo's branch matches the pushed branch
             if agnosticv_repo.git_ref != branch_name:
-                self.logger.debug(f"Skipping {agnosticv_repo.name}: branch mismatch ({agnosticv_repo.git_ref} != {branch_name})")
+                self.logger.debug(f"Skipping {agnosticv_repo.name}: branch mismatch ({agnosticv_repo.git_ref} != {safe_branch_name})")
                 continue
                 
             # SECURITY: Verify webhook signature for this repo


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/122](https://github.com/redhat-cop/babylon/security/code-scanning/122)

The best fix is to **sanitize any user-controlled string before writing it to logs**, specifically by removing carriage return and newline characters (and using the sanitized value only in log output).  
In this snippet, line 301 logs `branch_name` directly. We should reuse the already-created `safe_branch_name` (line 294), which is sanitized with `.replace('\r', '').replace('\n', '')`.

**Concrete change (single best minimal fix):**
- In `agnosticv-operator/operator/webhook_server.py`, inside `handle_push_event`, replace the log statement in the branch mismatch block to use `safe_branch_name` instead of raw `branch_name`.
- No new imports, helpers, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
