### PR TITLE
fix: resolve circular import between selfpacedlab and serviceaccessconfig

### DIFF
--- a/service-access-manager/operator/serviceaccessconfig.py
+++ b/service-access-manager/operator/serviceaccessconfig.py
@@ -2,7 +2,7 @@ from kubernetes_asyncio.client import ApiException as k8sApiException
 
 from babylon import Babylon
 from resourceclaim import ResourceClaim
-from selfpacedlab import SelfPacedLab
+import selfpacedlab
 from workshop import Workshop
 from workshopprovision import WorkshopProvision
 from workshopuserassignment import WorkshopUserAssignment
@@ -92,7 +92,7 @@ class ServiceAccessConfig(KopfObject):
     async def __handle_delete_kind_self_paced_lab(self, logger):
         """Handle cleanup of SelfPacedLab on delete of ServiceAccessConfig."""
         try:
-            self_paced_lab = await SelfPacedLab.fetch(
+            self_paced_lab = await selfpacedlab.SelfPacedLab.fetch(
                 name=self.object_name,
                 namespace=self.namespace,
             )
@@ -224,7 +224,7 @@ class ServiceAccessConfig(KopfObject):
 
     async def __manage_self_paced_lab_access(self, logger):
         try:
-            self_paced_lab = await SelfPacedLab.fetch(
+            self_paced_lab = await selfpacedlab.SelfPacedLab.fetch(
                 name=self.object_name,
                 namespace=self.namespace,
             )


### PR DESCRIPTION
## Summary
- Fixed `ImportError: cannot import name 'SelfPacedLab' from partially initialized module 'selfpacedlab' (most likely due to a circular import)` that prevented the service-access-manager operator from starting.
- Changed `serviceaccessconfig.py` to use `import selfpacedlab` (module import) instead of `from selfpacedlab import SelfPacedLab` (name import), deferring class attribute access to call time when both modules are fully loaded.
- This mirrors the pattern `selfpacedlab.py` already uses for its `import serviceaccessconfig`.

## Test plan
- [ ] Verify the operator starts without `ImportError`
- [ ] Verify SelfPacedLab delete handling still works (triggers `ServiceAccessConfig` cleanup)
- [ ] Verify ServiceAccessConfig management of SelfPacedLab access still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)