### PR TITLE
fix(security): separate impersonate verb into dedicated RBAC rule

### DIFF
--- a/catalog/helm/templates/api/clusterrole.yaml
+++ b/catalog/helm/templates/api/clusterrole.yaml
@@ -13,8 +13,15 @@ rules:
   - users
   verbs:
   - get
-  - impersonate
   - list
+- apiGroups:
+  - ""
+  - user.openshift.io
+  resources:
+  - users
+  - groups
+  verbs:
+  - impersonate
 - apiGroups:
   - ""
   resources:

--- a/helm/templates/catalog/interfaces/api/clusterrole.yaml
+++ b/helm/templates/catalog/interfaces/api/clusterrole.yaml
@@ -15,8 +15,15 @@ rules:
   - users
   verbs:
   - get
-  - impersonate
   - list
+- apiGroups:
+  - ""
+  - user.openshift.io
+  resources:
+  - users
+  - groups
+  verbs:
+  - impersonate
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Split the users/groups impersonate permission into its own RBAC rule, separate from get/list. This makes the impersonation permission explicitly auditable and easier to identify in RBAC reviews.

The impersonate verb is required for the catalog API to act on behalf of authenticated users when making K8s API calls, so it cannot be removed.