### PR TITLE
fix(security): add SecurityContext to all Helm deployment containers

### DIFF
--- a/helm/templates/admin/deployment.yaml
+++ b/helm/templates/admin/deployment.yaml
@@ -68,6 +68,12 @@ spec:
               name: {{ $admin.servicenow.secretName | default "babylon-admin-servicenow" }}
         image: {{ $admin.image.repository }}:{{ $admin.image.tag }}
         imagePullPolicy: {{ $admin.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $admin.resources | nindent 10 }}
         livenessProbe:

--- a/helm/templates/agnosticv/operator/deployment.yaml
+++ b/helm/templates/agnosticv/operator/deployment.yaml
@@ -63,6 +63,12 @@ spec:
         {{- end }}
         image: {{ $agnosticv.operator.image.repository }}:{{ $agnosticv.operator.image.tag }}
         imagePullPolicy: {{ $agnosticv.operator.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           failureThreshold: 5
           initialDelaySeconds: 30

--- a/helm/templates/catalog-manager/deployment.yaml
+++ b/helm/templates/catalog-manager/deployment.yaml
@@ -37,6 +37,12 @@ spec:
               key: salesforce-api-token
         image: {{ $catalogManager.image.repository }}:{{ $catalogManager.image.tag }}
         imagePullPolicy: {{ $catalogManager.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $catalogManager.resources | nindent 10 }}
         livenessProbe:

--- a/helm/templates/catalog/interfaces/api/deployment.yaml
+++ b/helm/templates/catalog/interfaces/api/deployment.yaml
@@ -65,6 +65,12 @@ spec:
           value: "{{ $api.loggingLevel }}"
         image: {{ $api.image.repository }}:{{ $api.image.tag }}
         imagePullPolicy: {{ $api.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/helm/templates/catalog/interfaces/oauth-proxy/deployment.yaml
+++ b/helm/templates/catalog/interfaces/oauth-proxy/deployment.yaml
@@ -72,6 +72,12 @@ spec:
               key: clientSecret
         image: {{ $oauthProxy.image.repository }}:{{ $oauthProxy.image.tag }}
         imagePullPolicy: {{ $oauthProxy.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         ports:
         - containerPort: 8443
           name: public

--- a/helm/templates/catalog/interfaces/redis/deployment.yaml
+++ b/helm/templates/catalog/interfaces/redis/deployment.yaml
@@ -51,6 +51,12 @@ spec:
               name: babylon-catalog-redis
         image: {{ $redis.image.repository }}:{{ $redis.image.tag }}
         imagePullPolicy: {{ $redis.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 30

--- a/helm/templates/catalog/interfaces/status/deployment.yaml
+++ b/helm/templates/catalog/interfaces/status/deployment.yaml
@@ -29,6 +29,12 @@ spec:
       - name: status
         image: {{ $status.image.repository }}:{{ $status.image.tag }}
         imagePullPolicy: {{ $status.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/helm/templates/catalog/interfaces/ui/deployment.yaml
+++ b/helm/templates/catalog/interfaces/ui/deployment.yaml
@@ -32,6 +32,12 @@ spec:
       - name: ui
         image: {{ $ui.image.repository }}:{{ $ui.image.tag }}
         imagePullPolicy: {{ $ui.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/helm/templates/notifier/deployment.yaml
+++ b/helm/templates/notifier/deployment.yaml
@@ -72,6 +72,12 @@ spec:
         {{- end }}
         image: {{ $notifier.image.repository }}:{{ $notifier.image.tag }}
         imagePullPolicy: {{ $notifier.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $notifier.resources | nindent 12 }}
         livenessProbe:

--- a/helm/templates/notifier/redis/deployment.yaml
+++ b/helm/templates/notifier/redis/deployment.yaml
@@ -38,6 +38,12 @@ spec:
               name: babylon-notifier-redis
         image: {{ $redis.image.repository }}:{{ $redis.image.tag }}
         imagePullPolicy: {{ $redis.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 30

--- a/helm/templates/selfpacedlabManager/deployment.yaml
+++ b/helm/templates/selfpacedlabManager/deployment.yaml
@@ -35,6 +35,12 @@ spec:
         {{- end }}
         image: "{{ $selfpacedlabManager.image.repository }}:{{ $selfpacedlabManager.image.tag }}"
         imagePullPolicy: {{ $selfpacedlabManager.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $selfpacedlabManager.resources | nindent 10 }}
         livenessProbe:

--- a/helm/templates/serviceAccessManager/deployment.yaml
+++ b/helm/templates/serviceAccessManager/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       - name: service-access-manager
         image: {{ $serviceAccessManager.image.repository }}:{{ $serviceAccessManager.image.tag }}
         imagePullPolicy: {{ $serviceAccessManager.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $serviceAccessManager.resources | nindent 10 }}
         livenessProbe:

--- a/helm/templates/workshopManager/deployment.yaml
+++ b/helm/templates/workshopManager/deployment.yaml
@@ -35,6 +35,12 @@ spec:
         {{- end }}
         image: "{{ $workshopManager.image.repository }}:{{ $workshopManager.image.tag }}"
         imagePullPolicy: {{ $workshopManager.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
         resources:
           {{- toYaml $workshopManager.resources | nindent 10 }}
         livenessProbe:


### PR DESCRIPTION
No deployment in the main Helm chart defined a container securityContext. Added to all 13 deployments:
- allowPrivilegeEscalation: false
- capabilities.drop: ALL
- runAsNonRoot: true

This prevents containers from running as root, escalating privileges, or using unnecessary Linux capabilities.