### PR TITLE
fix: add selfpacedlabs to service-access-manager ClusterRole

### DIFF
--- a/helm/templates/serviceAccessManager/clusterrole.yaml
+++ b/helm/templates/serviceAccessManager/clusterrole.yaml
@@ -52,6 +52,7 @@ rules:
   - {{ .Values.workshopManager.api.group }}
   resources:
   - multiworkshops
+  - selfpacedlabs
   - serviceaccessconfigs
   - workshops
   - workshops/status


### PR DESCRIPTION
The service-access-manager operator watches selfpacedlabs events via kopf but its ClusterRole was missing the selfpacedlabs resource, causing 403 Forbidden errors at cluster scope.