### PR TITLE
Only show SLA badges for Featured and Unsupported

### DIFF
--- a/catalog/ui/src/app/Catalog/catalog-item-card.css
+++ b/catalog/ui/src/app/Catalog/catalog-item-card.css
@@ -94,16 +94,8 @@
   background-color: var(--pf-t--global--icon--color--status--danger--default);
 }
 
-.catalog-badge--sla-supported {
-  background-color: var(--pf-t--global--icon--color--status--success--default);
-}
-
 .catalog-badge--sla-unsupported {
   background-color: var(--pf-t--color--gray--60);
-}
-
-.catalog-badge--sla-other {
-  background-color: var(--pf-t--global--icon--color--status--custom--default);
 }
 
 .catalog-item-card__subtitle {

--- a/catalog/ui/src/app/Catalog/catalog-utils.ts
+++ b/catalog/ui/src/app/Catalog/catalog-utils.ts
@@ -27,25 +27,25 @@ export function getStage(catalogItem: CatalogItem) {
 
 export const SLAs = {
   Featured: 'Featured',
-  Supported: 'Supported',
   Unsupported: 'Unsupported',
-  Community: 'Community',
 } as const;
 export type SLA = (typeof SLAs)[keyof typeof SLAs];
 export function getSLA(catalogItem: CatalogItem): string | null {
   const { domain, key } = CUSTOM_LABELS.SLA;
-  return catalogItem.metadata.labels?.[`${domain}/${key}`] || null;
+  const sla = catalogItem.metadata.labels?.[`${domain}/${key}`] || null;
+  if (sla === SLAs.Featured || sla === SLAs.Unsupported) {
+    return sla;
+  }
+  return null;
 }
 export function getSLABadgeClass(sla: string): string {
   switch (sla) {
     case SLAs.Featured:
       return 'catalog-badge--sla-featured';
-    case SLAs.Supported:
-      return 'catalog-badge--sla-supported';
     case SLAs.Unsupported:
       return 'catalog-badge--sla-unsupported';
     default:
-      return 'catalog-badge--sla-other';
+      return '';
   }
 }
 


### PR DESCRIPTION
## Summary
- Only display SLA badges for `Featured` and `Unsupported` values on catalog item cards
- Remove `Supported` and `Community` from the SLAs object and badge class mapping
- Remove unused `.catalog-badge--sla-supported` and `.catalog-badge--sla-other` CSS classes

## Test plan
- [x] Verify Featured items show a red SLA badge
- [x] Verify Unsupported items show a gray SLA badge
- [x] Verify Supported and Community items no longer show any SLA badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)