### PR TITLE
Add capacity utilization indicators to Tenant Cluster Pools admin page

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -7,6 +7,7 @@ import {
   Split,
   SplitItem,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
@@ -190,6 +191,7 @@ const TenantClusterPools: React.FC = () => {
                   <th style={{ width: '28px' }}></th>
                   <th>Name</th>
                   <th>Clusters</th>
+                  <th>Capacity</th>
                   <th>Placements</th>
                   <th>Sandbox API State</th>
                   <th>Created At</th>
@@ -202,6 +204,8 @@ const TenantClusterPools: React.FC = () => {
                   const clusters = pool.status?.clusters || [];
                   const clusterCount = clusters.length;
                   const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
+                  const utilizationPercent = clusterCount > 0 ? Math.round(((clusterCount - availableCount) / clusterCount) * 100) : 0;
+                  const capacityColor: 'green' | 'orange' | 'red' = utilizationPercent < 70 ? 'green' : utilizationPercent < 90 ? 'orange' : 'red';
 
                   return (
                     <React.Fragment key={poolKey}>
@@ -228,6 +232,13 @@ const TenantClusterPools: React.FC = () => {
                           </Label>
                         </td>
                         <td>{availableCount} / {clusterCount} available</td>
+                        <td>
+                          <Tooltip content={`${utilizationPercent}% utilized — ${clusterCount - availableCount} in use, ${availableCount} available`}>
+                            <Label isCompact color={capacityColor}>
+                              {utilizationPercent}%
+                            </Label>
+                          </Tooltip>
+                        </td>
                         <td></td>
                         <td></td>
                         <td>


### PR DESCRIPTION
## Summary
Add color-coded capacity percentage indicators following the established tenant cluster visibility pattern (green <70%, orange 70-90%, red >90%).

## Changes
- Add "Capacity" column to tenant pools table
- Calculate utilization percentage: `(total - available) / total * 100`
- Display percentage with color-coded PatternFly Label
- Tooltip shows breakdown: "X% utilized — Y in use, Z available"
- Consistent with Babylon ops admin capacity pattern

## Screenshot
| Before | After |
|--------|-------|
| Shows "X / Y available" only | Shows "X / Y available" + color-coded capacity % |

## Testing
- [x] TypeScript compilation: ✅ Passing
- [ ] UI tests: Not run yet (draft)
- [ ] Visual testing needed: Please review in dev environment

## Safety Considerations
- Admin-only page (not user-facing catalog)
- Read-only display (no writes to cluster state)
- Graceful with missing data (uses || [] for cluster status)
- Color thresholds match established pattern

## Related
- Pattern documentation: https://redhat.atlassian.net/wiki/x/n4TTGg
- Babylon ops PR: https://github.com/redhat-cop/babylon/pull/3644
- Flow PR: https://github.com/rhpds/rhpds-utils/pull/174
- Labugator PR: https://github.com/rhpds/labagator/pull/29
- **RHDPOPS-24147**
- **GPTEINFRA-17664**

## Reviewers
@aleixhub Please review for sensitivity concerns and UX appropriateness for cluster admins.

---

**Note:** The pattern has been implemented across RHDP-Flow and Labugator. This PR was rebased to remove duplicate commits from #3644 (merged).