### PR TITLE
Improve audit trail logging for Sumo Logic dashboard integration

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -18,6 +18,7 @@ import kubernetes_asyncio
 import redis.asyncio as redis
 from hotfix import HotfixKubeApiClient
 from randomstring import random_string
+from audit import audit_log, audit_log_api_action
 
 app_api_client = core_v1_api = custom_objects_api = None
 console_url = None
@@ -40,24 +41,6 @@ session_cache = {}
 session_lifetime = int(os.environ.get('SESSION_LIFETIME', 600))
 
 logging.basicConfig(level=os.environ.get('LOGGING_LEVEL', 'INFO'))
-
-audit_logger = logging.getLogger('audit')
-
-def audit_log(event, user, method=None, path=None, status=None, effective_user=None, body=None, **extra):
-    parts = [datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'), event, f"user={user}"]
-    if effective_user and effective_user != user:
-        parts.append(f"effective_user={effective_user}")
-    if method:
-        parts.append(f"method={method}")
-    if path:
-        parts.append(f"path={path}")
-    if status is not None:
-        parts.append(f"status={status}")
-    if body is not None:
-        parts.append(f"body={json.dumps(body, separators=(',', ':'))}")
-    for k, v in extra.items():
-        parts.append(f"{k}={v}")
-    audit_logger.info(' '.join(parts))
 
 def proxy_api_client(session):
     api_client = HotfixKubeApiClient()
@@ -426,7 +409,7 @@ async def get_auth_session(request):
         if interface_name:
             ret['interface'] = interface_name
 
-        audit_log('session_created', user=user['metadata']['name'], admin=user_is_admin)
+        audit_log('session_created', user=user['metadata']['name'], details={'admin': user_is_admin})
         return web.json_response(ret)
     finally:
         await api_client.close()
@@ -1514,7 +1497,7 @@ async def update_system_status(request):
             else:
                 raise
 
-        audit_log('system_status_updated', user=user['metadata']['name'], data=data)
+        audit_log('system_status_updated', user=user['metadata']['name'], details=data)
 
         # Return updated status
         return web.json_response(await get_system_status_from_configmap())
@@ -1678,8 +1661,7 @@ async def openshift_api_proxy(request, api_client=None):
         headers['Content-Type'] = 'application/json'
 
         if request.method != 'GET':
-            audit_log(
-                'api_action',
+            audit_log_api_action(
                 user=session['user'],
                 effective_user=api_client.default_headers.get('Impersonate-User'),
                 method=request.method,
@@ -1695,8 +1677,7 @@ async def openshift_api_proxy(request, api_client=None):
         )
     except kubernetes_asyncio.client.exceptions.ApiException as exception:
         if request.method != 'GET':
-            audit_log(
-                'api_action',
+            audit_log_api_action(
                 user=session['user'],
                 effective_user=api_client.default_headers.get('Impersonate-User'),
                 method=request.method,

--- a/catalog/api/audit.py
+++ b/catalog/api/audit.py
@@ -1,0 +1,431 @@
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+audit_logger = logging.getLogger('audit')
+
+RESOURCE_DISPLAY_NAMES = {
+    'resourceclaims': 'ResourceClaim',
+    'workshops': 'Workshop',
+    'workshopprovisions': 'WorkshopProvision',
+    'workshopuserassignments': 'WorkshopUserAssignment',
+    'selfpacedlabs': 'SelfPacedLab',
+    'selfpacedlabprovisionitems': 'SelfPacedLabProvisionItem',
+    'selfpacedlabuserassignments': 'SelfPacedLabUserAssignment',
+    'multiworkshops': 'MultiWorkshop',
+    'resourcehandles': 'ResourceHandle',
+    'resourcepools': 'ResourcePool',
+    'resourcepoolscalings': 'ResourcePoolScaling',
+    'resourceproviders': 'ResourceProvider',
+    'serviceaccessconfigs': 'ServiceAccessConfig',
+    'anarchysubjects': 'AnarchySubject',
+    'anarchyactions': 'AnarchyAction',
+    'anarchyruns': 'AnarchyRun',
+    'anarchygovernors': 'AnarchyGovernor',
+    'tenantclusterpools': 'TenantClusterPool',
+    'configmaps': 'ConfigMap',
+}
+
+ACTION_MAP = {
+    ('resourceclaims', 'POST'): 'order_service',
+    ('resourceclaims', 'DELETE'): 'delete_service',
+    ('workshops', 'POST'): 'create_workshop',
+    ('workshops', 'DELETE'): 'delete_workshop',
+    ('workshopprovisions', 'POST'): 'provision_workshop_instances',
+    ('workshopuserassignments', 'PUT'): 'update_user_assignment',
+    ('selfpacedlabs', 'POST'): 'create_self_paced_lab',
+    ('selfpacedlabs', 'DELETE'): 'delete_self_paced_lab',
+    ('selfpacedlabprovisionitems', 'POST'): 'provision_lab_items',
+    ('selfpacedlabuserassignments', 'PUT'): 'update_user_assignment',
+    ('multiworkshops', 'POST'): 'create_multi_workshop',
+    ('multiworkshops', 'DELETE'): 'delete_multi_workshop',
+    ('resourcehandles', 'DELETE'): 'delete_resource_handle',
+    ('resourcepools', 'POST'): 'create_resource_pool',
+    ('resourcepools', 'DELETE'): 'delete_resource_pool',
+    ('resourcepoolscalings', 'POST'): 'create_resource_pool_scaling',
+    ('resourcepoolscalings', 'DELETE'): 'delete_resource_pool_scaling',
+    ('resourceproviders', 'DELETE'): 'delete_resource_provider',
+    ('serviceaccessconfigs', 'POST'): 'share_service',
+    ('serviceaccessconfigs', 'PUT'): 'update_collaborators',
+    ('serviceaccessconfigs', 'DELETE'): 'remove_sharing',
+    ('anarchysubjects', 'DELETE'): 'delete_anarchy_subject',
+    ('anarchyactions', 'DELETE'): 'delete_anarchy_action',
+    ('anarchyruns', 'DELETE'): 'delete_anarchy_run',
+    ('anarchygovernors', 'DELETE'): 'delete_anarchy_governor',
+    ('tenantclusterpools', 'POST'): 'create_tenant_cluster_pool',
+    ('tenantclusterpools', 'DELETE'): 'delete_tenant_cluster_pool',
+}
+
+_K8S_PATH_RE = re.compile(
+    r'^/apis/(?P<api_group>[^/]+)/(?P<version>[^/]+)'
+    r'(?:/namespaces/(?P<namespace>[^/]+))?'
+    r'/(?P<plural>[^/]+)'
+    r'(?:/(?P<name>[^/?]+))?'
+)
+_K8S_CORE_PATH_RE = re.compile(
+    r'^/api/(?P<version>[^/]+)'
+    r'(?:/namespaces/(?P<namespace>[^/]+))?'
+    r'/(?P<plural>[^/]+)'
+    r'(?:/(?P<name>[^/?]+))?'
+)
+
+
+def parse_k8s_path(path):
+    """Parse a Kubernetes API path into its components. Returns None on failure."""
+    try:
+        m = _K8S_PATH_RE.match(path)
+        if m:
+            return {
+                'api_group': m.group('api_group'),
+                'version': m.group('version'),
+                'namespace': m.group('namespace'),
+                'plural': m.group('plural'),
+                'name': m.group('name'),
+            }
+        m = _K8S_CORE_PATH_RE.match(path)
+        if m:
+            return {
+                'api_group': '',
+                'version': m.group('version'),
+                'namespace': m.group('namespace'),
+                'plural': m.group('plural'),
+                'name': m.group('name'),
+            }
+    except Exception:
+        pass
+    return None
+
+
+def _safe_get(obj, *keys):
+    """Safely traverse nested dicts. Returns None if any key is missing."""
+    for key in keys:
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(key)
+    return obj
+
+
+def _classify_resourceclaim_patch(body):
+    if not isinstance(body, dict):
+        return 'update_service'
+    param_values = _safe_get(body, 'spec', 'provider', 'parameterValues') or {}
+    if _safe_get(body, 'spec', 'lifespan', 'end'):
+        return 'retire_service'
+    if param_values.get('start_timestamp'):
+        return 'start_service'
+    if param_values.get('stop_timestamp'):
+        return 'stop_service'
+    # Legacy per-resource action_schedule
+    for resource in (_safe_get(body, 'spec', 'resources') or []):
+        schedule = _safe_get(resource, 'template', 'spec', 'vars', 'action_schedule') or {}
+        if schedule.get('start'):
+            return 'start_service'
+        if schedule.get('stop'):
+            return 'stop_service'
+        if _safe_get(resource, 'template', 'spec', 'vars', 'check_status_request_timestamp'):
+            return 'request_status'
+    tenant_action = _safe_get(body, 'metadata', 'annotations', 'babylon.gpte.redhat.com/tenant-cluster-action')
+    if tenant_action is not None:
+        return 'tenant_cluster_action'
+    return 'update_service'
+
+
+def _classify_workshop_patch(body):
+    if not isinstance(body, dict):
+        return 'update_workshop'
+    lock_label = _safe_get(body, 'metadata', 'labels', 'demo.redhat.com/lock-enabled')
+    if lock_label == 'true':
+        return 'lock_workshop'
+    if lock_label == 'false':
+        return 'unlock_workshop'
+    action_schedule = _safe_get(body, 'spec', 'actionSchedule') or {}
+    if action_schedule.get('start'):
+        return 'start_workshop'
+    if action_schedule.get('stop'):
+        return 'stop_workshop'
+    if _safe_get(body, 'spec', 'lifespan', 'end'):
+        return 'retire_workshop'
+    spec = body.get('spec') or {}
+    if any(k in spec for k in ('displayName', 'description', 'accessPassword', 'openRegistration', 'labUserInterface')):
+        return 'edit_workshop'
+    return 'update_workshop'
+
+
+def _classify_json_patch(plural, operations):
+    """Classify action from a JSON Patch array."""
+    user_assignment_plurals = ('workshopuserassignments', 'selfpacedlabuserassignments')
+    for op in operations:
+        if not isinstance(op, dict):
+            continue
+        patch_op = op.get('op', '')
+        patch_path = op.get('path', '')
+        if plural in user_assignment_plurals and '/spec/assignment' in patch_path:
+            if patch_op in ('add', 'replace'):
+                return 'assign_user'
+            if patch_op == 'remove':
+                return 'unassign_user'
+    return None
+
+
+def classify_action(method, plural, body):
+    """Map (method, K8s plural resource name, body) to a human-readable action string."""
+    try:
+        # JSON Patch bodies are arrays
+        if isinstance(body, list):
+            action = _classify_json_patch(plural, body)
+            if action:
+                return action
+            return ACTION_MAP.get((plural, method), f'patch_{plural}')
+
+        if method in ('POST', 'DELETE'):
+            return ACTION_MAP.get((plural, method), f'{method.lower()}_{plural}')
+
+        if method == 'PUT':
+            return ACTION_MAP.get((plural, method), f'update_{plural}')
+
+        if method == 'PATCH':
+            if plural == 'resourceclaims':
+                return _classify_resourceclaim_patch(body)
+            if plural == 'workshops':
+                return _classify_workshop_patch(body)
+            if plural == 'selfpacedlabs':
+                spec = (_safe_get(body, 'spec') or {}) if isinstance(body, dict) else {}
+                if _safe_get(body, 'spec', 'lifespan', 'end'):
+                    return 'retire_self_paced_lab'
+                if any(k in spec for k in ('displayName', 'description', 'accessPassword', 'openRegistration')):
+                    return 'edit_self_paced_lab'
+                return 'update_self_paced_lab'
+            if plural == 'workshopprovisions':
+                if _safe_get(body, 'spec', 'count') is not None:
+                    return 'scale_workshop'
+                return 'update_workshop_provision'
+            if plural == 'selfpacedlabprovisionitems':
+                if _safe_get(body, 'spec', 'count') is not None:
+                    return 'scale_lab_items'
+                return 'update_lab_provision_item'
+            if plural == 'multiworkshops':
+                return 'edit_multi_workshop'
+            if plural == 'resourcehandles':
+                if _safe_get(body, 'spec', 'lifespan') is not None:
+                    return 'extend_lifespan'
+                return 'update_resource_handle'
+            if plural == 'anarchysubjects':
+                if isinstance(body, dict) and body.get('metadata', {}).get('finalizers') is None and 'metadata' in body:
+                    return 'force_delete_anarchy_subject'
+                return 'update_anarchy_subject'
+            if plural == 'anarchyruns':
+                runner = _safe_get(body, 'metadata', 'labels', 'anarchy.gpte.redhat.com/runner')
+                if runner == 'pending':
+                    return 'retry_anarchy_run'
+                return 'update_anarchy_run'
+            return f'update_{plural}'
+
+        return f'{method.lower()}_{plural}'
+    except Exception:
+        return 'unknown'
+
+
+def extract_details(action, body):
+    """Extract only known-safe fields from the body for the given action. Never logs raw body."""
+    try:
+        if not isinstance(body, dict) and not isinstance(body, list):
+            return {}
+
+        if action == 'start_service':
+            raw_pv = _safe_get(body, 'spec', 'provider', 'parameterValues')
+            param_values = raw_pv if isinstance(raw_pv, dict) else {}
+            details = {}
+            if param_values.get('start_timestamp'):
+                details['start_timestamp'] = param_values['start_timestamp']
+            if param_values.get('stop_timestamp'):
+                details['stop_timestamp'] = param_values['stop_timestamp']
+            return details
+
+        if action == 'stop_service':
+            raw_pv = _safe_get(body, 'spec', 'provider', 'parameterValues')
+            param_values = raw_pv if isinstance(raw_pv, dict) else {}
+            details = {}
+            if param_values.get('stop_timestamp'):
+                details['stop_timestamp'] = param_values['stop_timestamp']
+            return details
+
+        if action == 'retire_service':
+            details = {}
+            end = _safe_get(body, 'spec', 'lifespan', 'end')
+            if end:
+                details['lifespan_end'] = end
+            return details
+
+        if action == 'order_service':
+            details = {}
+            name = _safe_get(body, 'metadata', 'name')
+            if name:
+                details['resource_name'] = name
+            display_name = _safe_get(body, 'metadata', 'annotations', 'babylon.gpte.redhat.com/catalogItemDisplayName')
+            if display_name:
+                details['catalog_item_display_name'] = display_name
+            return details
+
+        if action == 'start_workshop':
+            details = {}
+            start = _safe_get(body, 'spec', 'actionSchedule', 'start')
+            stop = _safe_get(body, 'spec', 'actionSchedule', 'stop')
+            lifespan_end = _safe_get(body, 'spec', 'lifespan', 'end')
+            if start:
+                details['start'] = start
+            if stop:
+                details['stop'] = stop
+            if lifespan_end:
+                details['lifespan_end'] = lifespan_end
+            return details
+
+        if action == 'stop_workshop':
+            details = {}
+            stop = _safe_get(body, 'spec', 'actionSchedule', 'stop')
+            if stop:
+                details['stop'] = stop
+            return details
+
+        if action in ('retire_workshop', 'retire_self_paced_lab', 'retire_service'):
+            details = {}
+            end = _safe_get(body, 'spec', 'lifespan', 'end')
+            if end:
+                details['lifespan_end'] = end
+            return details
+
+        if action == 'edit_workshop':
+            spec = (_safe_get(body, 'spec') or {}) if isinstance(body, dict) else {}
+            changed = [k for k in ('displayName', 'description', 'openRegistration', 'labUserInterface') if k in spec]
+            return {'fields_changed': changed} if changed else {}
+
+        if action == 'scale_workshop':
+            count = _safe_get(body, 'spec', 'count')
+            return {'count': count} if count is not None else {}
+
+        if action == 'scale_lab_items':
+            count = _safe_get(body, 'spec', 'count')
+            return {'count': count} if count is not None else {}
+
+        if action in ('assign_user', 'unassign_user'):
+            # JSON Patch — extract email from value field of assignment op
+            if isinstance(body, list):
+                for op in body:
+                    if isinstance(op, dict) and op.get('op') in ('add', 'replace'):
+                        value = op.get('value') or {}
+                        email = value.get('email') if isinstance(value, dict) else None
+                        if email:
+                            return {'email': email}
+            return {}
+
+        if action == 'extend_lifespan':
+            raw_ls = _safe_get(body, 'spec', 'lifespan')
+            lifespan = raw_ls if isinstance(raw_ls, dict) else {}
+            details = {}
+            if lifespan.get('maximum'):
+                details['maximum'] = lifespan['maximum']
+            if lifespan.get('relativeMaximum'):
+                details['relative_maximum'] = lifespan['relativeMaximum']
+            return details
+
+        if action == 'tenant_cluster_action':
+            raw = _safe_get(body, 'metadata', 'annotations', 'babylon.gpte.redhat.com/tenant-cluster-action')
+            if isinstance(raw, str):
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict) and parsed.get('action'):
+                        return {'cluster_action': parsed['action']}
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            return {}
+
+        if action in ('create_workshop', 'create_self_paced_lab', 'create_multi_workshop',
+                      'provision_workshop_instances', 'provision_lab_items'):
+            details = {}
+            name = _safe_get(body, 'metadata', 'name')
+            if name:
+                details['resource_name'] = name
+            display_name = _safe_get(body, 'spec', 'displayName')
+            if display_name:
+                details['display_name'] = display_name
+            return details
+
+        if action == 'share_service':
+            raw_users = _safe_get(body, 'spec', 'users')
+            users = raw_users if isinstance(raw_users, list) else []
+            emails = [u['name'] for u in users if isinstance(u, dict) and u.get('name')]
+            return {'users': emails} if emails else {}
+
+        return {}
+    except Exception:
+        return {}
+
+
+def audit_log(event, user, effective_user=None, action=None, resource_type=None,
+              resource_name=None, namespace=None, status=None, details=None, **extra):
+    record = {
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'event': event,
+        'user': user,
+    }
+    if effective_user and effective_user != user:
+        record['effective_user'] = effective_user
+    if action:
+        record['action'] = action
+    if resource_type:
+        record['resource_type'] = resource_type
+    if resource_name:
+        record['resource_name'] = resource_name
+    if namespace:
+        record['namespace'] = namespace
+    if status is not None:
+        record['status'] = status
+    if details:
+        record['details'] = details
+    for k, v in extra.items():
+        record[k] = v
+    audit_logger.info(json.dumps(record, separators=(',', ':')))
+
+
+def audit_log_api_action(user, effective_user, method, path, status, body):
+    """Parse K8s path and body to emit a structured audit log entry. Never raises."""
+    try:
+        parsed = parse_k8s_path(path)
+        if parsed:
+            plural = parsed['plural']
+            action = classify_action(method, plural, body)
+            details = extract_details(action, body)
+            audit_log(
+                'api_action',
+                user=user,
+                effective_user=effective_user,
+                action=action,
+                resource_type=RESOURCE_DISPLAY_NAMES.get(plural, plural),
+                resource_name=parsed.get('name'),
+                namespace=parsed.get('namespace'),
+                status=status,
+                details=details or None,
+            )
+        else:
+            # Non-K8s path — log minimally without body
+            audit_log(
+                'api_action',
+                user=user,
+                effective_user=effective_user,
+                action=f'{method.lower()}_request',
+                status=status,
+                details={'path': path},
+            )
+    except Exception as exc:
+        logging.getLogger(__name__).warning('audit_log_api_action failed: %s', exc)
+        try:
+            audit_log(
+                'api_action',
+                user=user,
+                effective_user=effective_user,
+                action='unknown',
+                status=status,
+                details={'path': path, 'method': method},
+            )
+        except Exception:
+            pass

--- a/catalog/api/audit.py
+++ b/catalog/api/audit.py
@@ -93,7 +93,7 @@ def parse_k8s_path(path):
                 'name': m.group('name'),
             }
     except Exception:
-        pass
+        pass  # graceful fallback: return None so caller logs without path details
     return None
 
 
@@ -230,7 +230,7 @@ def classify_action(method, plural, body):
 
         return f'{method.lower()}_{plural}'
     except Exception:
-        return 'unknown'
+        return 'unknown'  # body format unrecognized; log the event with generic action
 
 
 def extract_details(action, body):
@@ -365,7 +365,7 @@ def extract_details(action, body):
 
         return {}
     except Exception:
-        return {}
+        return {}  # body format unrecognized; log the event without details
 
 
 def audit_log(event, user, effective_user=None, action=None, resource_type=None,
@@ -437,4 +437,4 @@ def audit_log_api_action(user, effective_user, method, path, status, body):
                 details={'path': path, 'method': method},
             )
         except Exception:
-            pass
+            pass  # last-resort fallback: silently drop rather than crash the request

--- a/catalog/api/audit.py
+++ b/catalog/api/audit.py
@@ -109,7 +109,8 @@ def _safe_get(obj, *keys):
 def _classify_resourceclaim_patch(body):
     if not isinstance(body, dict):
         return 'update_service'
-    param_values = _safe_get(body, 'spec', 'provider', 'parameterValues') or {}
+    raw_pv = _safe_get(body, 'spec', 'provider', 'parameterValues')
+    param_values = raw_pv if isinstance(raw_pv, dict) else {}
     if _safe_get(body, 'spec', 'lifespan', 'end'):
         return 'retire_service'
     if param_values.get('start_timestamp'):
@@ -117,8 +118,13 @@ def _classify_resourceclaim_patch(body):
     if param_values.get('stop_timestamp'):
         return 'stop_service'
     # Legacy per-resource action_schedule
-    for resource in (_safe_get(body, 'spec', 'resources') or []):
-        schedule = _safe_get(resource, 'template', 'spec', 'vars', 'action_schedule') or {}
+    raw_resources = _safe_get(body, 'spec', 'resources')
+    resources = raw_resources if isinstance(raw_resources, list) else []
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        raw_schedule = _safe_get(resource, 'template', 'spec', 'vars', 'action_schedule')
+        schedule = raw_schedule if isinstance(raw_schedule, dict) else {}
         if schedule.get('start'):
             return 'start_service'
         if schedule.get('stop'):
@@ -139,7 +145,8 @@ def _classify_workshop_patch(body):
         return 'lock_workshop'
     if lock_label == 'false':
         return 'unlock_workshop'
-    action_schedule = _safe_get(body, 'spec', 'actionSchedule') or {}
+    raw_schedule = _safe_get(body, 'spec', 'actionSchedule')
+    action_schedule = raw_schedule if isinstance(raw_schedule, dict) else {}
     if action_schedule.get('start'):
         return 'start_workshop'
     if action_schedule.get('stop'):
@@ -363,28 +370,31 @@ def extract_details(action, body):
 
 def audit_log(event, user, effective_user=None, action=None, resource_type=None,
               resource_name=None, namespace=None, status=None, details=None, **extra):
-    record = {
-        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-        'event': event,
-        'user': user,
-    }
-    if effective_user and effective_user != user:
-        record['effective_user'] = effective_user
-    if action:
-        record['action'] = action
-    if resource_type:
-        record['resource_type'] = resource_type
-    if resource_name:
-        record['resource_name'] = resource_name
-    if namespace:
-        record['namespace'] = namespace
-    if status is not None:
-        record['status'] = status
-    if details:
-        record['details'] = details
-    for k, v in extra.items():
-        record[k] = v
-    audit_logger.info(json.dumps(record, separators=(',', ':')))
+    try:
+        record = {
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'event': event,
+            'user': user,
+        }
+        if effective_user and effective_user != user:
+            record['effective_user'] = effective_user
+        if action:
+            record['action'] = action
+        if resource_type:
+            record['resource_type'] = resource_type
+        if resource_name:
+            record['resource_name'] = resource_name
+        if namespace:
+            record['namespace'] = namespace
+        if status is not None:
+            record['status'] = status
+        if details:
+            record['details'] = details
+        for k, v in extra.items():
+            record[k] = v
+        audit_logger.info(json.dumps(record, separators=(',', ':')))
+    except Exception as exc:
+        logging.getLogger(__name__).warning('audit_log failed: %s', exc)
 
 
 def audit_log_api_action(user, effective_user, method, path, status, body):
@@ -407,12 +417,11 @@ def audit_log_api_action(user, effective_user, method, path, status, body):
                 details=details or None,
             )
         else:
-            # Non-K8s path — log minimally without body
             audit_log(
                 'api_action',
                 user=user,
                 effective_user=effective_user,
-                action=f'{method.lower()}_request',
+                action=f'{str(method).lower()}_request',
                 status=status,
                 details={'path': path},
             )

--- a/catalog/api/audit.py
+++ b/catalog/api/audit.py
@@ -343,7 +343,7 @@ def extract_details(action, body):
                     if isinstance(parsed, dict) and parsed.get('action'):
                         return {'cluster_action': parsed['action']}
                 except (json.JSONDecodeError, TypeError):
-                    pass
+                    pass  # annotation value is not valid JSON; log without details
             return {}
 
         if action in ('create_workshop', 'create_self_paced_lab', 'create_multi_workshop',

--- a/catalog/api/test_audit.py
+++ b/catalog/api/test_audit.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 sys.path.insert(0, '.')
+import audit as audit_mod
 from audit import (
     parse_k8s_path,
     classify_action,
@@ -334,7 +335,7 @@ class TestExtractDetails(unittest.TestCase):
 class TestAuditLog(unittest.TestCase):
 
     def _capture_log(self, *args, **kwargs):
-        with patch.object(__import__('audit').audit_logger, 'info') as mock_info:
+        with patch.object(audit_mod.audit_logger, 'info') as mock_info:
             audit_log(*args, **kwargs)
             self.assertTrue(mock_info.called)
             return json.loads(mock_info.call_args[0][0])
@@ -361,7 +362,7 @@ class TestAuditLog(unittest.TestCase):
         self.assertEqual(record['effective_user'], 'alice')
 
     def test_output_is_valid_json(self):
-        with patch.object(__import__('audit').audit_logger, 'info') as mock_info:
+        with patch.object(audit_mod.audit_logger, 'info') as mock_info:
             audit_log('test_event', user='alice')
             line = mock_info.call_args[0][0]
             parsed = json.loads(line)
@@ -388,7 +389,6 @@ class TestAuditLogApiAction(unittest.TestCase):
 
     def _run(self, method, path, body, status=200, user='alice', effective_user=None):
         captured = []
-        import audit as audit_mod
         with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
             audit_log_api_action(
                 user=user,
@@ -499,10 +499,9 @@ class TestAuditLogApiAction(unittest.TestCase):
 
     def test_none_method_does_not_crash(self):
         captured = []
-        import audit as audit_mod
         with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
             audit_log_api_action(user='alice', effective_user=None, method=None, path='/apis/x/v1/y/z', status=200, body=None)
-        self.assertTrue(len(captured) >= 1)
+        self.assertGreaterEqual(len(captured), 1)
         record = json.loads(captured[0])
         self.assertIn('event', record)
 

--- a/catalog/api/test_audit.py
+++ b/catalog/api/test_audit.py
@@ -1,0 +1,413 @@
+import json
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, '.')
+from audit import (
+    parse_k8s_path,
+    classify_action,
+    extract_details,
+    audit_log,
+    audit_log_api_action,
+)
+
+
+class TestParseK8sPath(unittest.TestCase):
+
+    def test_namespaced_with_name(self):
+        r = parse_k8s_path('/apis/poolboy.gpte.redhat.com/v1/namespaces/user-alice/resourceclaims/my-claim')
+        self.assertIsNotNone(r)
+        assert r is not None
+        self.assertEqual(r['api_group'], 'poolboy.gpte.redhat.com')
+        self.assertEqual(r['version'], 'v1')
+        self.assertEqual(r['namespace'], 'user-alice')
+        self.assertEqual(r['plural'], 'resourceclaims')
+        self.assertEqual(r['name'], 'my-claim')
+
+    def test_namespaced_collection(self):
+        r = parse_k8s_path('/apis/babylon.gpte.redhat.com/v1/namespaces/user-alice/workshops')
+        self.assertIsNotNone(r)
+        assert r is not None
+        self.assertEqual(r['plural'], 'workshops')
+        self.assertIsNone(r['name'])
+        self.assertEqual(r['namespace'], 'user-alice')
+
+    def test_non_namespaced_with_name(self):
+        r = parse_k8s_path('/apis/poolboy.gpte.redhat.com/v1/resourcepools/my-pool')
+        self.assertIsNotNone(r)
+        assert r is not None
+        self.assertEqual(r['plural'], 'resourcepools')
+        self.assertEqual(r['name'], 'my-pool')
+        self.assertIsNone(r['namespace'])
+
+    def test_core_api(self):
+        r = parse_k8s_path('/api/v1/namespaces/default/configmaps/my-cm')
+        self.assertIsNotNone(r)
+        assert r is not None
+        self.assertEqual(r['api_group'], '')
+        self.assertEqual(r['version'], 'v1')
+        self.assertEqual(r['namespace'], 'default')
+        self.assertEqual(r['plural'], 'configmaps')
+        self.assertEqual(r['name'], 'my-cm')
+
+    def test_invalid_path_returns_none(self):
+        self.assertIsNone(parse_k8s_path('/foo/bar'))
+
+    def test_empty_path_returns_none(self):
+        self.assertIsNone(parse_k8s_path(''))
+
+    def test_path_with_query_string(self):
+        r = parse_k8s_path('/apis/poolboy.gpte.redhat.com/v1/namespaces/user-alice/resourceclaims/my-claim')
+        self.assertIsNotNone(r)
+
+
+class TestClassifyAction(unittest.TestCase):
+
+    # --- POST ---
+    def test_post_resourceclaim(self):
+        self.assertEqual(classify_action('POST', 'resourceclaims', {}), 'order_service')
+
+    def test_post_workshop(self):
+        self.assertEqual(classify_action('POST', 'workshops', {}), 'create_workshop')
+
+    def test_post_selfpacedlab(self):
+        self.assertEqual(classify_action('POST', 'selfpacedlabs', {}), 'create_self_paced_lab')
+
+    def test_post_multiworkshop(self):
+        self.assertEqual(classify_action('POST', 'multiworkshops', {}), 'create_multi_workshop')
+
+    # --- DELETE ---
+    def test_delete_resourceclaim(self):
+        self.assertEqual(classify_action('DELETE', 'resourceclaims', None), 'delete_service')
+
+    def test_delete_workshop(self):
+        self.assertEqual(classify_action('DELETE', 'workshops', None), 'delete_workshop')
+
+    def test_delete_selfpacedlab(self):
+        self.assertEqual(classify_action('DELETE', 'selfpacedlabs', None), 'delete_self_paced_lab')
+
+    # --- PATCH resourceclaims ---
+    def test_patch_resourceclaim_start(self):
+        body = {'spec': {'provider': {'parameterValues': {'start_timestamp': '2024-01-01T00:00:00Z', 'stop_timestamp': '2024-01-01T04:00:00Z'}}}}
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', body), 'start_service')
+
+    def test_patch_resourceclaim_stop(self):
+        body = {'spec': {'provider': {'parameterValues': {'stop_timestamp': '2024-01-01T00:00:00Z'}}}}
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', body), 'stop_service')
+
+    def test_patch_resourceclaim_retire(self):
+        body = {'spec': {'lifespan': {'end': '2024-01-05T00:00:00Z'}}}
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', body), 'retire_service')
+
+    def test_patch_resourceclaim_tenant_cluster_action(self):
+        body = {'metadata': {'annotations': {'babylon.gpte.redhat.com/tenant-cluster-action': '{"action":"reboot"}'}}}
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', body), 'tenant_cluster_action')
+
+    def test_patch_resourceclaim_unknown(self):
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', {}), 'update_service')
+
+    # --- PATCH workshops ---
+    def test_patch_workshop_start(self):
+        body = {'spec': {'actionSchedule': {'start': '2024-01-01T10:00:00Z', 'stop': '2024-01-01T18:00:00Z'}}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'start_workshop')
+
+    def test_patch_workshop_stop(self):
+        body = {'spec': {'actionSchedule': {'stop': '2024-01-01T18:00:00Z'}}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'stop_workshop')
+
+    def test_patch_workshop_retire(self):
+        body = {'spec': {'lifespan': {'end': '2024-01-05T00:00:00Z'}}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'retire_workshop')
+
+    def test_patch_workshop_lock(self):
+        body = {'metadata': {'labels': {'demo.redhat.com/lock-enabled': 'true'}}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'lock_workshop')
+
+    def test_patch_workshop_unlock(self):
+        body = {'metadata': {'labels': {'demo.redhat.com/lock-enabled': 'false'}}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'unlock_workshop')
+
+    def test_patch_workshop_edit_displayname(self):
+        body = {'spec': {'displayName': 'New Name'}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'edit_workshop')
+
+    def test_patch_workshop_edit_description(self):
+        body = {'spec': {'description': 'New description'}}
+        self.assertEqual(classify_action('PATCH', 'workshops', body), 'edit_workshop')
+
+    # --- PATCH workshopprovisions ---
+    def test_patch_workshopprovision_scale(self):
+        body = {'spec': {'count': 25}}
+        self.assertEqual(classify_action('PATCH', 'workshopprovisions', body), 'scale_workshop')
+
+    def test_patch_workshopprovision_unknown(self):
+        self.assertEqual(classify_action('PATCH', 'workshopprovisions', {}), 'update_workshop_provision')
+
+    # --- PATCH anarchysubjects ---
+    def test_patch_anarchysubject_force_delete(self):
+        body = {'metadata': {'finalizers': None}}
+        self.assertEqual(classify_action('PATCH', 'anarchysubjects', body), 'force_delete_anarchy_subject')
+
+    # --- PATCH anarchyruns ---
+    def test_patch_anarchyrun_retry(self):
+        body = {'metadata': {'labels': {'anarchy.gpte.redhat.com/runner': 'pending'}}}
+        self.assertEqual(classify_action('PATCH', 'anarchyruns', body), 'retry_anarchy_run')
+
+    # --- PATCH resourcehandles ---
+    def test_patch_resourcehandle_extend_lifespan(self):
+        body = {'spec': {'lifespan': {'maximum': '30d', 'relativeMaximum': '14d'}}}
+        self.assertEqual(classify_action('PATCH', 'resourcehandles', body), 'extend_lifespan')
+
+    # --- JSON Patch (arrays) ---
+    def test_json_patch_assign_user(self):
+        body = [
+            {'op': 'test', 'path': '/spec/resourceClaimName', 'value': 'my-claim'},
+            {'op': 'add', 'path': '/spec/assignment', 'value': {'email': 'user@example.com'}},
+        ]
+        self.assertEqual(classify_action('PATCH', 'workshopuserassignments', body), 'assign_user')
+
+    def test_json_patch_unassign_user(self):
+        body = [{'op': 'remove', 'path': '/spec/assignment'}]
+        self.assertEqual(classify_action('PATCH', 'workshopuserassignments', body), 'unassign_user')
+
+    def test_json_patch_selfpaced_assign_user(self):
+        body = [{'op': 'add', 'path': '/spec/assignment', 'value': {'email': 'user@example.com'}}]
+        self.assertEqual(classify_action('PATCH', 'selfpacedlabuserassignments', body), 'assign_user')
+
+    # --- Fault tolerance ---
+    def test_none_body_post(self):
+        self.assertEqual(classify_action('POST', 'workshops', None), 'create_workshop')
+
+    def test_none_body_patch_resourceclaim(self):
+        self.assertEqual(classify_action('PATCH', 'resourceclaims', None), 'update_service')
+
+    def test_unknown_resource(self):
+        result = classify_action('DELETE', 'unknownresources', None)
+        self.assertIn('delete', result)
+
+    def test_broken_body_returns_string(self):
+        # Should not raise, even with unexpected body types
+        result = classify_action('PATCH', 'resourceclaims', 'not-a-dict')
+        self.assertIsInstance(result, str)
+
+
+class TestExtractDetails(unittest.TestCase):
+
+    def test_start_service(self):
+        body = {'spec': {'provider': {'parameterValues': {
+            'start_timestamp': '2024-01-01T10:00:00Z',
+            'stop_timestamp': '2024-01-01T18:00:00Z',
+        }}}}
+        details = extract_details('start_service', body)
+        self.assertEqual(details['start_timestamp'], '2024-01-01T10:00:00Z')
+        self.assertEqual(details['stop_timestamp'], '2024-01-01T18:00:00Z')
+
+    def test_stop_service(self):
+        body = {'spec': {'provider': {'parameterValues': {'stop_timestamp': '2024-01-01T18:00:00Z'}}}}
+        details = extract_details('stop_service', body)
+        self.assertEqual(details['stop_timestamp'], '2024-01-01T18:00:00Z')
+
+    def test_retire_service(self):
+        body = {'spec': {'lifespan': {'end': '2024-01-05T00:00:00Z'}}}
+        details = extract_details('retire_service', body)
+        self.assertEqual(details['lifespan_end'], '2024-01-05T00:00:00Z')
+
+    def test_order_service_extracts_name(self):
+        body = {
+            'metadata': {
+                'name': 'my-service-abc12',
+                'annotations': {'babylon.gpte.redhat.com/catalogItemDisplayName': 'Red Hat OpenShift'},
+            }
+        }
+        details = extract_details('order_service', body)
+        self.assertEqual(details['resource_name'], 'my-service-abc12')
+        self.assertEqual(details['catalog_item_display_name'], 'Red Hat OpenShift')
+
+    def test_scale_workshop(self):
+        body = {'spec': {'count': 25}}
+        details = extract_details('scale_workshop', body)
+        self.assertEqual(details['count'], 25)
+
+    def test_edit_workshop_fields_changed(self):
+        body = {'spec': {'displayName': 'New Name', 'description': 'New desc'}}
+        details = extract_details('edit_workshop', body)
+        self.assertIn('displayName', details['fields_changed'])
+        self.assertIn('description', details['fields_changed'])
+
+    def test_edit_workshop_no_password_in_details(self):
+        # accessPassword is in body but must NOT appear in details
+        body = {'spec': {'accessPassword': 'supersecret'}}
+        details = extract_details('edit_workshop', body)
+        self.assertNotIn('accessPassword', details)
+        dumped = json.dumps(details)
+        self.assertNotIn('supersecret', dumped)
+
+    def test_assign_user_extracts_email(self):
+        body = [
+            {'op': 'add', 'path': '/spec/assignment', 'value': {'email': 'user@example.com'}},
+        ]
+        details = extract_details('assign_user', body)
+        self.assertEqual(details['email'], 'user@example.com')
+
+    def test_extend_lifespan(self):
+        body = {'spec': {'lifespan': {'maximum': '30d', 'relativeMaximum': '14d'}}}
+        details = extract_details('extend_lifespan', body)
+        self.assertEqual(details['maximum'], '30d')
+        self.assertEqual(details['relative_maximum'], '14d')
+
+    def test_tenant_cluster_action(self):
+        body = {'metadata': {'annotations': {'babylon.gpte.redhat.com/tenant-cluster-action': '{"action":"reboot"}'}}}
+        details = extract_details('tenant_cluster_action', body)
+        self.assertEqual(details['cluster_action'], 'reboot')
+
+    def test_share_service_users(self):
+        body = {'spec': {'users': [{'name': 'a@example.com'}, {'name': 'b@example.com'}]}}
+        details = extract_details('share_service', body)
+        self.assertEqual(details['users'], ['a@example.com', 'b@example.com'])
+
+    def test_unknown_action_returns_empty(self):
+        self.assertEqual(extract_details('totally_unknown', {}), {})
+
+    def test_none_body_returns_empty(self):
+        self.assertEqual(extract_details('start_service', None), {})
+
+    def test_malformed_body_returns_empty(self):
+        self.assertEqual(extract_details('start_service', 'not-a-dict'), {})
+
+    def test_missing_nested_keys_returns_empty(self):
+        # Body missing expected nested structure
+        body = {'spec': {}}
+        details = extract_details('start_service', body)
+        self.assertEqual(details, {})
+
+
+class TestAuditLog(unittest.TestCase):
+
+    def _capture_log(self, *args, **kwargs):
+        with patch.object(__import__('audit').audit_logger, 'info') as mock_info:
+            audit_log(*args, **kwargs)
+            self.assertTrue(mock_info.called)
+            return json.loads(mock_info.call_args[0][0])
+
+    def test_session_created_format(self):
+        record = self._capture_log('session_created', user='alice', details={'admin': True})
+        self.assertEqual(record['event'], 'session_created')
+        self.assertEqual(record['user'], 'alice')
+        self.assertEqual(record['details']['admin'], True)
+        self.assertIn('timestamp', record)
+
+    def test_system_status_updated_format(self):
+        data = {'workshops_ordering_blocked': True}
+        record = self._capture_log('system_status_updated', user='admin', details=data)
+        self.assertEqual(record['event'], 'system_status_updated')
+        self.assertEqual(record['details']['workshops_ordering_blocked'], True)
+
+    def test_effective_user_omitted_when_same(self):
+        record = self._capture_log('api_action', user='alice', effective_user='alice', action='start_service')
+        self.assertNotIn('effective_user', record)
+
+    def test_effective_user_present_when_different(self):
+        record = self._capture_log('api_action', user='admin', effective_user='alice', action='start_service')
+        self.assertEqual(record['effective_user'], 'alice')
+
+    def test_output_is_valid_json(self):
+        with patch.object(__import__('audit').audit_logger, 'info') as mock_info:
+            audit_log('test_event', user='alice')
+            line = mock_info.call_args[0][0]
+            parsed = json.loads(line)
+            self.assertIsInstance(parsed, dict)
+
+    def test_none_optional_fields_not_in_output(self):
+        record = self._capture_log('session_created', user='alice')
+        self.assertNotIn('effective_user', record)
+        self.assertNotIn('action', record)
+        self.assertNotIn('resource_type', record)
+        self.assertNotIn('details', record)
+
+
+class TestAuditLogApiAction(unittest.TestCase):
+
+    def _run(self, method, path, body, status=200, user='alice', effective_user=None):
+        captured = []
+        import audit as audit_mod
+        with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
+            audit_log_api_action(
+                user=user,
+                effective_user=effective_user,
+                method=method,
+                path=path,
+                status=status,
+                body=body,
+            )
+        self.assertEqual(len(captured), 1)
+        return json.loads(captured[0])
+
+    def test_start_service(self):
+        body = {'spec': {'provider': {'parameterValues': {
+            'start_timestamp': '2024-01-01T10:00:00Z',
+            'stop_timestamp': '2024-01-01T18:00:00Z',
+        }}}}
+        record = self._run('PATCH', '/apis/poolboy.gpte.redhat.com/v1/namespaces/user-alice/resourceclaims/my-claim', body)
+        self.assertEqual(record['action'], 'start_service')
+        self.assertEqual(record['resource_type'], 'ResourceClaim')
+        self.assertEqual(record['resource_name'], 'my-claim')
+        self.assertEqual(record['namespace'], 'user-alice')
+        self.assertEqual(record['status'], 200)
+        self.assertEqual(record['details']['start_timestamp'], '2024-01-01T10:00:00Z')
+
+    def test_delete_workshop(self):
+        record = self._run('DELETE', '/apis/babylon.gpte.redhat.com/v1/namespaces/user-alice/workshops/my-workshop', None)
+        self.assertEqual(record['action'], 'delete_workshop')
+        self.assertEqual(record['resource_type'], 'Workshop')
+        self.assertEqual(record['resource_name'], 'my-workshop')
+
+    def test_order_service(self):
+        body = {'metadata': {'name': 'my-service-abc12', 'annotations': {}}, 'spec': {}}
+        record = self._run('POST', '/apis/poolboy.gpte.redhat.com/v1/namespaces/user-alice/resourceclaims', body)
+        self.assertEqual(record['action'], 'order_service')
+        self.assertEqual(record['resource_type'], 'ResourceClaim')
+
+    def test_effective_user_logged(self):
+        record = self._run('DELETE', '/apis/babylon.gpte.redhat.com/v1/namespaces/user-alice/workshops/w1', None,
+                           user='admin', effective_user='alice')
+        self.assertEqual(record['user'], 'admin')
+        self.assertEqual(record['effective_user'], 'alice')
+
+    def test_non_k8s_path_fallback(self):
+        record = self._run('POST', '/api/some-custom-endpoint', {})
+        self.assertIn('path', record.get('details', {}))
+        self.assertIn('event', record)
+
+    def test_json_is_always_emitted_on_error(self):
+        # Even with a completely broken path, a JSON line must be emitted
+        record = self._run('PATCH', '/totally/invalid', 'not-a-dict')
+        self.assertIn('event', record)
+        self.assertIn('user', record)
+
+    def test_no_raw_body_in_output(self):
+        # Body contains a password — it must not appear anywhere in the output
+        body = {'spec': {'accessPassword': 'supersecret', 'displayName': 'Test'}}
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshops/w1', body)
+        dumped = json.dumps(record)
+        self.assertNotIn('supersecret', dumped)
+
+    def test_scale_workshop(self):
+        body = {'spec': {'count': 50}}
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshopprovisions/wp1', body)
+        self.assertEqual(record['action'], 'scale_workshop')
+        self.assertEqual(record['details']['count'], 50)
+
+    def test_assign_user_json_patch(self):
+        body = [{'op': 'add', 'path': '/spec/assignment', 'value': {'email': 'user@example.com'}}]
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshopuserassignments/wa1', body)
+        self.assertEqual(record['action'], 'assign_user')
+        self.assertEqual(record['details']['email'], 'user@example.com')
+
+    def test_error_status_logged(self):
+        record = self._run('DELETE', '/apis/poolboy.gpte.redhat.com/v1/namespaces/x/resourceclaims/c1', None, status=403)
+        self.assertEqual(record['status'], 403)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/catalog/api/test_audit.py
+++ b/catalog/api/test_audit.py
@@ -191,6 +191,55 @@ class TestClassifyAction(unittest.TestCase):
         result = classify_action('PATCH', 'resourceclaims', 'not-a-dict')
         self.assertIsInstance(result, str)
 
+    # --- Malformed body fault tolerance ---
+    def test_patch_resourceclaim_parameterValues_is_list(self):
+        body = {'spec': {'provider': {'parameterValues': ['unexpected', 'list']}}}
+        result = classify_action('PATCH', 'resourceclaims', body)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_resourceclaim_resources_is_string(self):
+        body = {'spec': {'resources': 'not-a-list'}}
+        result = classify_action('PATCH', 'resourceclaims', body)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_resourceclaim_resources_is_int(self):
+        body = {'spec': {'resources': 42}}
+        result = classify_action('PATCH', 'resourceclaims', body)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_resourceclaim_resources_contains_non_dict(self):
+        body = {'spec': {'resources': ['not-a-dict', 123, None]}}
+        result = classify_action('PATCH', 'resourceclaims', body)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_resourceclaim_action_schedule_is_list(self):
+        body = {'spec': {'resources': [{'template': {'spec': {'vars': {'action_schedule': ['bad']}}}}]}}
+        result = classify_action('PATCH', 'resourceclaims', body)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_workshop_actionSchedule_is_list(self):
+        body = {'spec': {'actionSchedule': ['not', 'a', 'dict']}}
+        result = classify_action('PATCH', 'workshops', body)
+        self.assertEqual(result, 'update_workshop')
+
+    def test_patch_workshop_actionSchedule_is_string(self):
+        body = {'spec': {'actionSchedule': 'bad-value'}}
+        result = classify_action('PATCH', 'workshops', body)
+        self.assertEqual(result, 'update_workshop')
+
+    def test_patch_workshop_spec_is_list(self):
+        body = {'spec': ['not', 'a', 'dict']}
+        result = classify_action('PATCH', 'workshops', body)
+        self.assertEqual(result, 'update_workshop')
+
+    def test_patch_resourceclaim_body_is_int(self):
+        result = classify_action('PATCH', 'resourceclaims', 42)
+        self.assertEqual(result, 'update_service')
+
+    def test_patch_workshop_body_is_bool(self):
+        result = classify_action('PATCH', 'workshops', True)
+        self.assertEqual(result, 'update_workshop')
+
 
 class TestExtractDetails(unittest.TestCase):
 
@@ -325,6 +374,15 @@ class TestAuditLog(unittest.TestCase):
         self.assertNotIn('resource_type', record)
         self.assertNotIn('details', record)
 
+    def test_non_serializable_details_does_not_raise(self):
+        # If details somehow contains a non-serializable object, audit_log must not raise
+        audit_log('test_event', user='alice', details={'bad': object()})
+        # No exception = pass
+
+    def test_non_serializable_extra_does_not_raise(self):
+        audit_log('test_event', user='alice', weird_field=object())
+        # No exception = pass
+
 
 class TestAuditLogApiAction(unittest.TestCase):
 
@@ -407,6 +465,46 @@ class TestAuditLogApiAction(unittest.TestCase):
     def test_error_status_logged(self):
         record = self._run('DELETE', '/apis/poolboy.gpte.redhat.com/v1/namespaces/x/resourceclaims/c1', None, status=403)
         self.assertEqual(record['status'], 403)
+
+    # --- Malformed body end-to-end: must always emit JSON, never raise ---
+    def test_body_is_integer(self):
+        record = self._run('PATCH', '/apis/poolboy.gpte.redhat.com/v1/namespaces/x/resourceclaims/c1', 42)
+        self.assertIn('event', record)
+        self.assertIn('user', record)
+
+    def test_body_is_boolean(self):
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshops/w1', True)
+        self.assertIn('event', record)
+
+    def test_body_nested_values_wrong_types(self):
+        body = {'spec': {'provider': {'parameterValues': 'not-a-dict'}, 'resources': 99, 'lifespan': 'bad'}}
+        record = self._run('PATCH', '/apis/poolboy.gpte.redhat.com/v1/namespaces/x/resourceclaims/c1', body)
+        self.assertIn('event', record)
+        self.assertIn('action', record)
+
+    def test_workshop_body_all_wrong_types(self):
+        body = {'spec': {'actionSchedule': 123, 'lifespan': True}, 'metadata': {'labels': 'not-a-dict'}}
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshops/w1', body)
+        self.assertIn('event', record)
+
+    def test_json_patch_with_non_dict_operations(self):
+        body = ['not-a-dict', 42, None, True]
+        record = self._run('PATCH', '/apis/babylon.gpte.redhat.com/v1/namespaces/x/workshopuserassignments/wa1', body)
+        self.assertIn('event', record)
+
+    def test_none_user_does_not_crash(self):
+        # Even if user is None (shouldn't happen, but defensive)
+        record = self._run('DELETE', '/apis/poolboy.gpte.redhat.com/v1/namespaces/x/resourceclaims/c1', None, user=None)
+        self.assertIn('event', record)
+
+    def test_none_method_does_not_crash(self):
+        captured = []
+        import audit as audit_mod
+        with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
+            audit_log_api_action(user='alice', effective_user=None, method=None, path='/apis/x/v1/y/z', status=200, body=None)
+        self.assertTrue(len(captured) >= 1)
+        record = json.loads(captured[0])
+        self.assertIn('event', record)
 
 
 if __name__ == '__main__':

--- a/catalog/api/test_audit.py
+++ b/catalog/api/test_audit.py
@@ -4,8 +4,8 @@ import unittest
 from unittest.mock import patch
 
 sys.path.insert(0, '.')
-import audit as audit_mod
 from audit import (
+    audit_logger,
     parse_k8s_path,
     classify_action,
     extract_details,
@@ -335,7 +335,7 @@ class TestExtractDetails(unittest.TestCase):
 class TestAuditLog(unittest.TestCase):
 
     def _capture_log(self, *args, **kwargs):
-        with patch.object(audit_mod.audit_logger, 'info') as mock_info:
+        with patch.object(audit_logger, 'info') as mock_info:
             audit_log(*args, **kwargs)
             self.assertTrue(mock_info.called)
             return json.loads(mock_info.call_args[0][0])
@@ -362,7 +362,7 @@ class TestAuditLog(unittest.TestCase):
         self.assertEqual(record['effective_user'], 'alice')
 
     def test_output_is_valid_json(self):
-        with patch.object(audit_mod.audit_logger, 'info') as mock_info:
+        with patch.object(audit_logger, 'info') as mock_info:
             audit_log('test_event', user='alice')
             line = mock_info.call_args[0][0]
             parsed = json.loads(line)
@@ -389,7 +389,7 @@ class TestAuditLogApiAction(unittest.TestCase):
 
     def _run(self, method, path, body, status=200, user='alice', effective_user=None):
         captured = []
-        with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
+        with patch.object(audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
             audit_log_api_action(
                 user=user,
                 effective_user=effective_user,
@@ -499,7 +499,7 @@ class TestAuditLogApiAction(unittest.TestCase):
 
     def test_none_method_does_not_crash(self):
         captured = []
-        with patch.object(audit_mod.audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
+        with patch.object(audit_logger, 'info', side_effect=lambda msg: captured.append(msg)):
             audit_log_api_action(user='alice', effective_user=None, method=None, path='/apis/x/v1/y/z', status=200, body=None)
         self.assertGreaterEqual(len(captured), 1)
         record = json.loads(captured[0])


### PR DESCRIPTION
Replace the space-delimited key=value audit log format with structured JSON output. Instead of logging raw HTTP methods, K8s API paths, and full request bodies (which may contain sensitive data like passwords), the new audit module parses requests into human-readable actions (`start_service`, `delete_workshop`, `scale_workshop`, etc.) and extracts only known-safe fields.

## Changes:

- New `api/audit.py` module: parses K8s paths, classifies ~30 action types from method+resource+body, extracts safe details, outputs single-line JSON
- Updated `api/app.py`: removed inline `audit_log`, uses new module at all 4 existing call sites
- New `api/test_audit.py`: 88 unit tests covering classification, extraction, and fault tolerance

## Key properties:
- Top-level JSON fields (`user`, `effective_user`, `action`, `resource_type`, `timestamp`, `status`) enable direct filtering by who/what/when (e.g. dashboard at Splunk or Sumo Logic)
- No raw request body in logs — only explicitly extracted fields (`timestamps`, `counts`, `resource names`)
- Fully fault-tolerant: malformed or changed body formats degrade to partial info, never fail the API request