### PR TITLE
Fix cluster name derivation for shared cluster placement status

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -479,7 +479,7 @@ const TenantClusterPools: React.FC = () => {
                       </tr>
                       {isExpanded
                         ? clusters.map((cluster: TenantClusterPoolStatusCluster, idx: number) => {
-                            const clusterName = cluster.resourceClaimName.replace(/\./g, '-');
+                            const clusterName = cluster.name;
                             return (
                               <tr key={idx} className="tenant-pools-child-row">
                                 <td></td>

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -71,6 +71,7 @@ import {
   ResourceClaim,
   ServiceAccessConfig,
   ServiceActionActions,
+  TenantClusterPool,
   Workshop,
   WorkshopUserAssignment,
   WorkshopUserAssignmentList,
@@ -369,9 +370,26 @@ const ServicesItemComponent: React.FC<{
 
   const tenantClusterPoolAnnotation = resourceClaim.metadata.annotations?.[`${BABYLON_DOMAIN}/tenant-cluster-pool`];
   const isTenantClusterItem = !!tenantClusterPoolAnnotation;
-  const clusterName = isTenantClusterItem
-    ? resourceClaim.metadata.name.replace(/\./g, '-')
-    : resourceClaim.status?.resourceHandle?.name || '';
+  const tenantClusterPoolOwnerRef = isTenantClusterItem
+    ? resourceClaim.metadata.ownerReferences?.find((ref) => ref.kind === 'TenantClusterPool')
+    : undefined;
+  const { data: tenantClusterPool } = useSWR<TenantClusterPool>(
+    tenantClusterPoolOwnerRef
+      ? apiPaths.TENANT_CLUSTER_POOL({
+          namespace: resourceClaim.metadata.namespace,
+          tenantClusterPoolName: tenantClusterPoolOwnerRef.name,
+        })
+      : null,
+    silentFetcher,
+    { shouldRetryOnError: false, refreshInterval: 8000 },
+  );
+  const clusterName = useMemo(() => {
+    if (!isTenantClusterItem) return resourceClaim.status?.resourceHandle?.name || '';
+    const clusterEntry = tenantClusterPool?.status?.clusters?.find(
+      (c) => c.resourceClaimName === resourceClaim.metadata.name,
+    );
+    return clusterEntry?.name || '';
+  }, [isTenantClusterItem, tenantClusterPool, resourceClaim.metadata.name, resourceClaim.status?.resourceHandle?.name]);
   const { data: sandboxPlacementsData, isLoading: sandboxStatusLoading } = useSWR(
     isTenantClusterItem && clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
     silentFetcher,


### PR DESCRIPTION
Instead of replacing dots with dashes in the ResourceClaim name to derive the cluster name for sandbox API calls, use the actual cluster name from the TenantClusterPool status. In ServicesItem, fetch the parent TenantClusterPool via ownerReferences and look up the correct cluster name from status.clusters. In TenantClusterPools admin view, use the existing cluster.name field directly.