### PR TITLE
Rename RHDP Content Advisor to Content Advisor (RCARS)

### DIFF
--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -77,7 +77,7 @@ const Navigation: React.FC = () => {
             rel="noreferrer noopener"
             className="pf-v6-c-nav__link"
           >
-            RHDP Content Advisor
+            Content Advisor (RCARS)
           </a>
         </NavItem>
       ) : null}


### PR DESCRIPTION
## Summary
- Rename navigation link from "RHDP Content Advisor" to "Content Advisor (RCARS)"

## Test plan
- [x] Verify the navigation sidebar displays "Content Advisor (RCARS)"
- [x] Verify the link still opens the correct RCARS URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)