### PR TITLE
fix(security): validate CLI redirect callback URL to prevent open redirect

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -441,7 +441,8 @@ async def get_auth_cli_redirect(request):
     cookie so the CLI can use both for subsequent API calls.
     """
     callback = request.query.get('callback', '')
-    if not callback or not callback.startswith('http://localhost'):
+    parsed_callback = urlparse(callback) if callback else None
+    if not parsed_callback or parsed_callback.scheme != 'http' or parsed_callback.hostname not in ('localhost', '127.0.0.1'):
         raise web.HTTPBadRequest(reason="Missing or invalid 'callback' parameter (must be http://localhost)")
 
     user = await get_proxy_user(request)


### PR DESCRIPTION


The callback URL validation used startswith('http://localhost') which is bypassable with URLs like http://localhost.evil.com/ or http://localhost@evil.com/. Since the session token is POSTed to this callback URL, this could lead to token theft.

Now uses urlparse() to validate hostname is exactly 'localhost' or '127.0.0.1' and scheme is 'http'.