### PR TITLE
feat: integrate Jira ticket creation with White Glove Requests

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import asyncio
+import base64
 import copy
 import gzip
 import json
@@ -34,6 +35,10 @@ sandbox_api = os.environ.get('SANDBOX_API', 'http://sandbox-api.babylon-sandbox-
 sandbox_api_authorization_token = os.environ.get('SANDBOX_AUTHORIZATION_TOKEN')
 shared_cluster_manager_token = os.environ.get('SHARED_CLUSTER_MANAGER_TOKEN')
 reporting_api_authorization_token = os.environ.get('SALESFORCE_AUTHORIZATION_TOKEN')
+jira_base_url = os.environ.get('JIRA_BASE_URL', 'https://redhat.atlassian.net')
+jira_api_token = os.environ.get('JIRA_API_TOKEN')
+jira_user_email = os.environ.get('JIRA_USER_EMAIL')
+jira_project_key = os.environ.get('JIRA_PROJECT_KEY', 'RHDPSPPT')
 response_cache = {}
 response_cache_clean_interval = int(os.environ.get('RESPONSE_CACHE_CLEAN_INTERVAL', 60))
 response_cache_clean_task = None
@@ -966,6 +971,152 @@ async def external_item_request(request):
         data=json.dumps(data),
         url=f"{reporting_api}/external_item/{quote(asset_uuid, safe='')}/request",
     )
+
+@routes.post("/api/jira/wgr")
+async def create_jira_wgr_ticket(request):
+    user = await get_proxy_user(request)
+
+    if not jira_api_token or not jira_user_email:
+        raise web.HTTPServiceUnavailable(reason="Jira integration is not configured")
+
+    data = await request.json()
+    display_name = data.get('displayName', 'White Glove Request')
+    requester = user['metadata']['name']
+
+    description_lines = [
+        f"Requester: {requester}",
+        f"Catalog Item: {data.get('catalogItemNamespace', '')}/{data.get('catalogItemName', '')}",
+        f"Activity: {data.get('activity', 'N/A')}",
+        f"Purpose: {data.get('purpose', 'N/A')}",
+    ]
+    if data.get('explanation'):
+        description_lines.append(f"Explanation: {data['explanation']}")
+    description_lines.append(f"Number of Users: {data.get('numberOfUsers', 'N/A')}")
+    if data.get('eventDate'):
+        description_lines.append(f"Event Start: {data['eventDate']}")
+    if data.get('eventEndDate'):
+        description_lines.append(f"Event End: {data['eventEndDate']}")
+    if data.get('salesforceItems'):
+        sf_ids = ', '.join(f"{item['type']}: {item['id']}" for item in data['salesforceItems'])
+        description_lines.append(f"Salesforce IDs: {sf_ids}")
+    if data.get('notes'):
+        description_lines.append(f"\nNotes:\n{data['notes']}")
+
+    description_text = '\n'.join(description_lines)
+
+    jira_payload = {
+        "fields": {
+            "project": {"key": jira_project_key},
+            "summary": f"[WGR] {display_name}",
+            "description": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": description_text}]
+                    }
+                ]
+            },
+            "issuetype": {"name": "Task"},
+            "reporter": {"emailAddress": requester},
+        }
+    }
+
+    credentials = base64.b64encode(f"{jira_user_email}:{jira_api_token}".encode()).decode()
+    headers = {
+        "Authorization": f"Basic {credentials}",
+        "Content-Type": "application/json",
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{jira_base_url}/rest/api/3/issue",
+            headers=headers,
+            data=json.dumps(jira_payload),
+        ) as resp:
+            if resp.status not in (200, 201):
+                error_body = await resp.text()
+                logging.error(f"Jira API error ({resp.status}): {error_body}")
+                raise web.HTTPBadGateway(reason=f"Failed to create Jira ticket: {resp.status}")
+            result = await resp.json()
+
+    ticket_key = result['key']
+    ticket_url = f"{jira_base_url}/browse/{ticket_key}"
+
+    audit_log('jira_ticket_created', user=requester, details={'ticket': ticket_key, 'display_name': display_name})
+
+    return web.json_response({"key": ticket_key, "url": ticket_url})
+
+@routes.get("/api/jira/issue/{issue_key}")
+async def get_jira_issue_details(request):
+    await get_proxy_user(request)
+
+    if not jira_api_token or not jira_user_email:
+        raise web.HTTPServiceUnavailable(reason="Jira integration is not configured")
+
+    issue_key = request.match_info.get('issue_key')
+    if not re.match(r'^[A-Z][A-Z0-9]+-\d+$', issue_key):
+        raise web.HTTPBadRequest(reason="Invalid Jira issue key format")
+
+    credentials = base64.b64encode(f"{jira_user_email}:{jira_api_token}".encode()).decode()
+    headers = {
+        "Authorization": f"Basic {credentials}",
+    }
+
+    async with aiohttp.ClientSession() as http_session:
+        async with http_session.get(
+            f"{jira_base_url}/rest/api/3/issue/{issue_key}?fields=assignee,status",
+            headers=headers,
+        ) as issue_resp:
+            if issue_resp.status == 404:
+                raise web.HTTPNotFound(reason=f"Jira issue {issue_key} not found")
+            if issue_resp.status != 200:
+                error_body = await issue_resp.text()
+                logging.error(f"Jira API error fetching issue ({issue_resp.status}): {error_body}")
+                raise web.HTTPBadGateway(reason=f"Failed to fetch Jira issue: {issue_resp.status}")
+            issue_data = await issue_resp.json()
+
+        async with http_session.get(
+            f"{jira_base_url}/rest/api/3/issue/{issue_key}/comment?orderBy=-created",
+            headers=headers,
+        ) as comments_resp:
+            if comments_resp.status != 200:
+                error_body = await comments_resp.text()
+                logging.error(f"Jira API error fetching comments ({comments_resp.status}): {error_body}")
+                raise web.HTTPBadGateway(reason=f"Failed to fetch Jira comments: {comments_resp.status}")
+            comments_data = await comments_resp.json()
+
+    assignee_field = issue_data.get('fields', {}).get('assignee')
+    status_field = issue_data.get('fields', {}).get('status')
+    assignee = None
+    if assignee_field:
+        assignee = {
+            "displayName": assignee_field.get('displayName'),
+            "emailAddress": assignee_field.get('emailAddress'),
+        }
+
+    comments = []
+    for comment in comments_data.get('comments', []):
+        body_content = comment.get('body', {}).get('content', [])
+        body_text = ''
+        for block in body_content:
+            for inline in block.get('content', []):
+                if inline.get('type') == 'text':
+                    body_text += inline.get('text', '')
+        comments.append({
+            "author": comment.get('author', {}).get('displayName'),
+            "body": body_text,
+            "created": comment.get('created'),
+            "updated": comment.get('updated'),
+        })
+
+    return web.json_response({
+        "key": issue_key,
+        "assignee": assignee,
+        "status": status_field.get('name') if status_field else None,
+        "comments": comments,
+    })
 
 @routes.get("/api/usage-cost/request/{request_id}")
 async def usage_cost_request(request):

--- a/catalog/helm/templates/_helpers.tpl
+++ b/catalog/helm/templates/_helpers.tpl
@@ -234,3 +234,10 @@ Shared Cluster Manager secret name
 {{- define "babylonCatalog.sharedClusterManagerSecretName" -}}
   {{- .Values.sharedClusterManager.secretName }}
 {{- end -}}
+
+{{/*
+Jira secret name
+*/}}
+{{- define "babylonCatalog.jiraSecretName" -}}
+  {{- .Values.jira.secretName | default "babylon-catalog-jira" }}
+{{- end -}}

--- a/catalog/helm/templates/api/deployment.yaml
+++ b/catalog/helm/templates/api/deployment.yaml
@@ -56,6 +56,28 @@ spec:
             secretKeyRef:
               name: {{ include "babylonCatalog.sharedClusterManagerSecretName" . }}
               key: shared-cluster-manager-token
+        {{- if .Values.jira.deploy }}
+        - name: JIRA_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "babylonCatalog.jiraSecretName" . }}
+              key: jira-api-token
+        - name: JIRA_USER_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "babylonCatalog.jiraSecretName" . }}
+              key: jira-user-email
+        - name: JIRA_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "babylonCatalog.jiraSecretName" . }}
+              key: jira-base-url
+        - name: JIRA_PROJECT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "babylonCatalog.jiraSecretName" . }}
+              key: jira-project-key
+        {{- end }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/catalog/helm/templates/api/jira-secret.yaml
+++ b/catalog/helm/templates/api/jira-secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.jira.deploy }}
+apiVersion: bitwarden-k8s-secrets-manager.demo.redhat.com/v1
+kind: BitwardenSyncSecret
+metadata:
+  name: {{ .Values.jira.secretName | default "babylon-catalog-jira" }}
+  namespace: {{ include "babylonCatalog.namespaceName" . }}
+spec:
+  data:
+    jira-api-token:
+      secret: jira_credentials
+      key: api_token
+    jira-user-email:
+      secret: jira_credentials
+      key: user_email
+    jira-base-url:
+      secret: jira_credentials
+      key: base_url
+    jira-project-key:
+      secret: jira_credentials
+      key: project_key
+{{- end }}

--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -131,3 +131,7 @@ sandboxApi:
 sharedClusterManager:
   deploy: true
   secretName: sandbox-api-shared-cluster-manager
+
+jira:
+  deploy: true
+  secretName: babylon-catalog-jira

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
@@ -12,9 +12,9 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import { createWhiteGloveRequest } from '@app/api';
+import { createWhiteGloveRequest, createJiraTicketForWgr, patchWhiteGloveRequest } from '@app/api';
 import { CatalogItem, SalesforceItem } from '@app/types';
-import { displayName } from '@app/util';
+import { DEMO_DOMAIN, displayName } from '@app/util';
 import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
 import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
 import DateTimePicker from '@app/components/DateTimePicker';
@@ -61,7 +61,7 @@ const WhiteGloveCreateContent: React.FC = () => {
     setSubmitError(null);
 
     try {
-      const result = await createWhiteGloveRequest({
+      const wgrData = {
         catalogItemName: selectedCatalogItem.metadata.name,
         catalogItemNamespace: selectedCatalogItem.metadata.namespace,
         displayName: eventName,
@@ -73,8 +73,29 @@ const WhiteGloveCreateContent: React.FC = () => {
         eventEndDate: eventEndDate.toISOString(),
         notes: notes || undefined,
         salesforceItems: salesforceItems.length > 0 ? salesforceItems : undefined,
+      };
+      const result = await createWhiteGloveRequest({
+        ...wgrData,
         namespace: userNamespace.name,
       });
+
+      try {
+        const jiraTicket = await createJiraTicketForWgr(wgrData);
+        await patchWhiteGloveRequest({
+          name: result.metadata.name,
+          namespace: result.metadata.namespace,
+          patch: {
+            metadata: {
+              annotations: {
+                [`${DEMO_DOMAIN}/jira-ticket-id`]: jiraTicket.key,
+                [`${DEMO_DOMAIN}/jira-ticket-url`]: jiraTicket.url,
+              },
+            },
+          },
+        });
+      } catch (jiraError) {
+        console.warn('Failed to create Jira ticket for WGR:', jiraError);
+      }
 
       navigate(`/white-glove/${result.metadata.namespace}/${result.metadata.name}`);
     } catch (error) {

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveDetail.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveDetail.tsx
@@ -29,7 +29,7 @@ import { Modal as PFModal, ModalBody as PFModalBody, ModalFooter as PFModalFoote
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ClockIcon from '@patternfly/react-icons/dist/js/icons/clock-icon';
-import { apiPaths, fetcher, patchWhiteGloveRequest } from '@app/api';
+import { apiPaths, fetcher, patchWhiteGloveRequest, silentFetcher } from '@app/api';
 import useDebounce from '@app/utils/useDebounce';
 import { WhiteGloveRequest } from '@app/types';
 import { BABYLON_DOMAIN, DEMO_DOMAIN } from '@app/util';
@@ -91,7 +91,6 @@ const WhiteGloveDetailContent: React.FC = () => {
   const { namespace, name } = useParams();
   const { isAdmin } = useSession().getSession();
   const [activeTab, setActiveTab] = useState<string>('details');
-  const [comment, setComment] = useState('');
   const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
   const [slackChannel, setSlackChannel] = useState('');
@@ -100,6 +99,14 @@ const WhiteGloveDetailContent: React.FC = () => {
     namespace && name ? apiPaths.WHITE_GLOVE_REQUEST({ namespace, name }) : null,
     fetcher,
     { refreshInterval: 8000 },
+  );
+
+  const jiraTicketId = wgr?.metadata?.annotations?.[`${DEMO_DOMAIN}/jira-ticket-id`];
+
+  const { data: jiraData } = useSWR(
+    jiraTicketId ? apiPaths.JIRA_ISSUE({ issueKey: jiraTicketId }) : null,
+    silentFetcher,
+    { refreshInterval: 30000 },
   );
 
   if (!wgr) {
@@ -116,9 +123,11 @@ const WhiteGloveDetailContent: React.FC = () => {
   const requester = ann[`${DEMO_DOMAIN}/requester`]
     || ann[`${BABYLON_DOMAIN}/created-by`]
     || '—';
-  const jiraTicketId = ann[`${DEMO_DOMAIN}/jira-ticket-id`];
   const jiraTicketUrl = ann[`${DEMO_DOMAIN}/jira-ticket-url`];
-  const assignee = ann[`${DEMO_DOMAIN}/assignee`];
+  const jiraAssignee = jiraData?.assignee;
+  const jiraStatus = jiraData?.status;
+  const jiraComments = jiraData?.comments || [];
+  const assignee = jiraAssignee?.displayName || ann[`${DEMO_DOMAIN}/assignee`];
   const serviceName = ann[`${DEMO_DOMAIN}/service-name`];
   const serviceNamespace = ann[`${DEMO_DOMAIN}/service-namespace`];
   const serviceType = ann[`${DEMO_DOMAIN}/service-type`] || 'services';
@@ -186,6 +195,9 @@ const WhiteGloveDetailContent: React.FC = () => {
                 <a href={jiraTicketUrl || '#'} target="_blank" rel="noopener noreferrer" className="wg-jira-link">
                   {jiraTicketId} &#8599;
                 </a>
+                {jiraStatus && (
+                  <span className="wg-jira-status">{jiraStatus}</span>
+                )}
               </SplitItem>
             )}
           </Split>
@@ -396,24 +408,28 @@ const WhiteGloveDetailContent: React.FC = () => {
               </DescriptionList>
             ) : null}
           </Tab>
-          <Tab eventKey="activity" title={<TabTitleText>Activity</TabTitleText>}>
+          <Tab eventKey="activity" title={<TabTitleText>Activity ({jiraComments.length})</TabTitleText>}>
             {activeTab === 'activity' ? (
               <div style={{ marginTop: '16px' }}>
-                <div className="wg-comment-input">
-                  <TextArea
-                    id="activity-comment"
-                    value={comment}
-                    onChange={(_, value) => setComment(value)}
-                    placeholder="Add a comment... (synced with Jira)"
-                    rows={2}
-                  />
-                  <div className="wg-comment-input__actions">
-                    <Button variant="primary" size="sm" isDisabled={!comment.trim()}>Send</Button>
+                {jiraComments.length > 0 ? (
+                  <div className="wg-comments-list">
+                    {jiraComments.map((c: { author: string; body: string; created: string; updated: string }, i: number) => (
+                      <div key={i} className="wg-comment">
+                        <div className="wg-comment__header">
+                          <strong>{c.author}</strong>
+                          <span className="wg-comment__time">
+                            <LocalTimestamp timestamp={c.created} />
+                          </span>
+                        </div>
+                        <div className="wg-comment__body">{c.body}</div>
+                      </div>
+                    ))}
                   </div>
-                </div>
-                <p style={{ color: 'var(--pf-t--global--text--color--subtle)', fontStyle: 'italic' }}>
-                  Activity feed will sync with Jira comments.
-                </p>
+                ) : (
+                  <p style={{ color: 'var(--pf-t--global--text--color--subtle)', fontStyle: 'italic' }}>
+                    No comments yet. Comments added in Jira will appear here.
+                  </p>
+                )}
               </div>
             ) : null}
           </Tab>

--- a/catalog/ui/src/app/WhiteGlove/white-glove.css
+++ b/catalog/ui/src/app/WhiteGlove/white-glove.css
@@ -123,3 +123,42 @@
   border-radius: 10px;
   margin-left: 6px;
 }
+
+/* ── Jira Status Badge ── */
+.wg-jira-status {
+  display: inline-block;
+  margin-top: var(--pf-t--global--spacer--xs);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--pf-t--global--text--color--subtle);
+  background-color: var(--pf-t--global--background--color--200, #f0f0f0);
+  border-radius: 10px;
+  padding: 2px 8px;
+}
+
+/* ── Jira Comments List ── */
+.wg-comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--md);
+}
+.wg-comment {
+  border: 1px solid var(--pf-t--global--border--color--default);
+  border-radius: var(--pf-t--global--border--radius--sm);
+  padding: var(--pf-t--global--spacer--md);
+}
+.wg-comment__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--pf-t--global--spacer--sm);
+}
+.wg-comment__time {
+  font-size: 12px;
+  color: var(--pf-t--global--text--color--subtle);
+}
+.wg-comment__body {
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -1644,6 +1644,27 @@ export async function deleteWhiteGloveRequest(wgr: WhiteGloveRequest) {
   return await deleteK8sObject(wgr);
 }
 
+export async function createJiraTicketForWgr(data: {
+  displayName: string;
+  catalogItemName: string;
+  catalogItemNamespace: string;
+  activity?: string;
+  purpose?: string;
+  explanation?: string;
+  numberOfUsers?: number;
+  eventDate?: string;
+  eventEndDate?: string;
+  notes?: string;
+  salesforceItems?: Array<{ id: string; type: string }>;
+}): Promise<{ key: string; url: string }> {
+  const response = await apiFetch('/api/jira/wgr', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return response.json();
+}
+
 export async function createWorkshopFromAssetWithRetry({
   multiworkshopName,
   multiworkshopUid,
@@ -2735,6 +2756,7 @@ export const apiPaths = {
     `/apis/${BABYLON_DOMAIN}/v1${namespace ? `/namespaces/${namespace}` : ''}/workshops?${
       limit ? `limit=${limit}` : ''
     }${continueId ? `&continue=${continueId}` : ''}`,
+  JIRA_ISSUE: ({ issueKey }: { issueKey: string }) => `/api/jira/issue/${issueKey}`,
   WHITE_GLOVE_REQUEST: ({ namespace, name }: { namespace: string; name: string }) =>
     `/apis/${BABYLON_DOMAIN}/v1/namespaces/${namespace}/whitegloverequests/${name}`,
   WHITE_GLOVE_REQUESTS: ({


### PR DESCRIPTION
Automatically create a Jira Task in RHDPSPPT when a user submits a White Glove Request, and display the ticket assignee, status, and comments on the WGR detail page.

Backend:
- POST /api/jira/wgr creates Jira ticket with WGR data, sets reporter
- GET /api/jira/issue/{key} returns assignee, status, and comments
- Jira credentials sourced from env vars via BitwardenSyncSecret

Helm:
- BitwardenSyncSecret template for jira_credentials secret
- Deployment updated to inject JIRA_API_TOKEN, JIRA_USER_EMAIL, JIRA_BASE_URL, JIRA_PROJECT_KEY from synced secret

Frontend:
- createJiraTicketForWgr() calls backend after WGR creation
- WGR patched with jira-ticket-id/url annotations on success
- Detail page fetches Jira data and shows status badge, assignee, and comments in the Activity tab