### PR TITLE
Show exact hourly cost in CostTierDisplay instead of hiding it in a tooltip

### DIFF
--- a/catalog/ui/src/app/components/CostTierDisplay.tsx
+++ b/catalog/ui/src/app/components/CostTierDisplay.tsx
@@ -11,27 +11,23 @@ const CostTierDisplay: React.FC<{ hourlyCost: number }> = ({ hourlyCost }) => {
   const formattedCost = formatCurrency(hourlyCost);
 
   return (
-    <Tooltip
-      content={
-        <div>
-          <div>{formattedCost}/hr</div>
-          <div>Cost level: {tierLabels[tier - 1]}</div>
-        </div>
-      }
-    >
-      <span className="cost-tier-display" tabIndex={0}>
-        {[1, 2, 3].map((level) => (
-          <span
-            key={level}
-            className={`cost-tier-display__sign ${
-              level <= tier ? 'cost-tier-display__sign--active' : 'cost-tier-display__sign--inactive'
-            }`}
-          >
-            $
-          </span>
-        ))}
-      </span>
-    </Tooltip>
+    <span className="cost-tier-display" tabIndex={0}>
+      <span className="cost-tier-display__amount">{formattedCost}/hr</span>
+      <Tooltip content={`Cost level: ${tierLabels[tier - 1]}`}>
+        <span className="cost-tier-display__tier" tabIndex={0}>
+          {[1, 2, 3].map((level) => (
+            <span
+              key={level}
+              className={`cost-tier-display__sign ${
+                level <= tier ? 'cost-tier-display__sign--active' : 'cost-tier-display__sign--inactive'
+              }`}
+            >
+              $
+            </span>
+          ))}
+        </span>
+      </Tooltip>
+    </span>
   );
 };
 

--- a/catalog/ui/src/app/components/cost-tier-display.css
+++ b/catalog/ui/src/app/components/cost-tier-display.css
@@ -1,11 +1,24 @@
 .cost-tier-display {
   display: inline-flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--sm);
+  cursor: default;
+}
+
+.cost-tier-display__amount {
+  font-size: var(--pf-t--global--font--size--md);
+  font-weight: var(--pf-t--global--font--weight--400);
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.cost-tier-display__tier {
+  display: inline-flex;
   gap: 1px;
   cursor: default;
 }
 
 .cost-tier-display__sign {
-  font-size: var(--pf-t--global--font--size--md);
+  font-size: var(--pf-t--global--font--size--xs);
   line-height: 1;
 }
 


### PR DESCRIPTION


The exact formatted cost (e.g. $1.25/hr) is now displayed as the primary element alongside the tier indicators. The tooltip is kept only on the tier dollar signs to show the cost level label (Low/Medium/High).