### PR TITLE
Bump catalog UI to v0.35.3 and update support links

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.2
+    tag: v0.35.3
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/catalog/ui/src/app/Catalog/catalog-item-card.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-card.css
@@ -87,7 +87,7 @@
 .catalog-item-card__badge--dev,
 .catalog-item-card__badge--test,
 .catalog-item-card__badge--event {
-  background-color: var(--pf-t--global--icon--color--status--danger--default);
+  background-color: var(--pf-t--global--color--brand--default);
 }
 
 .catalog-badge--sla-featured {

--- a/catalog/ui/src/app/Catalog/catalog-item-list-item.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-list-item.css
@@ -9,7 +9,7 @@
 .catalog-item-list-item__badge--dev,
 .catalog-item-list-item__badge--test,
 .catalog-item-list-item__badge--event {
-  background-color: var(--pf-t--global--icon--color--status--danger--default);
+  background-color: var(--pf-t--global--color--brand--default);
 }
 
 .catalog-item-list-item__card {

--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import useSWRImmutable from 'swr/immutable';
 import useSession from '@app/utils/useSession';
 import useServiceQuota from '@app/utils/useServiceQuota';
+import useHelpLink from '@app/utils/useHelpLink';
 import {
   PageSection,
   Title,
@@ -72,6 +73,7 @@ export async function fetcherItemsInAllPages(pathFn: (continueId: string) => str
 const MultiWorkshopCreate: React.FC = () => {
   const navigate = useNavigate();
   const { userNamespace, isAdmin, serviceNamespaces } = useSession().getSession();
+  const helpLink = useHelpLink();
   const { isWorkshopOrderingBlocked, workshopOrderingBlockedMessage } = useSystemStatus();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCatalogSelectorOpen, setIsCatalogSelectorOpen] = useState(false);
@@ -501,7 +503,7 @@ const MultiWorkshopCreate: React.FC = () => {
           <p style={{ marginTop: '8px' }}>
             If you need assistance or our workshop white glove service, please{' '}
             <a
-              href="https://issues.redhat.com/servicedesk/customer/portal/36/create/96"
+              href={helpLink}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -759,7 +761,7 @@ const MultiWorkshopCreate: React.FC = () => {
               <div style={{ marginTop: '4px', fontSize: '14px', color: 'var(--pf-t--global--text--color--subtle)' }}>
                 Maximum 30 seats allowed.{' '}
                 <a
-                  href="https://issues.redhat.com/servicedesk/customer/portal/36/create/96"
+                  href={helpLink}
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{ color: 'var(--pf-t--global--color--brand--default)' }}

--- a/catalog/ui/src/app/Support/SupportPage.tsx
+++ b/catalog/ui/src/app/Support/SupportPage.tsx
@@ -31,7 +31,7 @@ const SupportPage: React.FC<{ title: string }> = ({ title }) => {
   const { data } = useSWRImmutable('./public/incidents_technical_support.csv', publicFetcher);
   const dataArr = CSVToArray(data);
   function getHelpLink() {
-    return 'https://red.ht/open-support';
+    return 'https://connect.redhat.com/en/support';
   }
 
   function createColumnsFromArr(dataLabel: string, label?: string) {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.1
+        tag: v0.35.3
       replicaCount: 1
       resources:
         requests:


### PR DESCRIPTION
## Summary
- Bump catalog UI image tag to `v0.35.3` in both `catalog/helm/values.yaml` and `helm/values.yaml`
- Replace hardcoded support ticket URLs in `MultiWorkshopCreate.tsx` with `useHelpLink()` hook for consistency with the header
- Update `SupportPage.tsx` link to `https://connect.redhat.com/en/support`

## Test plan
- [x] Verify helm deploys with the correct UI image tag
- [x] Confirm support link in the header, support page, and multi-workshop create page all point to the correct URLs
- [x] Verify internal Red Hat users get the internal help link via `useHelpLink()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)