### PR TITLE
Fix React act() warning: use global instead of globalThis

### DIFF
--- a/catalog/ui/test-setup.ts
+++ b/catalog/ui/test-setup.ts
@@ -2,7 +2,7 @@ import { TextEncoder, TextDecoder } from 'util';
 
 Object.assign(globalThis, { TextEncoder, TextDecoder });
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+global.IS_REACT_ACT_ENVIRONMENT = true;
 
 import '@testing-library/jest-dom';
 import fetchMock from 'jest-fetch-mock';


### PR DESCRIPTION
## Summary
- React CJS bundle checks `typeof IS_REACT_ACT_ENVIRONMENT` as a bare identifier, which resolves against Node `global` not jsdom `globalThis`
- The previous fix (b890cef2) set `globalThis.IS_REACT_ACT_ENVIRONMENT = true`, but React never saw it because it reads from `global`
- Changed to `global.IS_REACT_ACT_ENVIRONMENT = true` so React correctly detects the test environment and suppresses the console error

## Test plan
- [x] `npx jest --maxWorkers=2` passes (17 suites pass, 1 skipped, same as before)
- [x] Verified the act() warning no longer appears in test output