### PR TITLE
Add RHDP Content Advisor link to Explore Content navigation

### DIFF
--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -20,7 +20,7 @@ const ExactNavLink = ({ children, to, className, ...props }: LinkProps) => {
 };
 const Navigation: React.FC = () => {
   const location = useLocation();
-  const { incidents_enabled, ratings_enabled, multiworkshops_enabled, partner_connect_header_enabled } = useInterfaceConfig();
+  const { incidents_enabled, ratings_enabled, multiworkshops_enabled, partner_connect_header_enabled, rcars_enabled } = useInterfaceConfig();
   const { isAdmin, userNamespace } = useSession().getSession();
 
   function locationStartsWith(str: string): boolean {
@@ -66,6 +66,18 @@ const Navigation: React.FC = () => {
             className="pf-v6-c-nav__link"
           >
             Model-as-a-Service (MaaS)
+          </a>
+        </NavItem>
+      ) : null}
+      {rcars_enabled ? (
+        <NavItem>
+          <a
+            href="https://rcars.apps.ocpv-infra01.dal12.infra.demo.redhat.com/"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="pf-v6-c-nav__link"
+          >
+            RHDP Content Advisor
           </a>
         </NavItem>
       ) : null}

--- a/catalog/ui/src/app/utils/useInterfaceConfig.tsx
+++ b/catalog/ui/src/app/utils/useInterfaceConfig.tsx
@@ -18,6 +18,7 @@ type TInterface = {
   sfdc_enabled: boolean;
   partner_connect_header_enabled: boolean;
   multiworkshops_enabled: boolean;
+  rcars_enabled: boolean;
 };
 export function useInterface(userInterface: string) {
   const { data, error } = useSWRImmutable<TInterface>(`./public/interfaces/${userInterface}.json`, publicFetcher);
@@ -43,7 +44,8 @@ export default function useInterfaceConfig() {
       onboarding_support_text: '',
       sfdc_enabled: true,
       partner_connect_header_enabled: false,
-      multiworkshops_enabled: true
+      multiworkshops_enabled: true,
+      rcars_enabled: false
     };
   }
   return data;

--- a/catalog/ui/src/public/interfaces/rhdp-partners.json
+++ b/catalog/ui/src/public/interfaces/rhdp-partners.json
@@ -9,5 +9,6 @@
   "learn_more_link": "https://content.redhat.com/content/rhcc/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": false,
   "partner_connect_header_enabled": true,
-  "multiworkshops_enabled": false
+  "multiworkshops_enabled": false,
+  "rcars_enabled": false
 }

--- a/catalog/ui/src/public/interfaces/rhpds.json
+++ b/catalog/ui/src/public/interfaces/rhpds.json
@@ -9,5 +9,6 @@
   "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": true,
   "partner_connect_header_enabled": false,
-  "multiworkshops_enabled": true
+  "multiworkshops_enabled": true,
+  "rcars_enabled": true
 }


### PR DESCRIPTION
## Summary
- Adds "RHDP Content Advisor" external link (https://rcars.apps.ocpv-infra01.dal12.infra.demo.redhat.com/) as the last item under "Explore Content" navigation menu
- Introduces `rcars_enabled` interface config variable to control visibility: enabled for `rhpds`, disabled for `rhdp-partners`

## Test plan
- [x] Verify the link appears in the "Explore Content" menu for non-partner users (rhpds interface)
- [x] Verify the link does NOT appear for partner users (rhdp-partners interface)
- [x] Verify the link opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)