### PR TITLE
feat: add share service link to self-paced lab detail page

### DIFF
--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -32,22 +32,40 @@ import {
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
-import { Select, SelectOption, SelectList } from '@patternfly/react-core';
+import {
+  Alert,
+  FormGroup,
+  Label as PfLabel,
+  LabelGroup,
+  Select,
+  SelectOption,
+  SelectList,
+  TextInput,
+  Modal as PfModal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
 
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import {
   apiPaths,
+  createServiceAccessConfig,
   dateToApiString,
   deleteSelfPacedLab,
   deleteResourceClaim,
+  deleteServiceAccessConfig,
   fetcher,
   fetcherItemsInAllPages,
+  FORBIDDEN_RESPONSE,
+  optionalFetcher,
   patchResourceClaim,
   patchSelfPacedLab,
   patchSelfPacedLabProvisionItem,
+  patchServiceAccessConfig,
   SERVICES_KEY,
 } from '@app/api';
-import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabProvisionItem as SelfPacedLabProvisionItemType, SelfPacedLabUserAssignmentList } from '@app/types';
+import { CatalogItem, ResourceClaim, SelfPacedLab, SelfPacedLabProvisionItem as SelfPacedLabProvisionItemType, SelfPacedLabUserAssignmentList, ServiceAccessConfig } from '@app/types';
 import {
   BABYLON_DOMAIN,
   DEMO_DOMAIN,
@@ -110,6 +128,8 @@ const SelfPacedLabItemComponent: React.FC<{
   const [modalDeleteRC, openModalDeleteRC] = useModal();
   const [deleteTargetRCs, setDeleteTargetRCs] = useState<ResourceClaim[]>([]);
   const [selectedUids, setSelectedUids] = useState<string[]>([]);
+  const [modalAddServiceAccess, setModalAddServiceAccess] = useState(false);
+  const [newServiceAccessEmail, setNewServiceAccessEmail] = useState('');
 
   const { data: selfPacedLab, mutate: mutateSelfPacedLab } = useSWR<SelfPacedLab>(
     apiPaths.SELF_PACED_LAB({ namespace: serviceNamespaceName, selfPacedLabName }),
@@ -190,6 +210,31 @@ const SelfPacedLabItemComponent: React.FC<{
       refreshInterval: 8000,
     },
   );
+
+  const {
+    data: serviceAccessConfigResponse,
+    isLoading: serviceAccessLoading,
+    mutate: mutateServiceAccessConfig,
+  } = useSWR<ServiceAccessConfig | typeof FORBIDDEN_RESPONSE | null>(
+    selfPacedLab && (isAdmin || sessionServiceNamespaces.some((ns) => ns.name === serviceNamespaceName))
+      ? apiPaths.SERVICE_ACCESS_CONFIG({
+          namespace: serviceNamespaceName,
+          name: selfPacedLab.metadata.name,
+        })
+      : null,
+    optionalFetcher,
+  );
+  const canManageCollaborators =
+    (sessionServiceNamespaces.some((ns) => ns.name === serviceNamespaceName) &&
+      serviceAccessConfigResponse !== FORBIDDEN_RESPONSE) ||
+    isAdmin;
+  const serviceAccessConfig = canManageCollaborators
+    ? (serviceAccessConfigResponse as ServiceAccessConfig | null)
+    : null;
+  const serviceAccessUsers = useMemo(() => {
+    if (!serviceAccessConfig?.spec?.users) return [];
+    return serviceAccessConfig.spec.users.map((u) => u.name);
+  }, [serviceAccessConfig]);
 
   const selfPacedLabId = selfPacedLab?.metadata.labels?.[`${BABYLON_DOMAIN}/selfpacedlab-id`];
   const activeResourceClaims = useMemo(
@@ -351,6 +396,62 @@ const SelfPacedLabItemComponent: React.FC<{
           patch: { spec: { lifespan: { start: dateToApiString(date) } } },
         }),
       );
+    }
+  }
+
+  async function handleAddServiceAccessUser() {
+    const email = newServiceAccessEmail.trim();
+    if (!email) return;
+
+    const updatedUsers = [...serviceAccessUsers, email];
+
+    try {
+      if (serviceAccessConfig) {
+        const updatedConfig = await patchServiceAccessConfig({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+          users: updatedUsers,
+        });
+        mutateServiceAccessConfig(updatedConfig);
+      } else {
+        const newConfig = await createServiceAccessConfig({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+          serviceName: selfPacedLab.metadata.name,
+          serviceNamespace: selfPacedLab.metadata.namespace,
+          serviceKind: 'SelfPacedLab',
+          users: updatedUsers,
+        });
+        mutateServiceAccessConfig(newConfig);
+      }
+    } catch (error) {
+      console.error('Failed to update ServiceAccessConfig:', error);
+    }
+
+    setNewServiceAccessEmail('');
+    setModalAddServiceAccess(false);
+  }
+
+  async function handleRemoveServiceAccessUser(emailToRemove: string) {
+    const updatedUsers = serviceAccessUsers.filter((email: string) => email !== emailToRemove);
+
+    try {
+      if (updatedUsers.length === 0) {
+        await deleteServiceAccessConfig({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+        });
+        mutateServiceAccessConfig(null);
+      } else {
+        const updatedConfig = await patchServiceAccessConfig({
+          name: selfPacedLab.metadata.name,
+          namespace: selfPacedLab.metadata.namespace,
+          users: updatedUsers,
+        });
+        mutateServiceAccessConfig(updatedConfig);
+      }
+    } catch (error) {
+      console.error('Failed to update ServiceAccessConfig:', error);
     }
   }
 
@@ -599,6 +700,50 @@ const SelfPacedLabItemComponent: React.FC<{
                     </Select>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+                {canManageCollaborators ? (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      Share service{' '}
+                      <Tooltip position="right" content={<p>Users who have access to this self-paced lab service.</p>}>
+                        <OutlinedQuestionCircleIcon
+                          aria-label="Users who have access to this self-paced lab service."
+                          className="tooltip-icon-only"
+                        />
+                      </Tooltip>
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--sm)' }}>
+                        {serviceAccessLoading ? (
+                          <LoadingIcon />
+                        ) : serviceAccessUsers.length > 0 ? (
+                          <LabelGroup>
+                            {serviceAccessUsers.map((email: string) => (
+                              <PfLabel
+                                key={email}
+                                onClose={() => handleRemoveServiceAccessUser(email)}
+                                closeBtnAriaLabel={`Remove ${email}`}
+                              >
+                                {email}
+                              </PfLabel>
+                            ))}
+                          </LabelGroup>
+                        ) : (
+                          <span style={{ color: 'var(--pf-t--global--color--nonstatus--gray--default)' }}>
+                            No users configured
+                          </span>
+                        )}
+                        <Button
+                          variant="link"
+                          icon={<PlusCircleIcon />}
+                          onClick={() => setModalAddServiceAccess(true)}
+                          style={{ alignSelf: 'flex-start', paddingLeft: 0, paddingTop: 0, paddingBottom: 0, paddingRight: 0 }}
+                        >
+                          Share service
+                        </Button>
+                      </div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
                 {autoStartTime && autoStartTime > Date.now() ? (
                   <DescriptionListGroup>
                     <DescriptionListTerm>Start Date</DescriptionListTerm>
@@ -1007,6 +1152,59 @@ const SelfPacedLabItemComponent: React.FC<{
           </Tab>
         </Tabs>
       </PageSection>
+      <PfModal
+        variant="medium"
+        isOpen={modalAddServiceAccess}
+        onClose={() => {
+          setModalAddServiceAccess(false);
+          setNewServiceAccessEmail('');
+        }}
+        aria-label="Share service"
+      >
+        <ModalHeader title="Share service" />
+        <ModalBody>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--pf-t--global--spacer--md)' }}>
+            <Alert variant="info" isInline title="Grant user access">
+              By adding a user&apos;s email, they will gain access to manage this self-paced lab. Please use the email
+              address associated with their account on the Demo platform.
+            </Alert>
+            <FormGroup label="Email address" isRequired fieldId="service-access-email">
+              <TextInput
+                id="service-access-email"
+                type="email"
+                value={newServiceAccessEmail}
+                onChange={(_event, value) => setNewServiceAccessEmail(value)}
+                placeholder="user@example.com"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newServiceAccessEmail.trim()) {
+                    handleAddServiceAccessUser();
+                  }
+                }}
+              />
+            </FormGroup>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            key="add"
+            variant="primary"
+            onClick={handleAddServiceAccessUser}
+            isDisabled={!newServiceAccessEmail.trim()}
+          >
+            Add
+          </Button>
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => {
+              setModalAddServiceAccess(false);
+              setNewServiceAccessEmail('');
+            }}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </PfModal>
     </>
   );
 };

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -2567,10 +2567,10 @@ export async function createServiceAccessConfig({
   namespace: string;
   serviceName: string;
   serviceNamespace: string;
-  serviceKind?: 'Workshop' | 'ResourceClaim';
+  serviceKind?: 'Workshop' | 'ResourceClaim' | 'SelfPacedLab';
   users: string[];
 }): Promise<ServiceAccessConfig> {
-  const labelKey = serviceKind === 'Workshop' ? 'workshop' : 'resourceclaim';
+  const labelKey = serviceKind === 'Workshop' ? 'workshop' : serviceKind === 'SelfPacedLab' ? 'selfpacedlab' : 'resourceclaim';
   const definition: ServiceAccessConfig = {
     apiVersion: `${BABYLON_DOMAIN}/v1`,
     kind: 'ServiceAccessConfig',

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -762,7 +762,7 @@ export interface ServiceAccessConfig extends K8sObject {
 }
 
 export interface ServiceAccessConfigSpec {
-  kind: 'ResourceClaim' | 'Workshop';
+  kind: 'ResourceClaim' | 'SelfPacedLab' | 'Workshop';
   name: string;
   users?: Array<{ name: string }>;
 }
@@ -784,7 +784,7 @@ export interface ServiceAccess extends K8sObject {
 }
 
 export interface ServiceAccessSpec {
-  kind: 'ResourceClaim' | 'Workshop';
+  kind: 'ResourceClaim' | 'SelfPacedLab' | 'Workshop';
   name: string;
   namespace: string;
 }

--- a/helm/crds/serviceaccessconfigs.babylon.gpte.redhat.com.yaml
+++ b/helm/crds/serviceaccessconfigs.babylon.gpte.redhat.com.yaml
@@ -38,10 +38,11 @@ spec:
               kind:
                 description:
                   Kind of object for access configuration.
-                  Either "ResourceClaim" or "Workshop".
+                  Either "ResourceClaim", "SelfPacedLab", or "Workshop".
                 type: string
                 enum:
                 - ResourceClaim
+                - SelfPacedLab
                 - Workshop
               name:
                 description: >-

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,7 +98,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-api
-        tag: v1.3.0
+        tag: v1.3.1
       loggingLevel: INFO
       replicaCount: 1
       resources:
@@ -224,7 +224,7 @@ serviceAccessManager:
   image:
     repository: quay.io/rhpds/babylon-service-access-manager
     pullPolicy: IfNotPresent
-    tag: v0.1.1
+    tag: v0.1.2
   namespace:
     create: true
     name: babylon-service-access-manager

--- a/service-access-manager/operator/operator.py
+++ b/service-access-manager/operator/operator.py
@@ -8,6 +8,7 @@ from babylon import Babylon
 from configure_kopf_logging import configure_kopf_logging
 from infinite_relative_backoff import InfiniteRelativeBackoff
 from resourceclaim import ResourceClaim
+from selfpacedlab import SelfPacedLab
 from serviceaccessconfig import ServiceAccessConfig
 from workshop import Workshop
 
@@ -101,6 +102,16 @@ async def service_access_config_update(logger, **kwargs):
 async def service_access_config_timer(logger, **kwargs):
     service_access_config = ServiceAccessConfig(**kwargs)
     await service_access_config.handle_timer(logger=logger)
+
+
+@kopf.on.event(
+    SelfPacedLab.api_group, SelfPacedLab.api_version, SelfPacedLab.plural,
+    labels={
+        Babylon.babylon_ignore_label: kopf.ABSENT,
+    },
+)
+async def self_paced_lab_event(event, logger, **_):
+    await SelfPacedLab.handle_event(event, logger=logger)
 
 
 @kopf.on.event(

--- a/service-access-manager/operator/selfpacedlab.py
+++ b/service-access-manager/operator/selfpacedlab.py
@@ -1,0 +1,63 @@
+from kubernetes_asyncio.client import ApiException as k8sApiException
+
+from babylon import Babylon
+from k8sobject import K8sObject
+
+import serviceaccessconfig
+
+class SelfPacedLab(K8sObject):
+    api_group = Babylon.babylon_domain
+    api_version = Babylon.babylon_api_version
+    kind = 'SelfPacedLab'
+    plural = 'selfpacedlabs'
+
+    @classmethod
+    async def handle_event(cls, event, logger):
+        definition = event.get('object')
+        if not definition or definition.get('kind') != 'SelfPacedLab':
+            logger.warning(event)
+            return
+        self_paced_lab = cls(definition=definition)
+        if (
+            event.get('type') == 'DELETED' or
+            self_paced_lab.deletion_timestamp is not None
+        ):
+            await self_paced_lab.__handle_delete(logger)
+        else:
+            await self_paced_lab.__handle_event(logger)
+
+    @property
+    def resource_claim_names(self) -> list[str]:
+        return list(self.status.get('resourceClaims', {}).keys())
+
+    @property
+    def service_access_config_names(self) -> list[str]:
+        return self.status.get('serviceAccessConfigs', [])
+
+    async def __handle_delete(self, logger):
+        for service_access_config_name in self.service_access_config_names:
+            try:
+                service_access_config = await serviceaccessconfig.ServiceAccessConfig.fetch(
+                    name=service_access_config_name,
+                    namespace=self.namespace,
+                )
+                logger.info("Deleting %s after delete of %s", service_access_config, self)
+                await service_access_config.delete()
+            except k8sApiException as exception:
+                if exception.status != 404:
+                    logger.exception("Failed to get ServiceAccessConfig %s for %s", service_access_config_name, self)
+
+    async def __handle_event(self, logger):
+        for service_access_config_name in self.service_access_config_names:
+            try:
+                service_access_config = await serviceaccessconfig.ServiceAccessConfig.fetch(
+                    name=service_access_config_name,
+                    namespace=self.namespace,
+                )
+            except k8sApiException as exception:
+                if exception.status == 404:
+                    logger.warning("ServiceAccessConfig %s for %s not found", service_access_config_name, self)
+                else:
+                    logger.exception("Failed to get ServiceAccessConfig %s for %s", service_access_config_name, self)
+                continue
+            await service_access_config.handle_self_paced_lab_event(self, logger)

--- a/service-access-manager/operator/serviceaccessconfig.py
+++ b/service-access-manager/operator/serviceaccessconfig.py
@@ -2,6 +2,7 @@ from kubernetes_asyncio.client import ApiException as k8sApiException
 
 from babylon import Babylon
 from resourceclaim import ResourceClaim
+from selfpacedlab import SelfPacedLab
 from workshop import Workshop
 from workshopprovision import WorkshopProvision
 from workshopuserassignment import WorkshopUserAssignment
@@ -88,6 +89,24 @@ class ServiceAccessConfig(KopfObject):
             service_access_configs.remove(self.name)
             await resource_claim.merge_patch_status({"serviceAccessConfigs": service_access_configs})
 
+    async def __handle_delete_kind_self_paced_lab(self, logger):
+        """Handle cleanup of SelfPacedLab on delete of ServiceAccessConfig."""
+        try:
+            self_paced_lab = await SelfPacedLab.fetch(
+                name=self.object_name,
+                namespace=self.namespace,
+            )
+        except k8sApiException as exception:
+            if exception.status == 404:
+                return
+            raise
+        if 'deletionTimestamp' in self_paced_lab.metadata:
+            return
+        service_access_configs = self_paced_lab.status.get('serviceAccessConfigs', [])
+        if self.name in service_access_configs:
+            service_access_configs.remove(self.name)
+            await self_paced_lab.merge_patch_status({"serviceAccessConfigs": service_access_configs})
+
     async def __handle_delete_kind_workshop(self, logger):
         """Handle cleanup of Workshop on delete of ServiceAccessConfig."""
         try:
@@ -110,6 +129,8 @@ class ServiceAccessConfig(KopfObject):
     async def __manage(self, logger):
         if self.object_kind == 'ResourceClaim':
             await self.__manage_resource_claim_access(logger)
+        elif self.object_kind == 'SelfPacedLab':
+            await self.__manage_self_paced_lab_access(logger)
         elif self.object_kind == 'Workshop':
             await self.__manage_workshop_access(logger)
         await self.__manage_service_accesses(logger)
@@ -200,6 +221,85 @@ class ServiceAccessConfig(KopfObject):
             service_access_configs.append(self.name)
             await resource_claim.merge_patch_status({"serviceAccessConfigs": service_access_configs})
             logger.info("Added %s to %s status", self, resource_claim)
+
+    async def __manage_self_paced_lab_access(self, logger):
+        try:
+            self_paced_lab = await SelfPacedLab.fetch(
+                name=self.object_name,
+                namespace=self.namespace,
+            )
+        except k8sApiException as exception:
+            if exception.status == 404:
+                logger.info("Deleting %s after deletion of SelfPacedLab %s", self, self.object_name)
+                await self.delete()
+                return
+            raise
+        if self_paced_lab.deletion_timestamp is not None:
+            logger.info("Deleting %s after deletion of %s", self, self_paced_lab)
+            await self.delete()
+            return
+        await self.__manage_self_paced_lab_access_with_object(self_paced_lab, logger)
+
+    async def __manage_self_paced_lab_access_with_object(self, self_paced_lab, logger):
+        await self.__manage_self_paced_lab_service_access_config_reference(self_paced_lab, logger)
+        await self.__manage_self_paced_lab_access_role(self_paced_lab, logger)
+        await self.__manage_role_binding(self_paced_lab, logger)
+
+    async def __manage_self_paced_lab_service_access_config_reference(self, self_paced_lab, logger):
+        """Make sure SelfPacedLab has reference to ServiceAccessConfig in status."""
+        service_access_configs = self_paced_lab.status.get('serviceAccessConfigs')
+        if service_access_configs is None:
+            await self_paced_lab.merge_patch_status({"serviceAccessConfigs": [self.name]})
+            logger.info("Added %s to %s status", self, self_paced_lab)
+        elif self.name not in service_access_configs:
+            service_access_configs.append(self.name)
+            await self_paced_lab.merge_patch_status({"serviceAccessConfigs": service_access_configs})
+            logger.info("Added %s to %s status", self, self_paced_lab)
+
+    async def __manage_self_paced_lab_access_role(self, self_paced_lab, logger):
+        """Manage role for access to SelfPacedLab and related objects."""
+        current_state = await self.__fetch_role(logger)
+
+        role = V1Role(
+            api_version="rbac.authorization.k8s.io/v1",
+            kind="Role",
+            metadata=(
+                V1ObjectMeta(name=self.name, namespace=self.namespace)
+                if current_state is None else current_state.metadata
+            ),
+        )
+        role.metadata.owner_references = [self.as_owner_reference()]
+        role.rules = [
+            V1PolicyRule(
+                api_groups=[self_paced_lab.api_group],
+                resource_names=[self_paced_lab.name],
+                resources=[self_paced_lab.plural],
+                verbs=['get', 'patch', 'update'],
+            ),
+        ]
+        if len(self_paced_lab.resource_claim_names) > 0:
+            role.rules.append(
+                V1PolicyRule(
+                    api_groups=[ResourceClaim.api_group],
+                    resource_names=self_paced_lab.resource_claim_names,
+                    resources=[ResourceClaim.plural],
+                    verbs=['delete', 'get', 'patch', 'update'],
+                )
+            )
+
+        if current_state is None:
+            try:
+                await Babylon.rbac_authorization_api.create_namespaced_role(self.namespace, role)
+                logger.info("Created service access role for %s", self_paced_lab)
+            except k8sApiException as exception:
+                if exception.status != 409:
+                    logger.exception("Failed to create service access role for %s", self_paced_lab)
+        elif role != current_state:
+            try:
+                await Babylon.rbac_authorization_api.replace_namespaced_role(self.name, self.namespace, role)
+                logger.info("Updated service access role for %s", self_paced_lab)
+            except k8sApiException:
+                logger.exception("Failed to update service access role for %s", self_paced_lab)
 
     async def __manage_role_binding(self, obj, logger):
         """Manage role binding for this service access config role."""
@@ -391,6 +491,8 @@ class ServiceAccessConfig(KopfObject):
         logger.debug(f"Handling delete {self}")
         if self.object_kind == 'ResourceClaim':
             await self.__handle_delete_kind_resource_claim(logger)
+        elif self.object_kind == 'SelfPacedLab':
+            await self.__handle_delete_kind_self_paced_lab(logger)
         elif self.object_kind == 'Workshop':
             await self.__handle_delete_kind_workshop(logger)
         await self.__delete_serviceaccesses(logger)
@@ -416,6 +518,10 @@ class ServiceAccessConfig(KopfObject):
     async def handle_update(self, logger):
         logger.debug(f"Handling update {self}")
         await self.__manage(logger)
+
+    async def handle_self_paced_lab_event(self, self_paced_lab, logger):
+        logger.debug(f"Handling event on %s for %s", self_paced_lab, self)
+        await self.__manage_self_paced_lab_access_with_object(self_paced_lab, logger)
 
     async def handle_workshop_event(self, workshop, logger):
         logger.debug(f"Handling event on %s for %s", workshop, self)


### PR DESCRIPTION
Add the ability to share service access on self-paced labs, matching the existing functionality in workshops and resource claims. This includes UI changes, operator support for the SelfPacedLab kind in ServiceAccessConfig, and CRD schema updates.