### PR TITLE
Remove create and delete actions from TenantClusterPool pages

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -25,7 +25,7 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import Editor from '@monaco-editor/react';
 import * as yaml from 'js-yaml';
-import { apiPaths, deleteTenantClusterPool, fetcher, patchTenantClusterPool } from '@app/api';
+import { apiPaths, fetcher, patchTenantClusterPool } from '@app/api';
 import { SalesforceItem, TenantClusterPool, TenantClusterPoolStatusCluster } from '@app/types';
 import { KeyedMutator } from 'swr';
 import { ActionDropdown, ActionDropdownItem } from '@app/components/ActionDropdown';
@@ -169,16 +169,7 @@ const TenantClusterPoolInstanceComponent: React.FC<{
     }
   }, [error, showBoundary]);
 
-  async function confirmThenDelete(): Promise<void> {
-    if (confirm(`Delete TenantClusterPool ${tenantClusterPoolName}?`)) {
-      await deleteTenantClusterPool(tenantClusterPool);
-      mutate();
-      navigate('/admin/tenantclusterpools');
-    }
-  }
-
   const clusters = tenantClusterPool?.status?.clusters || [];
-  const canDelete = clusters.length === 0 || clusters.every((c) => c.sandboxApiState === 'removed' || c.sandboxApiState === 'pending');
   const spec = tenantClusterPool?.spec;
 
   return (
@@ -204,7 +195,6 @@ const TenantClusterPoolInstanceComponent: React.FC<{
             <ActionDropdown
               position="right"
               actionDropdownItems={[
-                <ActionDropdownItem key="delete" label="Delete TenantClusterPool" onSelect={confirmThenDelete} isDisabled={!canDelete} />,
                 <ActionDropdownItem
                   key="editInOpenShift"
                   label="Edit in OpenShift Console"

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -1,37 +1,22 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import {
-  Button,
   EmptyState,
-  Form,
-  FormGroup,
-  HelperText,
-  HelperTextItem,
   Label,
-  NumberInput,
   PageSection,
   Split,
   SplitItem,
-  TextInput,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
-import { apiPaths, createTenantClusterPool, deleteTenantClusterPool, fetcherItemsInAllPages } from '@app/api';
-import { CatalogItem, CatalogItemSpecParameter, SalesforceItem, TenantClusterPool, TenantClusterPoolStatusCluster, TPurposeOpts } from '@app/types';
-import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
-import DynamicFormInput from '@app/components/DynamicFormInput';
+import { apiPaths, fetcherItemsInAllPages } from '@app/api';
+import { TenantClusterPool, TenantClusterPoolStatusCluster } from '@app/types';
 import KeywordSearchInput from '@app/components/KeywordSearchInput';
-import SalesforceItemsField from '@app/components/SalesforceItemsField';
 import TimeInterval from '@app/components/TimeInterval';
-import { BABYLON_DOMAIN, compareK8sObjectsArr, DEMO_DOMAIN, displayName, FETCH_BATCH_LIMIT } from '@app/util';
-import useInterfaceConfig from '@app/utils/useInterfaceConfig';
-import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
-import Modal, { useModal } from '@app/Modal/Modal';
+import { compareK8sObjectsArr, FETCH_BATCH_LIMIT } from '@app/util';
 import useSWR from 'swr';
 import SandboxApiActions from '@app/components/SandboxApiActions';
 import Footer from '@app/components/Footer';
@@ -115,192 +100,6 @@ function sandboxApiStateColor(state: string): 'green' | 'yellow' | 'red' | 'grey
   }
 }
 
-const CreateTenantClusterPoolForm: React.FC<{
-  setOnConfirmCb?: React.Dispatch<React.SetStateAction<() => Promise<void>>>;
-  onCreated: (pool: TenantClusterPool) => void;
-}> = ({ setOnConfirmCb, onCreated }) => {
-  const { sfdc_enabled } = useInterfaceConfig();
-  const [selectedCatalogItem, setSelectedCatalogItem] = useState<CatalogItem | null>(null);
-  const [isCatalogSelectorOpen, setIsCatalogSelectorOpen] = useState(false);
-  const [minClusters, setMinClusters] = useState(0);
-  const [maxClusters, setMaxClusters] = useState(0);
-  const [minAvailableSandboxPlacements, setMinAvailableSandboxPlacements] = useState(0);
-  const [activity, setActivity] = useState('');
-  const [purpose, setPurpose] = useState('');
-  const [explanation, setExplanation] = useState('');
-  const [salesforceItems, setSalesforceItems] = useState<SalesforceItem[]>([]);
-  const [parameterValues, setParameterValues] = useState<Record<string, unknown>>({});
-
-  const catalogItemName = selectedCatalogItem?.metadata?.name || '';
-  const purposeOpts: TPurposeOpts = selectedCatalogItem?.spec?.parameters
-    ? selectedCatalogItem.spec.parameters.find((p) => p.name === 'purpose')?.openAPIV3Schema?.['x-form-options'] || []
-    : [];
-  const dynamicParameters: CatalogItemSpecParameter[] = useMemo(
-    () =>
-      (selectedCatalogItem?.spec?.parameters || []).filter(
-        (p) => p.name !== 'purpose' && p.name !== 'salesforce_id',
-      ),
-    [selectedCatalogItem],
-  );
-
-  useEffect(() => {
-    if (!setOnConfirmCb) return;
-    setOnConfirmCb(() => async () => {
-      if (!catalogItemName) throw new Error('Please select a catalog item');
-      if (maxClusters < minClusters) throw new Error('Max Clusters must be greater than or equal to Min Clusters');
-      const annotations: Record<string, string> = {};
-      if (purpose) {
-        annotations[`${DEMO_DOMAIN}/purpose`] = purpose;
-      }
-      if (activity) {
-        annotations[`${DEMO_DOMAIN}/purpose-activity`] = activity;
-      }
-      if (explanation) {
-        annotations[`${DEMO_DOMAIN}/purpose-explanation`] = explanation;
-      }
-      if (salesforceItems.length > 0) {
-        annotations[`${DEMO_DOMAIN}/salesforce-items`] = JSON.stringify(salesforceItems);
-      }
-      const allParameterValues: Record<string, unknown> = { ...parameterValues };
-      if (purpose) {
-        allParameterValues.purpose = purpose;
-      }
-      const definition: TenantClusterPool = {
-        apiVersion: `${BABYLON_DOMAIN}/v1`,
-        kind: 'TenantClusterPool',
-        metadata: {
-          name: catalogItemName,
-          namespace: 'shared-clusters',
-          annotations,
-        },
-        spec: {
-          clusterProvisioning: {
-            provider: {
-              name: catalogItemName,
-              ...(Object.keys(allParameterValues).length > 0 ? { parameterValues: allParameterValues } : {}),
-            },
-          },
-          minClusters,
-          maxClusters,
-          minAvailableSandboxPlacements,
-        },
-      };
-      const created = await createTenantClusterPool(definition);
-      onCreated(created);
-    });
-  }, [catalogItemName, minClusters, maxClusters, minAvailableSandboxPlacements, activity, purpose, explanation, salesforceItems, parameterValues, onCreated, setOnConfirmCb]);
-
-  return (
-    <>
-      <CatalogItemSelectorModal
-        isOpen={isCatalogSelectorOpen}
-        onClose={() => setIsCatalogSelectorOpen(false)}
-        onSelect={(item) => {
-          const selected = Array.isArray(item) ? item[0] : item;
-          if (selected) setSelectedCatalogItem(selected);
-        }}
-        title="Select Catalog Item"
-        singleSelect
-      />
-      <Form>
-        <FormGroup label="Catalog Item" isRequired fieldId="tcp-catalog-item">
-          <Split hasGutter>
-            <SplitItem isFilled>
-              <TextInput
-                id="tcp-catalog-item"
-                readOnly
-                value={selectedCatalogItem ? displayName(selectedCatalogItem) : ''}
-                placeholder="Select a catalog item..."
-              />
-            </SplitItem>
-            <SplitItem>
-              <Button variant="secondary" onClick={() => setIsCatalogSelectorOpen(true)}>
-                Browse Catalog
-              </Button>
-            </SplitItem>
-          </Split>
-        </FormGroup>
-        {catalogItemName ? (
-          <FormGroup label="Name / Provider" fieldId="tcp-name">
-            <TextInput id="tcp-name" readOnly value={catalogItemName} />
-          </FormGroup>
-        ) : null}
-        <FormGroup label="Max Clusters" fieldId="tcp-max-clusters">
-          <NumberInput
-            id="tcp-max-clusters"
-            value={maxClusters}
-            min={0}
-            onMinus={() => setMaxClusters(Math.max(0, maxClusters - 1))}
-            onPlus={() => setMaxClusters(maxClusters + 1)}
-            onChange={(event: React.FormEvent<HTMLInputElement>) => {
-              const val = parseInt((event.target as HTMLInputElement).value, 10);
-              if (!isNaN(val) && val >= 0) setMaxClusters(val);
-            }}
-          />
-        </FormGroup>
-        <FormGroup label="Min Clusters" fieldId="tcp-min-clusters">
-          <NumberInput
-            id="tcp-min-clusters"
-            value={minClusters}
-            min={0}
-            onMinus={() => setMinClusters(Math.max(0, minClusters - 1))}
-            onPlus={() => setMinClusters(minClusters + 1)}
-            onChange={(event: React.FormEvent<HTMLInputElement>) => {
-              const val = parseInt((event.target as HTMLInputElement).value, 10);
-              if (!isNaN(val) && val >= 0) setMinClusters(val);
-            }}
-          />
-          {minClusters > maxClusters ? (
-            <HelperText>
-              <HelperTextItem variant="error">Min Clusters must be less than or equal to Max Clusters</HelperTextItem>
-            </HelperText>
-          ) : null}
-        </FormGroup>
-        <FormGroup label="Min Available Sandbox Placements" fieldId="tcp-min-placements">
-          <NumberInput
-            id="tcp-min-placements"
-            value={minAvailableSandboxPlacements}
-            min={0}
-            onMinus={() => setMinAvailableSandboxPlacements(Math.max(0, minAvailableSandboxPlacements - 1))}
-            onPlus={() => setMinAvailableSandboxPlacements(minAvailableSandboxPlacements + 1)}
-            onChange={(event: React.FormEvent<HTMLInputElement>) => {
-              const val = parseInt((event.target as HTMLInputElement).value, 10);
-              if (!isNaN(val) && val >= 0) setMinAvailableSandboxPlacements(val);
-            }}
-          />
-        </FormGroup>
-        {purposeOpts.length > 0 ? (
-          <ActivityPurposeSelector
-            purposeOpts={purposeOpts}
-            value={{ activity, purpose, explanation }}
-            onChange={(a, p, e) => {
-              if (a !== null) setActivity(a);
-              if (p !== null) setPurpose(p);
-              setExplanation(e || '');
-            }}
-          />
-        ) : null}
-        {sfdc_enabled ? (
-          <SalesforceItemsField
-            items={salesforceItems}
-            onChange={setSalesforceItems}
-          />
-        ) : null}
-        {dynamicParameters.map((param) => (
-          <FormGroup key={param.name} label={param.formLabel || param.name} fieldId={`tcp-param-${param.name}`} isRequired={param.required}>
-            <DynamicFormInput
-              id={`tcp-param-${param.name}`}
-              parameter={param}
-              value={parameterValues[param.name] ?? param.openAPIV3Schema?.default ?? param.value}
-              onChange={(value: unknown) => setParameterValues((prev) => ({ ...prev, [param.name]: value }))}
-            />
-          </FormGroup>
-        ))}
-      </Form>
-    </>
-  );
-};
-
 const TenantClusterPools: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const keywordFilter = useMemo(
@@ -314,12 +113,9 @@ const TenantClusterPools: React.FC = () => {
         : null,
     [searchParams.get('search')],
   );
-  const [createModal, openCreateModal] = useModal();
-  const [deleteModal, openDeleteModal] = useModal();
-  const [poolToDelete, setPoolToDelete] = useState<TenantClusterPool | null>(null);
   const [expandedPools, setExpandedPools] = useState<Set<string>>(new Set());
 
-  const { data: tenantClusterPools, mutate } = useSWR<TenantClusterPool[]>(
+  const { data: tenantClusterPools } = useSWR<TenantClusterPool[]>(
     apiPaths.TENANT_CLUSTER_POOLS({ limit: 'ALL' }),
     () =>
       fetcherItemsInAllPages((continueId) =>
@@ -356,56 +152,14 @@ const TenantClusterPools: React.FC = () => {
     });
   }, []);
 
-  const showDeleteModal = useCallback(
-    (pool: TenantClusterPool) => {
-      setPoolToDelete(pool);
-      openDeleteModal();
-    },
-    [openDeleteModal],
-  );
-
   return (
     <div className="admin-container">
-      <Modal
-        ref={createModal}
-        title="Create Tenant Cluster Pool"
-        onConfirm={() => {}}
-        passModifiers
-        confirmText="Create"
-      >
-        <CreateTenantClusterPoolForm
-          onCreated={(created) => {
-            mutate((prev) => [...(prev || []), created], false);
-          }}
-        />
-      </Modal>
-      <Modal
-        ref={deleteModal}
-        title={`Delete TenantClusterPool ${poolToDelete?.metadata.name}?`}
-        onConfirm={async () => {
-          if (!poolToDelete) return;
-          await deleteTenantClusterPool(poolToDelete);
-          mutate(
-            (prev) => (prev || []).filter((p) => p.metadata.uid !== poolToDelete.metadata.uid),
-            false,
-          );
-          setPoolToDelete(null);
-        }}
-        confirmText="Delete"
-      >
-        <p>This will permanently delete the TenantClusterPool and its managed clusters.</p>
-      </Modal>
       <PageSection hasBodyWrapper={false} key="header" className="admin-header">
         <Split hasGutter>
           <SplitItem isFilled>
             <Title headingLevel="h4" size="xl">
               Tenant Cluster Pools
             </Title>
-          </SplitItem>
-          <SplitItem>
-            <Button variant="primary" onClick={openCreateModal}>
-              Create Tenant Cluster Pool
-            </Button>
           </SplitItem>
           <SplitItem>
             <KeywordSearchInput
@@ -439,7 +193,6 @@ const TenantClusterPools: React.FC = () => {
                   <th>Placements</th>
                   <th>Sandbox API State</th>
                   <th>Created At</th>
-                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -449,7 +202,6 @@ const TenantClusterPools: React.FC = () => {
                   const clusters = pool.status?.clusters || [];
                   const clusterCount = clusters.length;
                   const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
-                  const canDelete = clusterCount === 0 || clusters.every((c) => c.sandboxApiState === 'removed' || c.sandboxApiState === 'pending');
 
                   return (
                     <React.Fragment key={poolKey}>
@@ -480,34 +232,6 @@ const TenantClusterPools: React.FC = () => {
                         <td></td>
                         <td>
                           <TimeInterval toTimestamp={pool.metadata.creationTimestamp} />
-                        </td>
-                        <td>
-                          {canDelete ? (
-                            <Button
-                              variant="plain"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                showDeleteModal(pool);
-                              }}
-                              aria-label={`Delete ${pool.metadata.name}`}
-                            >
-                              <TrashIcon />
-                            </Button>
-                          ) : (
-                            <Tooltip content="All clusters must be removed before the pool can be deleted">
-                              <span>
-                                <Button
-                                  variant="plain"
-                                  size="sm"
-                                  isDisabled
-                                  aria-label={`Delete ${pool.metadata.name}`}
-                                >
-                                  <TrashIcon />
-                                </Button>
-                              </span>
-                            </Tooltip>
-                          )}
                         </td>
                       </tr>
                       {isExpanded

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -520,10 +520,6 @@ export async function createResourcePool(definition: ResourcePool) {
   return await createK8sObject<ResourcePool>(definition);
 }
 
-export async function createTenantClusterPool(definition: TenantClusterPool) {
-  return await createK8sObject<TenantClusterPool>(definition);
-}
-
 export async function createResourcePoolScaling(definition: ResourcePoolScaling) {
   return await createK8sObject<ResourcePoolScaling>(definition);
 }
@@ -1191,16 +1187,6 @@ export async function deleteResourceProvider(resourceProvider: ResourceProvider)
     resourceProvider.metadata.namespace,
     'resourcehandles',
     resourceProvider.metadata.name,
-  );
-}
-
-export async function deleteTenantClusterPool(tenantClusterPool: TenantClusterPool) {
-  return await deleteNamespacedCustomObject(
-    BABYLON_DOMAIN,
-    'v1',
-    tenantClusterPool.metadata.namespace,
-    'tenantclusterpools',
-    tenantClusterPool.metadata.name,
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove the "Create Tenant Cluster Pool" button, form, and modal from the list page
- Remove the trash/delete icons and "Actions" column from the list page table
- Remove the "Delete TenantClusterPool" action from the detail page action dropdown
- Clean up all unused imports related to create/delete functionality

## Test plan
- [ ] Navigate to `/admin/tenantclusterpools` and verify no "Create" button appears
- [ ] Verify the list table no longer shows an "Actions" column or trash icons
- [ ] Navigate to a TenantClusterPool detail page and verify the action dropdown no longer has a "Delete" option
- [ ] Verify "Edit in OpenShift Console" and "Open in OpenShift Console" actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)