### PR TITLE
Fix horizontal overflow of long provision data in service details

### DIFF
--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -236,6 +236,10 @@ const ComponentDetailsList: React.FC<{
                                   <a href={value} target="_blank" rel="noopener noreferrer">
                                     <code>{value}</code>
                                   </a>
+                                ) : value.length > 200 ? (
+                                  <div className="services-item__provision-data--long-value">
+                                    <code>{value}</code>
+                                  </div>
                                 ) : (
                                   <code>{value}</code>
                                 )
@@ -1562,7 +1566,7 @@ const ServicesItemComponent: React.FC<{
                             Components
                           </h3>
                         </header>
-                        <Accordion asDefinitionList={false} style={{ maxWidth: '600px' }}>
+                        <Accordion asDefinitionList={false}>
                           {children}
                         </Accordion>
                       </section>
@@ -1628,7 +1632,7 @@ const ServicesItemComponent: React.FC<{
                             key={idx}
                             condition={resourceClaim.status?.resources && resourceClaim.status.resources.length > 1}
                             wrapper={(children) => (
-                              <Accordion asDefinitionList={false} style={{ maxWidth: '600px' }}>
+                              <Accordion asDefinitionList={false}>
                                 <AccordionItem isExpanded={expanded.includes(`item-${idx}`)}>
                                   <AccordionToggle id={`item-${idx}`} onClick={() => toggle(`item-${idx}`)}>
                                     {componentDisplayName}

--- a/catalog/ui/src/app/Services/services-item.css
+++ b/catalog/ui/src/app/Services/services-item.css
@@ -85,6 +85,21 @@
   align-items: flex-start;
   row-gap: 0;
 }
+.services-item__provision-data code {
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  display: inline-block;
+  max-width: 100%;
+}
+.services-item__provision-data--long-value {
+  max-height: 150px;
+  overflow-y: auto;
+  border: 1px solid var(--pf-t--chart--color--black--300);
+  border-radius: var(--pf-t--global--border--radius--sm, 4px);
+  padding: var(--pf-t--global--spacer--sm);
+  background-color: var(--pf-t--color--background--disabled, #f5f5f5);
+}
 .services-item__estimated-cost-label {
   font-size: var(--pf-t--global--icon--size--font--body--sm);
   color: var(--pf-v6-global--palette--black-800);


### PR DESCRIPTION
## Summary
- Removed the hardcoded maxWidth: 600px on the Components accordion so it uses the full available width
- Added word-breaking CSS for code elements inside provision data to prevent horizontal overflow of long URLs and certificates
- Values longer than 200 characters (e.g., certificates) are now rendered inside a scrollable container with a 150px max-height

## Test plan
- [x] Navigate to a service details page with provision data containing certificates or long URLs
- [x] Verify the Components accordion takes the full available width
- [x] Verify long values wrap properly and do not overflow horizontally
- [x] Verify certificates/long strings appear in a scrollable box
- [x] Verify short values still render inline as before