### PR TITLE
Fix crash when rating API returns non-200 response

### DIFF
--- a/catalog-manager/helm/Chart.yaml
+++ b/catalog-manager/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: babylon-catalog-manager
 description: A Helm chart for the babylon catalog manager component.
 type: application
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1

--- a/catalog-manager/operator/catalog_item_service.py
+++ b/catalog-manager/operator/catalog_item_service.py
@@ -95,3 +95,4 @@ class CatalogItemService:
             except Exception as e:
                 self.logger.error(f"Invalid connection with {Babylon.reporting_api} - {e}")
                 raise
+        return False

--- a/catalog-manager/operator/catalog_item_service.py
+++ b/catalog-manager/operator/catalog_item_service.py
@@ -69,6 +69,7 @@ class CatalogItemService:
             except Exception as e:
                 self.logger.error(f"Invalid connection with {Babylon.reporting_api} - {e}")
                 raise
+        return Rating(None, 0)
 
     async def get_is_disabled(self):
         if len(self.catalog_item.labels['gpte.redhat.com/asset-uuid']) != 0:


### PR DESCRIPTION
get_rating_from_api() returned None on non-200 responses (e.g. 404), causing an AttributeError in the caller when accessing rating_score. Return a default Rating(None, 0) instead, which the caller already handles gracefully via its rating_score is not None check.