### PR TITLE
Fix layout issues in TenantClusterPool modal

### DIFF
--- a/catalog/ui/src/app/Modal/modal.css
+++ b/catalog/ui/src/app/Modal/modal.css
@@ -4,8 +4,8 @@
 }
 
 .modal-component.pf-v6-c-modal-box .pf-v6-c-modal-box__body {
-  overflow-x: visible;
-  overflow-y: visible;
+  overflow: auto;
+  padding-bottom: var(--pf-t--global--spacer--lg);
 }
 
 .modal-component.pf-v6-c-modal-box .pf-c-dropdown__menu {

--- a/catalog/ui/src/app/components/ActivityPurposeSelector.tsx
+++ b/catalog/ui/src/app/components/ActivityPurposeSelector.tsx
@@ -124,7 +124,7 @@ const ActivityPurposeSelector: React.FC<{
           </Select>
 
           {purposeOpts.find((p) => p.name === purpose)?.requireUserInput && (
-            <div className="catalog-item-form__group-control--single">
+            <div className="catalog-item-form__group-control--single" style={{ marginTop: 'var(--pf-t--global--spacer--sm)' }}>
               <TextInput
                 aria-label="Specify purpose"
                 placeholder="Specify purpose"

--- a/catalog/ui/src/app/components/SalesforceItemsField.tsx
+++ b/catalog/ui/src/app/components/SalesforceItemsField.tsx
@@ -109,7 +109,7 @@ const SalesforceItemsField: React.FC<{
     <>
       {/* Display existing items as read-only input fields */}
       {existingItems.map((item, idx) => (
-        <div key={`existing-${idx}`} style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginBottom: 16, minWidth: '600px' }}>
+        <div key={`existing-${idx}`} style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginBottom: 16 }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap', marginBottom: 4 }}>
               <Radio
@@ -149,7 +149,7 @@ const SalesforceItemsField: React.FC<{
                 Id Finder
               </Button>
               <TextInput
-                style={{ minWidth: '300px', flex: 1 }}
+                style={{ flex: 1, minWidth: 0 }}
                 id={`${fieldId}-existing-${idx}`}
                 value={item.id || ''}
                 validated="success"
@@ -180,7 +180,7 @@ const SalesforceItemsField: React.FC<{
 
       {/* Add new item form */}
       {showAddForm && (
-        <div style={{ marginTop: 0, marginBottom: 16, minWidth: '600px', maxWidth: '800px' }}>
+        <div style={{ marginTop: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap', marginBottom: 4 }}>
               <Radio
@@ -222,7 +222,7 @@ const SalesforceItemsField: React.FC<{
                 Id Finder
               </Button>
               <TextInput
-                style={{ minWidth: '300px', flex: 1 }}
+                style={{ flex: 1, minWidth: 0 }}
                 id={fieldId}
                 value={newItem.id || ''}
                 onChange={(_e, v) => handleIdChange(v as string)}


### PR DESCRIPTION
## Summary
- **Salesforce ID overflow**: Removed `minWidth` constraints on the Salesforce ID input containers and text inputs that forced content wider than the modal
- **Create/Cancel button positioning**: Changed modal body `overflow` from `visible` to `auto` so the body scrolls when content overflows, keeping the footer buttons at the bottom. Added bottom padding for spacing before the footer
- **Purpose explanation spacing**: Added top margin between the "Other" dropdown and the "Specify purpose" text input in `ActivityPurposeSelector`

## Test plan
- [x] Open Create Tenant Cluster Pool modal — verify Salesforce ID row fits within modal bounds
- [x] Select a catalog item with dynamic parameters (Activity, Purpose, etc.) — verify Create/Cancel buttons stay at the bottom of the modal, not mid-form
- [x] Select "Other" purpose — verify spacing between dropdown and free text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)