### PR TITLE
fix: update cost tier display styling and element order

### DIFF
--- a/catalog/ui/src/app/components/CostTierDisplay.tsx
+++ b/catalog/ui/src/app/components/CostTierDisplay.tsx
@@ -12,7 +12,6 @@ const CostTierDisplay: React.FC<{ hourlyCost: number }> = ({ hourlyCost }) => {
 
   return (
     <span className="cost-tier-display" tabIndex={0}>
-      <span className="cost-tier-display__amount">{formattedCost}/hr</span>
       <Tooltip content={`Cost level: ${tierLabels[tier - 1]}`}>
         <span className="cost-tier-display__tier" tabIndex={0}>
           {[1, 2, 3].map((level) => (
@@ -27,6 +26,7 @@ const CostTierDisplay: React.FC<{ hourlyCost: number }> = ({ hourlyCost }) => {
           ))}
         </span>
       </Tooltip>
+      <span className="cost-tier-display__amount">{formattedCost}/hr</span>
     </span>
   );
 };

--- a/catalog/ui/src/app/components/cost-tier-display.css
+++ b/catalog/ui/src/app/components/cost-tier-display.css
@@ -6,8 +6,8 @@
 }
 
 .cost-tier-display__amount {
-  font-size: var(--pf-t--global--font--size--md);
-  font-weight: var(--pf-t--global--font--weight--400);
+  font-size: var(--pf-t--global--font--size--xs);
+  font-weight: var(--pf-t--global--font--weight--100);
   color: var(--pf-t--global--text--color--regular);
 }
 


### PR DESCRIPTION
Reduce the cost amount font size to xs and weight to 100 for a subtler appearance, and reorder elements so tier symbols render before the amount.