### PR TITLE
Add ResourceClaim annotations to tenant clusters in sandbox api

### DIFF
--- a/helm/templates/tenantClusterPoolManager/deployment.yaml
+++ b/helm/templates/tenantClusterPoolManager/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       containers:
       - name: tenant-cluster-pool-manager
         env:
+        - name: BABYLON_CLUSTER
+          value: {{ $.Values.clusterDomain }}
         - name: SANDBOX_API_URL
           value: http://sandbox-api.babylon-sandbox-api.svc.cluster.local:8080
         - name: SANDBOX_API_AUTH_TOKEN

--- a/tenant-cluster-pool-manager/operator/operator.py
+++ b/tenant-cluster-pool-manager/operator/operator.py
@@ -350,7 +350,13 @@ async def handle_tenant_cluster_without_sandbox_config(
 
     # Cluster is not in the sandbox api, but should be.
     await OperatorRuntime.sandbox_api.create_ocp_shared_cluster_configuration(
-        annotations=tenant_cluster_pool.sandbox_host.annotations,
+        annotations={
+            **tenant_cluster_pool.sandbox_host.annotations,
+            "babylon_cluster": OperatorRuntime.babylon_cluster,
+            "guid": resource_claim.guid,
+            "resource_claim_name": resource_claim.name,
+            "resource_claim_namespace": resource_claim.namespace,
+        },
         api_url=resource_claim.provision_data['openshift_api_url'],
         ingress_domain=resource_claim.provision_data['openshift_cluster_ingress_domain'],
         deployer_admin_sa_token_refresh_interval=tenant_cluster_pool.sandbox_host.deployer_admin_sa_token_refresh_interval,

--- a/tenant-cluster-pool-manager/operator/operatorruntime.py
+++ b/tenant-cluster-pool-manager/operator/operatorruntime.py
@@ -6,6 +6,7 @@ from babylon_async import BabylonClient
 from sandboxapi import SandboxAPI
 
 class OperatorRuntime():
+    babylon_cluster = os.environ.get('BABYLON_CLUSTER', 'unknown')
     babylon_domain = os.environ.get('BABYLON_DOMAIN', 'babylon.gpte.redhat.com')
     babylon_api_version = os.environ.get('BABYLON_API_VERSION', 'v1')
     poolboy_domain = os.environ.get('POOLBOY_DOMAIN', 'poolboy.gpte.redhat.com')
@@ -23,11 +24,13 @@ class OperatorRuntime():
 
     @classmethod
     async def on_cleanup(cls):
+        """Setup operator runtime on startup"""
         await cls.api_client.close()
         await cls.sandbox_api.close()
 
     @classmethod
     async def on_startup(cls):
+        """Setup operator runtime on startup"""
         if os.path.exists('/run/secrets/kubernetes.io/serviceaccount'):
             kubernetes_asyncio.config.load_incluster_config()
         else:

--- a/tenant-cluster-pool-manager/run-local.sh
+++ b/tenant-cluster-pool-manager/run-local.sh
@@ -21,6 +21,7 @@ EOF
 
 cd ./operator
 
+export BABYLON_CLUSTER=$(oc get ingresses.config.openshift.io cluster -o jsonpath="{.spec.domain}" | sed 's/apps\.//')
 export SANDBOX_API_AUTH_TOKEN=$(oc get secret -n babylon-catalog sandbox-api-shared-cluster-manager -o jsonpath={.data.shared-cluster-manager-token} | base64 -d)
 
 exec kopf run \


### PR DESCRIPTION
- Add setting annotations `babylon_cluster`, `guid`, `resource_claim_name`, `resource_claim_namespace`