### PR TITLE
fix: display shared SelfPacedLabs in services list

### DIFF
--- a/catalog/ui/src/app/Services/ServicesList.tsx
+++ b/catalog/ui/src/app/Services/ServicesList.tsx
@@ -121,6 +121,20 @@ async function fetchServices(namespace: string): Promise<Service[]> {
           };
 
           sharedServices.push(resourceClaimWithCollaborator);
+        } else if (serviceAccess.spec.kind === 'SelfPacedLab') {
+          const selfPacedLab = (await fetcher(
+            apiPaths.SELF_PACED_LAB({
+              namespace: serviceAccess.spec.namespace,
+              selfPacedLabName: serviceAccess.spec.name,
+            }),
+          )) as SelfPacedLab;
+
+          const selfPacedLabWithCollaborator: SelfPacedLabWithResourceClaims = {
+            ...selfPacedLab,
+            isCollaborator: true,
+          };
+
+          sharedServices.push(selfPacedLabWithCollaborator);
         }
       } catch (error) {
         console.warn(`Failed to fetch shared ${serviceAccess.spec.kind} ${serviceAccess.spec.namespace}/${serviceAccess.spec.name}:`, error);

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -943,6 +943,7 @@ export type WorkshopWithResourceClaims = Workshop & {
 };
 export type SelfPacedLabWithResourceClaims = SelfPacedLab & {
   resourceClaims?: ResourceClaim[];
+  isCollaborator?: boolean;
 };
 export type Service = ResourceClaimWithCollaborator | WorkshopWithResourceClaims | SelfPacedLabWithResourceClaims;
 


### PR DESCRIPTION
fetchSharedServices() only handled Workshop and ResourceClaim kinds from ServiceAccess objects, silently skipping SelfPacedLab entries.