### PR TITLE
fix(security): make Gunicorn forwarded_allow_ips configurable

### DIFF
--- a/catalog/api/config.py
+++ b/catalog/api/config.py
@@ -3,5 +3,5 @@ import os
 workers = int(os.environ.get('GUNICORN_PROCESSES', '3'))
 threads = int(os.environ.get('GUNICORN_THREADS', '1'))
 
-forwarded_allow_ips = '*'
+forwarded_allow_ips = os.environ.get('FORWARDED_ALLOW_IPS', '*')
 secure_scheme_headers = { 'X-Forwarded-Proto': 'https' }


### PR DESCRIPTION
The hardcoded forwarded_allow_ips='*' trusts X-Forwarded-* proxy headers from any source IP. Make it configurable via FORWARDED_ALLOW_IPS env var so operators can restrict it to their actual reverse proxy IPs (e.g. '127.0.0.1' for sidecar deployments).

Defaults to '*' for backward compatibility.