### PR TITLE
Suppress React act() console.error in test setup

### DIFF
--- a/catalog/ui/test-setup.ts
+++ b/catalog/ui/test-setup.ts
@@ -4,6 +4,12 @@ Object.assign(globalThis, { TextEncoder, TextDecoder });
 
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
+const originalConsoleError = console.error;
+console.error = (...args: unknown[]) => {
+  if (typeof args[0] === 'string' && args[0].includes('not configured to support act')) return;
+  originalConsoleError(...args);
+};
+
 import '@testing-library/jest-dom';
 import fetchMock from 'jest-fetch-mock';
 


### PR DESCRIPTION
## Summary
- The `global.IS_REACT_ACT_ENVIRONMENT = true` flag from #3588 does not prevent warnings from PatternFly Popper and `useEffect` callbacks (e.g. `Ops.tsx:816`) that trigger state updates outside `act()` boundaries
- Filters out the specific `not configured to support act` console.error in test-setup.ts to keep CI logs clean
- Tests continue to pass (17 suites, 177 tests)

## Test plan
- [x] `npx jest --maxWorkers=2` passes locally
- [x] No act() warnings in test output
- [ ] Verify CI pipeline passes without act() warnings