### PR TITLE
Show pending action states in TenantClusterPool pages

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -108,7 +108,7 @@ const ClusterRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, maxPlacements, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, pendingAction, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   return (
     <Tr>
@@ -129,6 +129,7 @@ const ClusterRow: React.FC<{
         <SandboxApiActions
           status={status}
           updating={updating}
+          pendingAction={pendingAction}
           performAction={performAction}
           isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
           size="sm"

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -60,7 +60,7 @@ const ClusterChildRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, maxPlacements, updating, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, pendingAction, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   return (
     <tr className="tenant-pools-child-row">
@@ -94,6 +94,7 @@ const ClusterChildRow: React.FC<{
         <SandboxApiActions
           status={status}
           updating={updating}
+          pendingAction={pendingAction}
           performAction={performAction}
           isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
           size="sm"

--- a/catalog/ui/src/app/components/SandboxApiActions.tsx
+++ b/catalog/ui/src/app/components/SandboxApiActions.tsx
@@ -2,13 +2,30 @@ import React from 'react';
 import { Button, Spinner } from '@patternfly/react-core';
 import { SandboxApiStatus } from '@app/utils/useSandboxApi';
 
+const actionLabels: Record<string, string> = {
+  onboard: 'Onboarding...',
+  offboard: 'Offboarding...',
+  enable: 'Enabling...',
+  disable: 'Disabling...',
+};
+
 const SandboxApiActions: React.FC<{
   status: SandboxApiStatus;
   updating: boolean;
+  pendingAction?: string | null;
   performAction: (action: string) => Promise<void>;
   isDisabled?: boolean;
   size?: 'sm' | 'lg';
-}> = ({ status, updating, performAction, isDisabled = false, size }) => {
+}> = ({ status, updating, pendingAction, performAction, isDisabled = false, size }) => {
+  if (pendingAction) {
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+        <Spinner size="sm" />
+        {actionLabels[pendingAction] || 'Processing...'}
+      </span>
+    );
+  }
+
   if (updating) {
     return <Spinner size="sm" />;
   }

--- a/catalog/ui/src/app/utils/useSandboxApi.ts
+++ b/catalog/ui/src/app/utils/useSandboxApi.ts
@@ -1,6 +1,8 @@
 import { useMemo, useState, useCallback } from 'react';
 import useSWR from 'swr';
 import { apiPaths, silentFetcher, setTenantClusterAction } from '@app/api';
+import { ResourceClaim } from '@app/types';
+import { BABYLON_DOMAIN } from '@app/util';
 
 export type SandboxApiStatus = 'loading' | 'not onboarded' | 'available' | 'disabled';
 
@@ -9,6 +11,7 @@ interface UseSandboxApiResult {
   placementCount: number;
   maxPlacements: number | null;
   updating: boolean;
+  pendingAction: string | null;
   performAction: (action: string) => Promise<void>;
 }
 
@@ -29,6 +32,21 @@ export default function useSandboxApi(
     silentFetcher,
     { shouldRetryOnError: false, refreshInterval: 8000 },
   );
+  const { data: resourceClaim } = useSWR<ResourceClaim>(
+    resourceClaimName ? apiPaths.RESOURCE_CLAIM({ namespace, resourceClaimName }) : null,
+    silentFetcher,
+    { shouldRetryOnError: false, refreshInterval: 8000 },
+  );
+
+  const pendingAction = useMemo(() => {
+    const raw = resourceClaim?.metadata?.annotations?.[`${BABYLON_DOMAIN}/tenant-cluster-action`];
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw)?.action || null;
+    } catch {
+      return null;
+    }
+  }, [resourceClaim?.metadata?.annotations]);
 
   const status: SandboxApiStatus = useMemo(() => {
     if (isLoading) return 'loading';
@@ -53,5 +71,5 @@ export default function useSandboxApi(
     }
   }, [namespace, resourceClaimName, mutatePlacements, mutateConfig]);
 
-  return { status, placementCount, maxPlacements, updating, performAction };
+  return { status, placementCount, maxPlacements, updating, pendingAction, performAction };
 }


### PR DESCRIPTION
## Summary
- Fetch the ResourceClaim tenant-cluster-action annotation in useSandboxApi to detect when the backend is processing a sandbox API action
- Show a spinner with status text (Onboarding..., Disabling..., etc.) in SandboxApiActions while an action is being reconciled, instead of showing action buttons
- Applied to both the TenantClusterPools list page (expanded cluster rows) and the TenantClusterPool detail page (clusters tab), matching the existing behavior in the ResourceClaim detail page

## Test plan
- [x] Navigate to Tenant Cluster Pools list, expand a pool, trigger an action (e.g. Onboard) on a cluster -- verify spinner + Onboarding... text appears and persists until the backend clears the annotation
- [x] Navigate to a TenantClusterPool detail page, Clusters tab, trigger an action -- verify the same pending state display
- [x] Verify the ResourceClaim detail page still shows the same behavior (no regression)
- [x] Verify that once the backend clears the annotation, the UI reverts to showing the normal action buttons