### PR TITLE
Fix React act() environment warning in tests

### DIFF
--- a/catalog/ui/test-setup.ts
+++ b/catalog/ui/test-setup.ts
@@ -2,6 +2,8 @@ import { TextEncoder, TextDecoder } from 'util';
 
 Object.assign(globalThis, { TextEncoder, TextDecoder });
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 import '@testing-library/jest-dom';
 import fetchMock from 'jest-fetch-mock';
 


### PR DESCRIPTION
## Summary
- Set `globalThis.IS_REACT_ACT_ENVIRONMENT = true` in `catalog/ui/test-setup.ts` to eliminate `console.error` noise from React's development build during test runs
- PatternFly's Popper/Popover components trigger state updates after `@testing-library/react` restores the flag to its previous value (`undefined`); setting it to `true` upfront ensures it stays `true` after restoration

## Test plan
- [x] All 177 tests pass with `--maxWorkers=2` (matching CI config)
- [x] Zero `act(...)` console errors after the change
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)