### PR TITLE
fix: configure DOMPurify to preserve partner header styles and web components

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -87,7 +87,14 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
             style={{ minHeight: 'auto', padding: 0, zIndex: 999, position: 'relative' }}
           >
             <div>
-              <div dangerouslySetInnerHTML={{ __html: dompurify.sanitize(partnerHeaderHtml || '') }}></div>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: dompurify.sanitize(partnerHeaderHtml || '', {
+                    ADD_TAGS: ['style', 'pfe-navigation', 'pfe-navigation-dropdown'],
+                    ADD_ATTR: ['part', 'slot', 'dropdown-width', 'icon', 'name'],
+                  }),
+                }}
+              ></div>
             </div>
           </PageSection>
         ) : null}


### PR DESCRIPTION


DOMPurify default config strips style tags and custom elements (pfe-navigation, pfe-navigation-dropdown), breaking CSS rendering of the partner header introduced in f582d21. Whitelist the specific tags and attributes used by the partner header while keeping XSS protection.