### PR TITLE
Potential fix for code scanning alert no. 126: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -387,7 +387,9 @@ class WebhookServer:
         # Debug log for closed PRs to troubleshoot merge detection
         if action == 'closed':
             merged_field = pull_request.get('merged')
-            self.logger.debug(f"PR #{pr_number} closed payload debug: merged={merged_field}, merged_at={pull_request.get('merged_at')}, state={pr_state}")
+            safe_merged_field = self._sanitize_for_log(merged_field)
+            safe_merged_at = self._sanitize_for_log(pull_request.get('merged_at'))
+            self.logger.debug(f"PR #{pr_number} closed payload debug: merged={safe_merged_field}, merged_at={safe_merged_at}, state={pr_state}")
         
         # Only process specific actions
         if action not in ['opened', 'closed', 'reopened', 'synchronize']:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/126](https://github.com/redhat-cop/babylon/security/code-scanning/126)

General fix: sanitize any user-controlled values before writing them to logs, especially by stripping `\r` and `\n` to prevent line-forging.

Best fix here (minimal functional change): in `agnosticv-operator/operator/webhook_server.py`, within `handle_pull_request_event`, sanitize `merged_field` and `pull_request.get('merged_at')` before interpolating them into the debug log at line 390, and log those sanitized versions instead of raw values.

What to change:
- In the `if action == 'closed':` block, create:
  - `safe_merged_field = self._sanitize_for_log(merged_field)`
  - `safe_merged_at = self._sanitize_for_log(pull_request.get('merged_at'))`
- Update the debug `self.logger.debug(...)` call to use `safe_merged_field` and `safe_merged_at`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
