### PR TITLE
Improve TenantClusterPool pages with sandbox API actions

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -26,7 +26,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import Editor from '@monaco-editor/react';
 import * as yaml from 'js-yaml';
 import { apiPaths, deleteTenantClusterPool, fetcher, patchTenantClusterPool } from '@app/api';
-import { SalesforceItem, TenantClusterPool } from '@app/types';
+import { SalesforceItem, TenantClusterPool, TenantClusterPoolStatusCluster } from '@app/types';
 import { KeyedMutator } from 'swr';
 import { ActionDropdown, ActionDropdownItem } from '@app/components/ActionDropdown';
 import LocalTimestamp from '@app/components/LocalTimestamp';
@@ -36,7 +36,9 @@ import { useErrorBoundary } from 'react-error-boundary';
 import useSWR from 'swr';
 import { compareK8sObjects, DEMO_DOMAIN } from '@app/util';
 import useSession from '@app/utils/useSession';
+import SandboxApiActions from '@app/components/SandboxApiActions';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import useSandboxApi from '@app/utils/useSandboxApi';
 
 import './admin.css';
 
@@ -102,6 +104,49 @@ const TenantClusterPoolNumberInput: React.FC<{
   );
 };
 
+const ClusterRow: React.FC<{
+  cluster: TenantClusterPoolStatusCluster;
+  namespace: string;
+}> = ({ cluster, namespace }) => {
+  const { status, placementCount, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+
+  return (
+    <Tr>
+      <Td dataLabel="ResourceClaim">
+        <Link to={`/services/${namespace}/${cluster.resourceClaimName}`}>
+          {cluster.resourceClaimName}
+        </Link>
+      </Td>
+      <Td dataLabel="Sandbox API State">
+        <Label isCompact color={sandboxApiStateColor(cluster.sandboxApiState)}>
+          {cluster.sandboxApiState}
+        </Label>
+      </Td>
+      <Td dataLabel="Sandbox API">
+        {status === 'loading' ? (
+          <Spinner size="sm" />
+        ) : (
+          <Label isCompact color={status === 'available' ? 'green' : status === 'disabled' ? 'red' : 'orange'}>
+            {status === 'available' ? 'Onboarded' : status === 'disabled' ? 'Disabled' : 'Not Onboarded'}
+          </Label>
+        )}
+      </Td>
+      <Td dataLabel="Placements">
+        {status === 'loading' ? <Spinner size="sm" /> : placementCount}
+      </Td>
+      <Td dataLabel="Actions">
+        <SandboxApiActions
+          status={status}
+          updating={updating}
+          performAction={performAction}
+          isDisabled={cluster.sandboxApiState !== 'available'}
+          size="sm"
+        />
+      </Td>
+    </Tr>
+  );
+};
+
 const TenantClusterPoolInstanceComponent: React.FC<{
   tenantClusterPoolName: string;
   tenantClusterPoolNamespace: string;
@@ -141,6 +186,7 @@ const TenantClusterPoolInstanceComponent: React.FC<{
   }
 
   const clusters = tenantClusterPool?.status?.clusters || [];
+  const canDelete = clusters.length === 0 || clusters.every((c) => c.sandboxApiState === 'removed' || c.sandboxApiState === 'pending');
   const spec = tenantClusterPool?.spec;
 
   return (
@@ -166,7 +212,7 @@ const TenantClusterPoolInstanceComponent: React.FC<{
             <ActionDropdown
               position="right"
               actionDropdownItems={[
-                <ActionDropdownItem key="delete" label="Delete TenantClusterPool" onSelect={confirmThenDelete} />,
+                <ActionDropdownItem key="delete" label="Delete TenantClusterPool" onSelect={confirmThenDelete} isDisabled={!canDelete} />,
                 <ActionDropdownItem
                   key="editInOpenShift"
                   label="Edit in OpenShift Console"
@@ -391,22 +437,14 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                   <Tr>
                     <Th>ResourceClaim</Th>
                     <Th>Sandbox API State</Th>
+                    <Th>Sandbox API</Th>
+                    <Th>Placements</Th>
+                    <Th>Actions</Th>
                   </Tr>
                 </Thead>
                 <Tbody>
                   {clusters.map((cluster, idx) => (
-                    <Tr key={idx}>
-                      <Td dataLabel="ResourceClaim">
-                        <Link to={`/services/${tenantClusterPoolNamespace}/${cluster.resourceClaimName}`}>
-                          {cluster.resourceClaimName}
-                        </Link>
-                      </Td>
-                      <Td dataLabel="Sandbox API State">
-                        <Label isCompact color={sandboxApiStateColor(cluster.sandboxApiState)}>
-                          {cluster.sandboxApiState}
-                        </Label>
-                      </Td>
-                    </Tr>
+                    <ClusterRow key={idx} cluster={cluster} namespace={tenantClusterPoolNamespace} />
                   ))}
                 </Tbody>
               </Table>

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -14,13 +14,14 @@ import {
   SplitItem,
   TextInput,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
-import { apiPaths, createTenantClusterPool, deleteTenantClusterPool, fetcherItemsInAllPages, silentFetcher } from '@app/api';
+import { apiPaths, createTenantClusterPool, deleteTenantClusterPool, fetcherItemsInAllPages } from '@app/api';
 import { CatalogItem, CatalogItemSpecParameter, SalesforceItem, TenantClusterPool, TenantClusterPoolStatusCluster, TPurposeOpts } from '@app/types';
 import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
 import DynamicFormInput from '@app/components/DynamicFormInput';
@@ -32,7 +33,9 @@ import useInterfaceConfig from '@app/utils/useInterfaceConfig';
 import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
 import Modal, { useModal } from '@app/Modal/Modal';
 import useSWR from 'swr';
+import SandboxApiActions from '@app/components/SandboxApiActions';
 import Footer from '@app/components/Footer';
+import useSandboxApi from '@app/utils/useSandboxApi';
 
 import './admin.css';
 import './tenant-cluster-pools.css';
@@ -53,39 +56,52 @@ function filterPool(pool: TenantClusterPool, keywordFilter: string[]): boolean {
   return true;
 }
 
-const ClusterPlacementsCell: React.FC<{ clusterName: string }> = ({ clusterName }) => {
-  const { data: placementsData } = useSWR(
-    clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
-    silentFetcher,
-    { shouldRetryOnError: false, suspense: false },
-  );
-  const { data: configData } = useSWR(
-    clusterName ? apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName }) : null,
-    silentFetcher,
-    { shouldRetryOnError: false, suspense: false },
-  );
-  const count = placementsData?.placements?.length ?? 0;
-  const max = configData?.max_placements;
-  if (!placementsData?.placements && !configData) return <span className="tenant-pools-muted">-</span>;
-  if (max != null) return <span>{count} / {max}</span>;
-  return <span>{count}</span>;
-};
+const ClusterChildRow: React.FC<{
+  cluster: TenantClusterPoolStatusCluster;
+  namespace: string;
+}> = ({ cluster, namespace }) => {
+  const { status, placementCount, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
-const ClusterSandboxApiCell: React.FC<{ clusterName: string }> = ({ clusterName }) => {
-  const { data } = useSWR(
-    clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
-    silentFetcher,
-    { shouldRetryOnError: false, suspense: false },
+  return (
+    <tr className="tenant-pools-child-row">
+      <td></td>
+      <td>
+        <Link
+          to={`/services/${namespace}/${cluster.resourceClaimName}`}
+          className="tenant-pools-name-link"
+        >
+          {cluster.resourceClaimName}
+        </Link>
+      </td>
+      <td>
+        <Label isCompact color={sandboxApiStateColor(cluster.sandboxApiState)}>
+          {cluster.sandboxApiState}
+        </Label>
+      </td>
+      <td>{status === 'loading' ? <span className="tenant-pools-muted">-</span> : placementCount}</td>
+      <td>
+        {status === 'loading' ? (
+          <span className="tenant-pools-muted">-</span>
+        ) : status === 'available' ? (
+          <span className="tenant-pools-onboarded"><CheckCircleIcon /> Onboarded</span>
+        ) : status === 'disabled' ? (
+          <span className="tenant-pools-not-onboarded">Disabled</span>
+        ) : (
+          <span className="tenant-pools-not-onboarded">Not onboarded</span>
+        )}
+      </td>
+      <td>
+        <SandboxApiActions
+          status={status}
+          updating={updating}
+          performAction={performAction}
+          isDisabled={cluster.sandboxApiState !== 'available'}
+          size="sm"
+        />
+      </td>
+      <td></td>
+    </tr>
   );
-  if (data === undefined) return <span className="tenant-pools-muted">-</span>;
-  if (data?.placements) {
-    return (
-      <span className="tenant-pools-onboarded">
-        <CheckCircleIcon /> Onboarded
-      </span>
-    );
-  }
-  return <span className="tenant-pools-not-onboarded">Not onboarded</span>;
 };
 
 function sandboxApiStateColor(state: string): 'green' | 'yellow' | 'red' | 'grey' {
@@ -432,6 +448,7 @@ const TenantClusterPools: React.FC = () => {
                   const clusters = pool.status?.clusters || [];
                   const clusterCount = clusters.length;
                   const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
+                  const canDelete = clusterCount === 0 || clusters.every((c) => c.sandboxApiState === 'removed' || c.sandboxApiState === 'pending');
 
                   return (
                     <React.Fragment key={poolKey}>
@@ -464,49 +481,38 @@ const TenantClusterPools: React.FC = () => {
                           <TimeInterval toTimestamp={pool.metadata.creationTimestamp} />
                         </td>
                         <td>
-                          <Button
-                            variant="plain"
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              showDeleteModal(pool);
-                            }}
-                            aria-label={`Delete ${pool.metadata.name}`}
-                          >
-                            <TrashIcon />
-                          </Button>
+                          {canDelete ? (
+                            <Button
+                              variant="plain"
+                              size="sm"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                showDeleteModal(pool);
+                              }}
+                              aria-label={`Delete ${pool.metadata.name}`}
+                            >
+                              <TrashIcon />
+                            </Button>
+                          ) : (
+                            <Tooltip content="All clusters must be removed before the pool can be deleted">
+                              <span>
+                                <Button
+                                  variant="plain"
+                                  size="sm"
+                                  isDisabled
+                                  aria-label={`Delete ${pool.metadata.name}`}
+                                >
+                                  <TrashIcon />
+                                </Button>
+                              </span>
+                            </Tooltip>
+                          )}
                         </td>
                       </tr>
                       {isExpanded
-                        ? clusters.map((cluster: TenantClusterPoolStatusCluster, idx: number) => {
-                            const clusterName = cluster.name;
-                            return (
-                              <tr key={idx} className="tenant-pools-child-row">
-                                <td></td>
-                                <td>
-                                  <Link
-                                    to={`/services/${pool.metadata.namespace}/${cluster.resourceClaimName}`}
-                                    className="tenant-pools-name-link"
-                                  >
-                                    {cluster.resourceClaimName}
-                                  </Link>
-                                </td>
-                                <td>
-                                  <Label isCompact color={sandboxApiStateColor(cluster.sandboxApiState)}>
-                                    {cluster.sandboxApiState}
-                                  </Label>
-                                </td>
-                                <td>
-                                  <ClusterPlacementsCell clusterName={clusterName} />
-                                </td>
-                                <td>
-                                  <ClusterSandboxApiCell clusterName={clusterName} />
-                                </td>
-                                <td></td>
-                                <td></td>
-                              </tr>
-                            );
-                          })
+                        ? clusters.map((cluster: TenantClusterPoolStatusCluster, idx: number) => (
+                            <ClusterChildRow key={idx} cluster={cluster} namespace={pool.metadata.namespace} />
+                          ))
                         : null}
                     </React.Fragment>
                   );

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -60,7 +60,6 @@ import {
   createServiceAccessConfig,
   patchServiceAccessConfig,
   deleteServiceAccessConfig,
-  setTenantClusterAction,
 } from '@app/api';
 import {
   AnarchySubject,
@@ -116,7 +115,9 @@ import ServiceUsers from './ServiceUsers';
 import ServiceStatus from './ServiceStatus';
 import ServiceItemStatus from './ServiceItemStatus';
 import InfoTab from './InfoTab';
+import SandboxApiActions from '@app/components/SandboxApiActions';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import useSandboxApi from '@app/utils/useSandboxApi';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import useDebounceState from '@app/utils/useDebounceState';
@@ -399,27 +400,19 @@ const ServicesItemComponent: React.FC<{
     );
     return clusterEntry?.name || '';
   }, [isTenantClusterItem, tenantClusterPool, resourceClaim.metadata.name, resourceClaim.status?.resourceHandle?.name]);
-  const { data: sandboxPlacementsData, isLoading: sandboxStatusLoading } = useSWR(
-    isTenantClusterItem && clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
-    silentFetcher,
-    { shouldRetryOnError: false, refreshInterval: 8000 },
+  const {
+    status: sandboxApiStatus,
+    updating: tenantActionUpdating,
+    performAction: performSandboxAction,
+  } = useSandboxApi(
+    isTenantClusterItem ? clusterName : '',
+    resourceClaim.metadata.namespace,
+    resourceClaim.metadata.name,
   );
-  const { data: sandboxConfigData } = useSWR(
-    isTenantClusterItem && clusterName && sandboxPlacementsData?.placements
-      ? apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName })
-      : null,
-    silentFetcher,
-    { shouldRetryOnError: false, refreshInterval: 8000 },
-  );
-  const sandboxApiStatus = useMemo(() => {
-    if (!isTenantClusterItem) return null;
-    if (sandboxStatusLoading) return 'loading';
-    if (sandboxPlacementsData?.placements) {
-      return sandboxConfigData?.valid === true ? 'available' : 'disabled';
-    }
-    return 'not onboarded';
-  }, [isTenantClusterItem, sandboxStatusLoading, sandboxPlacementsData, sandboxConfigData]);
-  const [tenantActionUpdating, setTenantActionUpdating] = useState(false);
+  const isRunning = useMemo(() => {
+    const resource = resourceClaim.status?.resources?.[0]?.state;
+    return resource?.kind === 'AnarchySubject' && resource.spec?.vars?.current_state === 'started';
+  }, [resourceClaim.status?.resources]);
 
   const [serviceAlias, setServiceAlias] = useState(
     resourceClaim.metadata.annotations?.[`${DEMO_DOMAIN}/service-alias`] || '',
@@ -931,7 +924,30 @@ const ServicesItemComponent: React.FC<{
       <PageSection hasBodyWrapper={false} key="head" className="services-item__head">
         <Split hasGutter>
           <SplitItem isFilled>
-            {isAdmin || serviceNamespaces.length > 1 ? (
+            {isAdmin && isTenantClusterItem ? (
+              <Breadcrumb>
+                <BreadcrumbItem
+                  render={({ className }) => (
+                    <Link to="/admin/tenantclusterpools" className={className}>
+                      Tenant Cluster Pools
+                    </Link>
+                  )}
+                />
+                {tenantClusterPoolOwnerRef ? (
+                  <BreadcrumbItem
+                    render={({ className }) => (
+                      <Link
+                        to={`/admin/tenantclusterpools/${resourceClaim.metadata.namespace}/${tenantClusterPoolOwnerRef.name}/clusters`}
+                        className={className}
+                      >
+                        {tenantClusterPoolOwnerRef.name}
+                      </Link>
+                    )}
+                  />
+                ) : null}
+                <BreadcrumbItem>{resourceClaimName}</BreadcrumbItem>
+              </Breadcrumb>
+            ) : isAdmin || serviceNamespaces.length > 1 ? (
               <Breadcrumb>
                 <BreadcrumbItem
                   render={({ className }) => (
@@ -1276,23 +1292,12 @@ const ServicesItemComponent: React.FC<{
                             >
                               <p>Tenants will not be able to discover or request placements on this cluster until it is onboarded.</p>
                             </Alert>
-                            <Button
-                              style={{ alignSelf: 'flex-start' }}
-                              variant="primary"
-                              isLoading={tenantActionUpdating}
-                              isDisabled={tenantActionUpdating}
-                              onClick={async () => {
-                                setTenantActionUpdating(true);
-                                try {
-                                  await setTenantClusterAction(resourceClaim.metadata.namespace, resourceClaim.metadata.name, 'onboard');
-                                  mutate();
-                                } finally {
-                                  setTenantActionUpdating(false);
-                                }
-                              }}
-                            >
-                              Onboard to Sandbox API
-                            </Button>
+                            <SandboxApiActions
+                              status={sandboxApiStatus}
+                              updating={tenantActionUpdating}
+                              performAction={performSandboxAction}
+                              isDisabled={!isRunning}
+                            />
                           </div>
                         ) : sandboxApiStatus === 'available' ? (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--sm)' }}>
@@ -1300,66 +1305,22 @@ const ServicesItemComponent: React.FC<{
                               <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
                               Onboarded — Enabled
                             </span>
-                            <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)' }}>
-                              <Button
-                                variant="secondary"
-                                isDanger
-                                isLoading={tenantActionUpdating}
-                                isDisabled={tenantActionUpdating}
-                                onClick={async () => {
-                                  setTenantActionUpdating(true);
-                                  try {
-                                    await setTenantClusterAction(resourceClaim.metadata.namespace, resourceClaim.metadata.name, 'disable');
-                                    mutate();
-                                  } finally {
-                                    setTenantActionUpdating(false);
-                                  }
-                                }}
-                              >
-                                Disable
-                              </Button>
-                            </div>
+                            <SandboxApiActions
+                              status={sandboxApiStatus}
+                              updating={tenantActionUpdating}
+                              performAction={performSandboxAction}
+                            />
                           </div>
                         ) : sandboxApiStatus === 'disabled' ? (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--sm)' }}>
                             <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
                               Onboarded — Disabled
                             </span>
-                            <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--sm)' }}>
-                              <Button
-                                variant="primary"
-                                isLoading={tenantActionUpdating}
-                                isDisabled={tenantActionUpdating}
-                                onClick={async () => {
-                                  setTenantActionUpdating(true);
-                                  try {
-                                    await setTenantClusterAction(resourceClaim.metadata.namespace, resourceClaim.metadata.name, 'enable');
-                                    mutate();
-                                  } finally {
-                                    setTenantActionUpdating(false);
-                                  }
-                                }}
-                              >
-                                Enable
-                              </Button>
-                              <Button
-                                variant="secondary"
-                                isDanger
-                                isLoading={tenantActionUpdating}
-                                isDisabled={tenantActionUpdating}
-                                onClick={async () => {
-                                  setTenantActionUpdating(true);
-                                  try {
-                                    await setTenantClusterAction(resourceClaim.metadata.namespace, resourceClaim.metadata.name, 'offboard');
-                                    mutate();
-                                  } finally {
-                                    setTenantActionUpdating(false);
-                                  }
-                                }}
-                              >
-                                Offboard
-                              </Button>
-                            </div>
+                            <SandboxApiActions
+                              status={sandboxApiStatus}
+                              updating={tenantActionUpdating}
+                              performAction={performSandboxAction}
+                            />
                           </div>
                         ) : null}
                       </DescriptionListDescription>

--- a/catalog/ui/src/app/components/SandboxApiActions.tsx
+++ b/catalog/ui/src/app/components/SandboxApiActions.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button, Spinner } from '@patternfly/react-core';
+import { SandboxApiStatus } from '@app/utils/useSandboxApi';
+
+const SandboxApiActions: React.FC<{
+  status: SandboxApiStatus;
+  updating: boolean;
+  performAction: (action: string) => Promise<void>;
+  isDisabled?: boolean;
+  size?: 'sm' | 'lg';
+}> = ({ status, updating, performAction, isDisabled = false, size }) => {
+  if (updating) {
+    return <Spinner size="sm" />;
+  }
+
+  if (status === 'not onboarded') {
+    return (
+      <Button style={{ alignSelf: 'flex-start' }} variant="primary" size={size} isDisabled={isDisabled} onClick={() => performAction('onboard')}>
+        Onboard
+      </Button>
+    );
+  }
+
+  if (status === 'available') {
+    return (
+      <Button style={{ alignSelf: 'flex-start' }} variant="secondary" size={size} isDanger onClick={() => performAction('disable')}>
+        Disable
+      </Button>
+    );
+  }
+
+  if (status === 'disabled') {
+    return (
+      <span style={{ display: 'inline-flex', gap: '8px', alignSelf: 'flex-start' }}>
+        <Button variant="primary" size={size} onClick={() => performAction('enable')}>
+          Enable
+        </Button>
+        <Button variant="secondary" size={size} isDanger onClick={() => performAction('offboard')}>
+          Offboard
+        </Button>
+      </span>
+    );
+  }
+
+  return null;
+};
+
+export default SandboxApiActions;

--- a/catalog/ui/src/app/utils/useSandboxApi.ts
+++ b/catalog/ui/src/app/utils/useSandboxApi.ts
@@ -1,0 +1,55 @@
+import { useMemo, useState, useCallback } from 'react';
+import useSWR from 'swr';
+import { apiPaths, silentFetcher, setTenantClusterAction } from '@app/api';
+
+export type SandboxApiStatus = 'loading' | 'not onboarded' | 'available' | 'disabled';
+
+interface UseSandboxApiResult {
+  status: SandboxApiStatus;
+  placementCount: number;
+  updating: boolean;
+  performAction: (action: string) => Promise<void>;
+}
+
+export default function useSandboxApi(
+  clusterName: string,
+  namespace: string,
+  resourceClaimName: string,
+): UseSandboxApiResult {
+  const { data: placementsData, isLoading, mutate: mutatePlacements } = useSWR(
+    clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
+    silentFetcher,
+    { shouldRetryOnError: false, refreshInterval: 8000 },
+  );
+  const { data: configData, mutate: mutateConfig } = useSWR(
+    clusterName && placementsData?.placements
+      ? apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName })
+      : null,
+    silentFetcher,
+    { shouldRetryOnError: false, refreshInterval: 8000 },
+  );
+
+  const status: SandboxApiStatus = useMemo(() => {
+    if (isLoading) return 'loading';
+    if (placementsData?.placements) {
+      return configData?.valid === true ? 'available' : 'disabled';
+    }
+    return 'not onboarded';
+  }, [isLoading, placementsData, configData]);
+
+  const placementCount = placementsData?.placements?.length ?? 0;
+  const [updating, setUpdating] = useState(false);
+
+  const performAction = useCallback(async (action: string) => {
+    setUpdating(true);
+    try {
+      await setTenantClusterAction(namespace, resourceClaimName, action);
+      mutatePlacements();
+      mutateConfig();
+    } finally {
+      setUpdating(false);
+    }
+  }, [namespace, resourceClaimName, mutatePlacements, mutateConfig]);
+
+  return { status, placementCount, updating, performAction };
+}


### PR DESCRIPTION
## Summary
- Disable delete button (trash on list page, dropdown on detail page) unless all clusters have `sandboxApiState` of `removed` or `pending`; tooltip on disabled trash explains why
- Add onboarded status, placement count, and sandbox action buttons (onboard/disable/enable/offboard) to cluster rows on both the list and detail pages
- Disable onboard button on ResourceClaim detail when the cluster is not running
- Update breadcrumb for admin shared-cluster ResourceClaim detail to navigate through TenantClusterPool hierarchy
- Extract shared sandbox API logic into `useSandboxApi` hook and `SandboxApiActions` component to deduplicate across ServicesItem and TenantClusterPool pages

## Test plan
- [x] Verify trash button is disabled on list page when clusters are not all removed/pending, and tooltip shows on hover
- [x] Verify Delete dropdown item is disabled on detail page under same conditions
- [x] Verify onboarded status and placement count display on both list and detail cluster tables
- [x] Verify onboard/disable/enable/offboard buttons work correctly per cluster
- [x] Verify onboard button is disabled when ResourceClaim is not running
- [x] Verify breadcrumb on shared-cluster ResourceClaim detail navigates through TenantClusterPool pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)