### PR TITLE
Potential fix for code scanning alert no. 128: Log Injection

### DIFF
--- a/agnosticv-operator/operator/webhook_server.py
+++ b/agnosticv-operator/operator/webhook_server.py
@@ -427,7 +427,8 @@ class WebhookServer:
                 elif action == 'closed':
                     # PR closed - remove from tracking (all repos, regardless of preloadPullRequests)
                     merged = pull_request.get('merged', False)
-                    self.logger.info(f"PR #{pr_number} closed: merged={merged}, state={safe_pr_state}")
+                    safe_merged = self._sanitize_for_log(merged)
+                    self.logger.info(f"PR #{pr_number} closed: merged={safe_merged}, state={safe_pr_state}")
                     await self.trigger_pr_cleanup(agnosticv_repo, pr_number, head_ref, merged)
                     results.append({
                         "repo": agnosticv_repo.name,


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/babylon/security/code-scanning/128](https://github.com/redhat-cop/babylon/security/code-scanning/128)

General fix: ensure every user-controlled value included in log messages is sanitized (remove `\r`/`\n`, normalize to safe string) before interpolation.

Best targeted fix in `agnosticv-operator/operator/webhook_server.py`:
- In `handle_pull_request_event`, in the `action == 'closed'` branch, sanitize `merged` before logging.
- Keep runtime behavior unchanged for business logic by still passing original `merged` to `trigger_pr_cleanup`; only the logged representation should use sanitized value.

Concrete change region:
- Around lines 429–431:
  - keep `merged = pull_request.get('merged', False)`
  - add `safe_merged = self._sanitize_for_log(merged)`
  - change logger line to use `safe_merged` instead of `merged`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
