### PR TITLE
fix(security): remove over-privileged admin ClusterRoleBindings

### DIFF
--- a/admin/helm/templates/rbac.yaml
+++ b/admin/helm/templates/rbac.yaml
@@ -64,19 +64,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "babylon-admin.serviceAccountName" . }}
   namespace: {{ include "babylon-admin.namespaceName" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "babylon-admin.name" . }}:admin
-  labels:
-    {{- include "babylon-admin.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-- kind: ServiceAccount
-  name: {{ include "babylon-admin.serviceAccountName" . }}
-  namespace: {{ include "babylon-admin.namespaceName" . }}
 {{ end }}

--- a/catalog-manager/helm/templates/rbac.yaml
+++ b/catalog-manager/helm/templates/rbac.yaml
@@ -66,19 +66,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "babylon-catalog-manager.serviceAccountName" . }}
   namespace: {{ include "babylon-catalog-manager.namespaceName" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "babylon-catalog-manager.name" . }}:admin
-  labels:
-    {{- include "babylon-catalog-manager.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-- kind: ServiceAccount
-  name: {{ include "babylon-catalog-manager.serviceAccountName" . }}
-  namespace: {{ include "babylon-catalog-manager.namespaceName" . }}
 {{ end }}

--- a/selfpacedlab-manager/helm/templates/rbac.yaml
+++ b/selfpacedlab-manager/helm/templates/rbac.yaml
@@ -107,19 +107,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "babylon-selfpacedlab-manager.serviceAccountName" . }}
   namespace: {{ include "babylon-selfpacedlab-manager.namespaceName" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "babylon-selfpacedlab-manager.name" . }}:admin
-  labels:
-    {{- include "babylon-selfpacedlab-manager.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-- kind: ServiceAccount
-  name: {{ include "babylon-selfpacedlab-manager.serviceAccountName" . }}
-  namespace: {{ include "babylon-selfpacedlab-manager.namespaceName" . }}
 {{ end }}

--- a/workshop-manager/helm/templates/rbac.yaml
+++ b/workshop-manager/helm/templates/rbac.yaml
@@ -112,19 +112,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "babylon-workshop-manager.serviceAccountName" . }}
   namespace: {{ include "babylon-workshop-manager.namespaceName" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "babylon-workshop-manager.name" . }}:admin
-  labels:
-    {{- include "babylon-workshop-manager.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-- kind: ServiceAccount
-  name: {{ include "babylon-workshop-manager.serviceAccountName" . }}
-  namespace: {{ include "babylon-workshop-manager.namespaceName" . }}
 {{ end }}


### PR DESCRIPTION
Four operators were bound to the Kubernetes built-in 'admin' ClusterRole via ClusterRoleBindings, granting cluster-wide create/delete on deployments, services, secrets, roles, rolebindings, and more. Each operator already has a custom ClusterRole with precisely the permissions it needs, making the admin binding redundant and a privilege escalation risk.

Affected: workshop-manager, admin, catalog-manager, selfpacedlab-manager.