### PR TITLE
Potential fix for code scanning alert no. 129: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -389,7 +389,7 @@ class WebhookServer:
             merged_field = pull_request.get('merged')
             safe_merged_field = self._sanitize_for_log(merged_field)
             safe_merged_at = self._sanitize_for_log(pull_request.get('merged_at'))
-            self.logger.debug(f"PR #{pr_number} closed payload debug: merged={safe_merged_field}, merged_at={safe_merged_at}, state={pr_state}")
+            self.logger.debug(f"PR #{pr_number} closed payload debug: merged={safe_merged_field}, merged_at={safe_merged_at}, state={safe_pr_state}")
         
         # Only process specific actions
         if action not in ['opened', 'closed', 'reopened', 'synchronize']:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/129](https://github.com/redhat-cop/babylon/security/code-scanning/129)

To fix log injection, ensure every user-controlled value is sanitized before being written to logs.  
The best minimal fix here is to use the already-prepared sanitized variable `safe_pr_state` (computed on line 374) in the debug log at line 392 instead of raw `pr_state`.

Change needed in `agnosticv-operator/operator/webhook_server.py`:
- In `handle_pull_request_event`, update the debug log for closed PRs to log `safe_pr_state`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
