### PR TITLE
Add per-value SLA badge colors and stack with stage badges

### DIFF
--- a/catalog/ui/src/app/Catalog/CatalogItemCard.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemCard.tsx
@@ -5,7 +5,7 @@ import { CatalogItem } from '@app/types';
 import StatusPageIcons from '@app/components/StatusPageIcons';
 import { displayName, renderContent, stripHtml } from '@app/util';
 import StarRating from '@app/components/StarRating';
-import { ALL_CATALOGS_NS, formatString, getDescription, getProvider, getRating, getStage, getStatusFromCatalogItem, getSLA } from './catalog-utils';
+import { ALL_CATALOGS_NS, formatString, getDescription, getProvider, getRating, getStage, getStatusFromCatalogItem, getSLA, getSLABadgeClass } from './catalog-utils';
 import CatalogItemIcon from './CatalogItemIcon';
 
 import './catalog-item-card.css';
@@ -45,13 +45,14 @@ const CatalogItemCard: React.FC<CatalogItemCardProps> = ({ catalogItem, onClick,
   return (
     <div className="catalog-item-card__wrapper">
       <div className="catalog-item-card__badge">
-        {sla && stage === 'prod' ? (
+        {sla ? (
           <Tooltip content={<p>Service Level</p>}>
             <a href="/support" target="_blank" rel="nofollow noreferrer">
-              <Badge className="catalog-item-card__badge--sla">{sla.replace(/_+/g, ' | ')}</Badge>
+              <Badge className={getSLABadgeClass(sla)}>{formatString(sla)}</Badge>
             </a>
           </Tooltip>
-        ) : stage === 'dev' ? (
+        ) : null}
+        {stage === 'dev' ? (
           <Badge className="catalog-item-card__badge--dev">development</Badge>
         ) : stage === 'test' ? (
           <Badge className="catalog-item-card__badge--test">test</Badge>

--- a/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
@@ -373,12 +373,6 @@ const CatalogItemDetails: React.FC<{ catalogItem: CatalogItem; onClose: () => vo
                     <DescriptionListDescription>
                       {attr === CUSTOM_LABELS.RATING.key ? (
                         <StarRating count={5} rating={rating?.ratingScore} total={rating?.totalRatings} readOnly />
-                      ) : attr === CUSTOM_LABELS.SLA.key ? (
-                        value.includes('External') ? (
-                          formatString(value)
-                        ) : (
-                          <Link to="/support">{formatString(value)}</Link>
-                        )
                       ) : attr === CUSTOM_LABELS.ESTIMATED_COST.key ? null : (
                         formatString(value)
                       )}

--- a/catalog/ui/src/app/Catalog/CatalogItemListItem.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemListItem.tsx
@@ -6,7 +6,7 @@ import StatusPageIcons from '@app/components/StatusPageIcons';
 import { displayName, renderContent, stripHtml } from '@app/util';
 import StarRating from '@app/components/StarRating';
 import CatalogItemIcon from './CatalogItemIcon';
-import { ALL_CATALOGS_NS, formatString, getDescription, getProvider, getRating, getSLA, getStage, getStatusFromCatalogItem } from './catalog-utils';
+import { ALL_CATALOGS_NS, formatString, getDescription, getProvider, getRating, getSLA, getSLABadgeClass, getStage, getStatusFromCatalogItem } from './catalog-utils';
 
 import './catalog-item-list-item.css';
 
@@ -44,13 +44,14 @@ const CatalogItemListItem: React.FC<{ catalogItem: CatalogItem }> = ({ catalogIt
               {status && status.name !== 'Operational' ? (
                 <StatusPageIcons status={status.name} className="catalog-item-list-item__statusPageIcon" />
               ) : null}
-              {sla && stage === 'prod' ? (
+              {sla ? (
                 <Tooltip content={<p>Service Level</p>}>
                   <a href="/support" target="_blank" rel="nofollow noreferrer">
-                    <Badge className="catalog-item-list-item__badge--sla">{sla.replace(/_+/g, ' | ')}</Badge>
+                    <Badge className={getSLABadgeClass(sla)}>{formatString(sla)}</Badge>
                   </a>
                 </Tooltip>
-              ) : stage === 'dev' ? (
+              ) : null}
+              {stage === 'dev' ? (
                 <Badge className="catalog-item-list-item__badge--dev">development</Badge>
               ) : stage === 'test' ? (
                 <Badge className="catalog-item-list-item__badge--test">test</Badge>

--- a/catalog/ui/src/app/Catalog/catalog-item-card.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-card.css
@@ -74,21 +74,36 @@
   width: 20px !important;
 }
 .catalog-item-card__badge {
-  text-align: right;
   position: absolute;
   top: var(--pf-t--global--spacer--md);
   right: var(--pf-t--global--spacer--lg);
   z-index: 50;
-}
-
-.catalog-item-card__badge--sla {
-  background-color: var(--pf-t--global--icon--color--status--danger--default);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
 }
 
 .catalog-item-card__badge--dev,
 .catalog-item-card__badge--test,
 .catalog-item-card__badge--event {
   background-color: var(--pf-t--global--icon--color--status--danger--default);
+}
+
+.catalog-badge--sla-featured {
+  background-color: var(--pf-t--global--icon--color--status--danger--default);
+}
+
+.catalog-badge--sla-supported {
+  background-color: var(--pf-t--global--icon--color--status--success--default);
+}
+
+.catalog-badge--sla-unsupported {
+  background-color: var(--pf-t--color--gray--60);
+}
+
+.catalog-badge--sla-other {
+  background-color: var(--pf-t--global--icon--color--status--custom--default);
 }
 
 .catalog-item-card__subtitle {

--- a/catalog/ui/src/app/Catalog/catalog-item-list-item.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-list-item.css
@@ -8,8 +8,7 @@
 }
 .catalog-item-list-item__badge--dev,
 .catalog-item-list-item__badge--test,
-.catalog-item-list-item__badge--event,
-.catalog-item-list-item__badge--sla {
+.catalog-item-list-item__badge--event {
   background-color: var(--pf-t--global--icon--color--status--danger--default);
 }
 

--- a/catalog/ui/src/app/Catalog/catalog-utils.ts
+++ b/catalog/ui/src/app/Catalog/catalog-utils.ts
@@ -27,17 +27,26 @@ export function getStage(catalogItem: CatalogItem) {
 
 export const SLAs = {
   Featured: 'Featured',
-  Enterprise_Premium: 'Enterprise_Premium',
-  Enterprise_Standard: 'Enterprise_Standard',
+  Supported: 'Supported',
+  Unsupported: 'Unsupported',
   Community: 'Community',
-  External_Support: 'External_Support',
 } as const;
 export type SLA = (typeof SLAs)[keyof typeof SLAs];
-export function getSLA(catalogItem: CatalogItem): SLA | null {
+export function getSLA(catalogItem: CatalogItem): string | null {
   const { domain, key } = CUSTOM_LABELS.SLA;
-  const sla = catalogItem.metadata.labels?.[`${domain}/${key}`];
-  if (!Object.values(SLAs).includes(sla as SLA)) return null;
-  return sla as SLA;
+  return catalogItem.metadata.labels?.[`${domain}/${key}`] || null;
+}
+export function getSLABadgeClass(sla: string): string {
+  switch (sla) {
+    case SLAs.Featured:
+      return 'catalog-badge--sla-featured';
+    case SLAs.Supported:
+      return 'catalog-badge--sla-supported';
+    case SLAs.Unsupported:
+      return 'catalog-badge--sla-unsupported';
+    default:
+      return 'catalog-badge--sla-other';
+  }
 }
 
 export function getRating(catalogItem: CatalogItem): { ratingScore: number; totalRatings: number } | null {

--- a/catalog/ui/src/app/MultiWorkshops/CatalogItemSelectorModal.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/CatalogItemSelectorModal.tsx
@@ -36,6 +36,7 @@ import {
   getStage,
   getStatusFromCatalogItem,
   getSLA,
+  getSLABadgeClass,
   formatString,
   CUSTOM_LABELS,
 } from '@app/Catalog/catalog-utils';
@@ -131,13 +132,14 @@ const SelectableCatalogItemCard: React.FC<{
   return (
     <div className="catalog-item-card__wrapper">
       <div className="catalog-item-card__badge">
-        {sla && stage === 'prod' ? (
+        {sla ? (
           <Tooltip content={<p>Service Level</p>}>
             <a href="/support" target="_blank" rel="nofollow noreferrer">
-              <Badge className="catalog-item-card__badge--sla">{sla.replace(/_+/g, ' | ')}</Badge>
+              <Badge className={getSLABadgeClass(sla)}>{formatString(sla)}</Badge>
             </a>
           </Tooltip>
-        ) : stage === 'dev' ? (
+        ) : null}
+        {stage === 'dev' ? (
           <Badge className="catalog-item-card__badge--dev">development</Badge>
         ) : stage === 'test' ? (
           <Badge className="catalog-item-card__badge--test">test</Badge>


### PR DESCRIPTION
Simplify SLA values to Featured/Supported/Unsupported, assign distinct colors (red, green, grey) to each, and allow SLA badges to display alongside dev/test/event stage badges instead of being mutually exclusive.