### PR TITLE
fix: preserve created_by when only adding a comment to catalog incident

### DIFF
--- a/catalog/ui/src/app/Admin/CatalogItemAdmin.tsx
+++ b/catalog/ui/src/app/Admin/CatalogItemAdmin.tsx
@@ -126,10 +126,14 @@ const CatalogItemAdmin: React.FC = () => {
       });
     }
 
+    const statusChanged =
+      status !== (catalogItemIncident?.status || 'Operational') ||
+      isDisabled !== (catalogItemIncident?.disabled ?? false);
+
     await fetcher(apiPaths.CATALOG_ITEM_INCIDENTS({ asset_uuid, stage }), {
       method: 'POST',
       body: JSON.stringify({
-        created_by: userEmail,
+        created_by: statusChanged ? userEmail : catalogItemIncident?.created_by || userEmail,
         disabled: isDisabled,
         status,
         incident_url: incidentUrl,


### PR DESCRIPTION
Adding a comment was overwriting created_by with the commenter's email, making it appear as if they changed the status. Now created_by only updates when status or disabled actually changes.