### PR TITLE
Fix React act() environment warning in tests

### DIFF
--- a/catalog/ui/test-setup.ts
+++ b/catalog/ui/test-setup.ts
@@ -2,6 +2,8 @@ import { TextEncoder, TextDecoder } from 'util';
 
 Object.assign(globalThis, { TextEncoder, TextDecoder });
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 import '@testing-library/jest-dom';
 import fetchMock from 'jest-fetch-mock';
 


### PR DESCRIPTION
Set `globalThis.IS_REACT_ACT_ENVIRONMENT = true` in test-setup.ts to suppress "The current testing environment is not configured to support act(...)" console errors during test runs.