### PR TITLE
Show 'Scheduled' status for self-paced labs

### DIFF
--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -525,7 +525,9 @@ const SelfPacedLabItemComponent: React.FC<{
                 <DescriptionListGroup>
                   <DescriptionListTerm>Status</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selfPacedLab.status?.poolCount ? (
+                    {autoStartTime && autoStartTime > Date.now() ? (
+                      <span className="services-item__status--scheduled">Scheduled</span>
+                    ) : selfPacedLab.status?.poolCount ? (
                       <SelfPacedLabStatus poolCount={selfPacedLab.status.poolCount} />
                     ) : (
                       <Spinner size="md" />

--- a/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
+++ b/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SelfPacedLab, ServiceActionActions } from '@app/types';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { displayName, getStageFromK8sObject } from '@app/util';
 import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
 import TimeInterval from '@app/components/TimeInterval';
@@ -32,6 +33,7 @@ const renderSelfPacedLabRow = ({
     lifespan: () => showModal({ action: 'retirement', modal: 'scheduleAction', selfPacedLab }),
   };
   const stage = getStageFromK8sObject(selfPacedLab);
+  const autoStartTime = selfPacedLab.spec.lifespan?.start ? Date.parse(selfPacedLab.spec.lifespan.start) : null;
   const autoDestroyTime = selfPacedLab.spec.lifespan?.end ? Date.parse(selfPacedLab.spec.lifespan.end) : null;
 
   const poolCount = selfPacedLab.status?.poolCount;
@@ -52,7 +54,11 @@ const renderSelfPacedLabRow = ({
     </>
   );
   const guidCell = <span key="selfpacedlab-guid">-</span>;
-  const statusCell = poolCount ? (
+  const statusCell = autoStartTime && autoStartTime > Date.now() ? (
+    <span className="services-item__status--scheduled" key="scheduled">
+      <CheckCircleIcon key="scheduled-icon" /> Scheduled
+    </span>
+  ) : poolCount ? (
     <SelfPacedLabStatus key="selfpacedlab-status" poolCount={poolCount} />
   ) : (
     <span key="selfpacedlab-status">Initializing...</span>


### PR DESCRIPTION
## Summary
- When a self-paced lab has a future start time (`lifespan.start`), display "Scheduled" status instead of pool counts ("0 ready, 0 assigned, 0 provisioning"), matching existing workshop behavior.
- Applied in both the services list row (`renderSelfPacedLabRow.tsx`) and the detail view (`SelfPacedLabItem.tsx`).

## Test plan
- [x] Create a self-paced lab with a future start date and verify "Scheduled" is shown in the services list
- [x] Open the self-paced lab detail view and verify "Scheduled" is shown in the Status field
- [x] Verify that once the start time passes, pool counts are displayed as before
- [x] Verify workshops still show "Scheduled" correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)