### PR TITLE
fix(security): remove unused cluster-wide secrets access from ClusterRoles

### DIFF
--- a/admin/helm/templates/rbac.yaml
+++ b/admin/helm/templates/rbac.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/catalog/helm/templates/api/clusterrole.yaml
+++ b/catalog/helm/templates/api/clusterrole.yaml
@@ -19,7 +19,6 @@ rules:
   - ""
   resources:
   - namespaces
-  - secrets
   verbs:
   - get
   - list

--- a/helm/templates/catalog/interfaces/api/clusterrole.yaml
+++ b/helm/templates/catalog/interfaces/api/clusterrole.yaml
@@ -21,7 +21,6 @@ rules:
   - ""
   resources:
   - namespaces
-  - secrets
   verbs:
   - get
   - list


### PR DESCRIPTION

Neither the catalog API nor the admin API programmatically reads Kubernetes secrets via the API. Both services receive their credentials through environment variables injected by the deployment. The cluster-wide secrets access in the ClusterRoles was unnecessarily broad — if either service account were compromised, all cluster secrets would be exposed.

Removed 'secrets' from the catalog API and admin API ClusterRoles while keeping 'namespaces' access which is actively used.