### PR TITLE
Enable sandbox API onboard action for removed clusters

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -139,7 +139,7 @@ const ClusterRow: React.FC<{
           status={status}
           updating={updating}
           performAction={performAction}
-          isDisabled={cluster.sandboxApiState !== 'available'}
+          isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
           size="sm"
         />
       </Td>

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -95,7 +95,7 @@ const ClusterChildRow: React.FC<{
           status={status}
           updating={updating}
           performAction={performAction}
-          isDisabled={cluster.sandboxApiState !== 'available'}
+          isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
           size="sm"
         />
       </td>


### PR DESCRIPTION
The onboard button was disabled for clusters with sandboxApiState 'removed', preventing re-onboarding. Allow onboard when state is 'removed' in both the list and detail views.