### PR TITLE
Remove multiworkshops_enabled flag, enable Multi Asset Workshop everywhere

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.spec.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.spec.tsx
@@ -29,7 +29,6 @@ jest.mock('@app/utils/useInterfaceConfig', () => {
     ratings_enabled: false,
     status_page_url: 'https://redhat.com',
     help_text: '',
-    multiworkshops_enabled: true,
     help_link: '',
     internal_help_link: '',
     sfdc_enabled: true,

--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -20,7 +20,7 @@ const ExactNavLink = ({ children, to, className, ...props }: LinkProps) => {
 };
 const Navigation: React.FC = () => {
   const location = useLocation();
-  const { incidents_enabled, ratings_enabled, multiworkshops_enabled, partner_connect_header_enabled, rcars_enabled } = useInterfaceConfig();
+  const { incidents_enabled, ratings_enabled, partner_connect_header_enabled, rcars_enabled } = useInterfaceConfig();
   const { isAdmin, userNamespace } = useSession().getSession();
 
   function locationStartsWith(str: string): boolean {
@@ -112,7 +112,7 @@ const Navigation: React.FC = () => {
     </NavItem>
   );
 
-  const multiWorkshopNavigation = userNamespace && multiworkshops_enabled ? (
+  const multiWorkshopNavigation = userNamespace ? (
     <NavItem>
       <NavLink
         to={`/multi-workshop/${userNamespace.name}`}

--- a/catalog/ui/src/app/Catalog/CatalogItemForm.spec.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.spec.tsx
@@ -58,7 +58,6 @@ jest.mock('@app/utils/useInterfaceConfig', () => {
     ratings_enabled: false,
     status_page_url: 'https://redhat.com',
     help_text: '',
-    multiworkshops_enabled: true,
     help_link: '',
     internal_help_link: '',
     sfdc_enabled: true,

--- a/catalog/ui/src/app/MultiWorkshops/README.md
+++ b/catalog/ui/src/app/MultiWorkshops/README.md
@@ -9,7 +9,6 @@ The Multi Asset Workshop feature allows organizers to bundle multiple workshop s
 - [Architecture Overview](#architecture-overview)
 - [User Roles](#user-roles)
 - [Routes and Navigation](#routes-and-navigation)
-- [Feature Flag](#feature-flag)
 - [Creating a Multi Asset Workshop](#creating-a-multi-asset-workshop)
 - [Managing a Multi Asset Workshop (Detail Page)](#managing-a-multi-asset-workshop-detail-page)
 - [Listing Multi Asset Workshops](#listing-multi-asset-workshops)
@@ -89,19 +88,8 @@ Data flows through **SWR** (stale-while-revalidate) for server state, with no Re
 
 ### Navigation
 
-- **Side nav**: "Multi Asset Workshop" link appears under the user's namespace when `multiworkshops_enabled` is `true` in the interface config.
+- **Side nav**: "Multi Asset Workshop" link appears under the user's namespace.
 - **Admin nav**: "Multi-Workshops" link under `/admin/multiworkshops` for admin users.
-
----
-
-## Feature Flag
-
-The feature is gated by the `multiworkshops_enabled` flag in the interface configuration.
-
-- **RHPDS** (`catalog/ui/src/public/interfaces/rhpds.json`): `"multiworkshops_enabled": true`
-- **RHDP Partners** (`catalog/ui/src/public/interfaces/rhdp-partners.json`): hidden (not enabled)
-
-The flag controls the visibility of the "Multi Asset Workshop" nav link. The underlying API routes still exist regardless of this flag.
 
 ---
 

--- a/catalog/ui/src/app/Services/ServiceActions.spec.tsx
+++ b/catalog/ui/src/app/Services/ServiceActions.spec.tsx
@@ -10,7 +10,6 @@ jest.mock('@app/utils/useInterfaceConfig', () => {
     ratings_enabled: true,
     status_page_url: 'https://redhat.com',
     help_link: '',
-    multiworkshops_enabled: true,
     help_text: '',
     internal_help_link: '',
     sfdc_enabled: true,

--- a/catalog/ui/src/app/utils/useInterfaceConfig.tsx
+++ b/catalog/ui/src/app/utils/useInterfaceConfig.tsx
@@ -17,7 +17,6 @@ type TInterface = {
   onboarding_support_text: string;
   sfdc_enabled: boolean;
   partner_connect_header_enabled: boolean;
-  multiworkshops_enabled: boolean;
   rcars_enabled: boolean;
 };
 export function useInterface(userInterface: string) {
@@ -44,7 +43,6 @@ export default function useInterfaceConfig() {
       onboarding_support_text: '',
       sfdc_enabled: true,
       partner_connect_header_enabled: false,
-      multiworkshops_enabled: true,
       rcars_enabled: false
     };
   }

--- a/catalog/ui/src/public/interfaces/rhdp-partners.json
+++ b/catalog/ui/src/public/interfaces/rhdp-partners.json
@@ -9,6 +9,5 @@
   "learn_more_link": "https://content.redhat.com/content/rhcc/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": false,
   "partner_connect_header_enabled": true,
-  "multiworkshops_enabled": true,
   "rcars_enabled": false
 }

--- a/catalog/ui/src/public/interfaces/rhdp-partners.json
+++ b/catalog/ui/src/public/interfaces/rhdp-partners.json
@@ -9,5 +9,5 @@
   "learn_more_link": "https://content.redhat.com/content/rhcc/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": false,
   "partner_connect_header_enabled": true,
-  "multiworkshops_enabled": false
+  "multiworkshops_enabled": true
 }

--- a/catalog/ui/src/public/interfaces/rhpds.json
+++ b/catalog/ui/src/public/interfaces/rhpds.json
@@ -9,6 +9,5 @@
   "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": true,
   "partner_connect_header_enabled": false,
-  "multiworkshops_enabled": true,
   "rcars_enabled": true
 }


### PR DESCRIPTION
## Summary
- Removes the `multiworkshops_enabled` interface config flag entirely since Multi Asset Workshop is now enabled for all interfaces (rhpds and rhdp-partners)
- Removes the field from the `TInterface` type, both JSON config files, error fallback defaults, Navigation conditional, test mocks, and README documentation

## Test plan
- [x] Verify "Multi Asset Workshop" nav item appears for both partner and non-partner users
- [x] Verify multi-workshop creation flow still works
- [x] Run existing tests (`AppLayout.spec`, `CatalogItemForm.spec`, `ServiceActions.spec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)