### PR TITLE
Show placements as current/max and remove duplicate Sandbox API column

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -108,7 +108,7 @@ const ClusterRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   return (
     <Tr>
@@ -122,17 +122,8 @@ const ClusterRow: React.FC<{
           {cluster.sandboxApiState}
         </Label>
       </Td>
-      <Td dataLabel="Sandbox API">
-        {status === 'loading' ? (
-          <Spinner size="sm" />
-        ) : (
-          <Label isCompact color={status === 'available' ? 'green' : status === 'disabled' ? 'red' : 'orange'}>
-            {status === 'available' ? 'Onboarded' : status === 'disabled' ? 'Disabled' : 'Not Onboarded'}
-          </Label>
-        )}
-      </Td>
       <Td dataLabel="Placements">
-        {status === 'loading' ? <Spinner size="sm" /> : placementCount}
+        {status === 'loading' ? <Spinner size="sm" /> : `${placementCount}/${maxPlacements ?? '-'}`}
       </Td>
       <Td dataLabel="Actions">
         <SandboxApiActions
@@ -437,7 +428,6 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                   <Tr>
                     <Th>ResourceClaim</Th>
                     <Th>Sandbox API State</Th>
-                    <Th>Sandbox API</Th>
                     <Th>Placements</Th>
                     <Th>Actions</Th>
                   </Tr>

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -60,7 +60,7 @@ const ClusterChildRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   return (
     <tr className="tenant-pools-child-row">
@@ -78,7 +78,7 @@ const ClusterChildRow: React.FC<{
           {cluster.sandboxApiState}
         </Label>
       </td>
-      <td>{status === 'loading' ? <span className="tenant-pools-muted">-</span> : placementCount}</td>
+      <td>{status === 'loading' ? <span className="tenant-pools-muted">-</span> : `${placementCount}/${maxPlacements ?? '-'}`}</td>
       <td>
         {status === 'loading' ? (
           <span className="tenant-pools-muted">-</span>

--- a/catalog/ui/src/app/utils/useSandboxApi.ts
+++ b/catalog/ui/src/app/utils/useSandboxApi.ts
@@ -7,6 +7,7 @@ export type SandboxApiStatus = 'loading' | 'not onboarded' | 'available' | 'disa
 interface UseSandboxApiResult {
   status: SandboxApiStatus;
   placementCount: number;
+  maxPlacements: number | null;
   updating: boolean;
   performAction: (action: string) => Promise<void>;
 }
@@ -38,6 +39,7 @@ export default function useSandboxApi(
   }, [isLoading, placementsData, configData]);
 
   const placementCount = placementsData?.placements?.length ?? 0;
+  const maxPlacements: number | null = configData?.max_placements ?? null;
   const [updating, setUpdating] = useState(false);
 
   const performAction = useCallback(async (action: string) => {
@@ -51,5 +53,5 @@ export default function useSandboxApi(
     }
   }, [namespace, resourceClaimName, mutatePlacements, mutateConfig]);
 
-  return { status, placementCount, updating, performAction };
+  return { status, placementCount, maxPlacements, updating, performAction };
 }


### PR DESCRIPTION
Display placement counts as "current/max" (e.g. 0/10) on both the TenantClusterPool instance clusters tab and the list page. Remove the redundant "Sandbox API" column from the instance clusters table since "Sandbox API State" already conveys that information.