### PR TITLE
Bump catalog UI to v0.35.4

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.3
+    tag: v0.35.4
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.3
+        tag: v0.35.4
       replicaCount: 1
       resources:
         requests:


### PR DESCRIPTION
## Summary
- Bump catalog UI image tag from `v0.35.3` to `v0.35.4` in `catalog/helm/values.yaml` and `helm/values.yaml`

## Test plan
- [ ] Verify catalog UI deploys with the new image tag
- [ ] Confirm UI loads and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)