### PR TITLE
fix: display Shared Service tag for collaborator SelfPacedLabs

### DIFF
--- a/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
+++ b/catalog/ui/src/app/SelfPacedLabs/SelfPacedLabItem.tsx
@@ -119,6 +119,7 @@ const SelfPacedLabItemComponent: React.FC<{
   const location = useLocation();
   const { cache } = useSWRConfig();
   const { isAdmin, serviceNamespaces: sessionServiceNamespaces } = useSession().getSession();
+  const isCollaborator = !isAdmin && !sessionServiceNamespaces.some((ns) => ns.name === serviceNamespaceName);
   const { sfdc_enabled } = useInterfaceConfig();
   const [modalDelete, openModalDelete] = useModal();
   const [modalSchedule, openModalSchedule] = useModal();
@@ -554,6 +555,11 @@ const SelfPacedLabItemComponent: React.FC<{
             </Breadcrumb>
             <Title headingLevel="h4" size="xl" style={{ display: 'flex', alignItems: 'center' }}>
               {displayName(selfPacedLab)}
+              {isCollaborator ? (
+                <Label key="selfpacedlab-item__collaborator" tooltipDescription={<div>You have been granted access to this self-paced lab as a collaborator</div>}>
+                  Shared Service
+                </Label>
+              ) : null}
               {stage !== 'prod' ? <Label key="selfpacedlab-item__stage">{stage}</Label> : null}
               <Label key="selfpacedlab-item__type" tooltipDescription={<div>Self-paced lab with warm pool</div>}>
                 Self-Paced Lab

--- a/catalog/ui/src/app/Services/ServicesList.tsx
+++ b/catalog/ui/src/app/Services/ServicesList.tsx
@@ -792,7 +792,7 @@ const ServicesList: React.FC<{
               if (service.kind === 'SelfPacedLab') {
                 return Object.assign(
                   selectObj,
-                  renderSelfPacedLabRow({ selfPacedLab: service as SelfPacedLab, showModal, isAdmin }),
+                  renderSelfPacedLabRow({ selfPacedLab: service as SelfPacedLabWithResourceClaims, showModal, isAdmin }),
                 );
               }
               return null;

--- a/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
+++ b/catalog/ui/src/app/Services/renderSelfPacedLabRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SelfPacedLab, ServiceActionActions } from '@app/types';
+import { SelfPacedLabWithResourceClaims, ServiceActionActions } from '@app/types';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { displayName, getStageFromK8sObject } from '@app/util';
@@ -16,7 +16,7 @@ const renderSelfPacedLabRow = ({
   showModal,
   isAdmin,
 }: {
-  selfPacedLab: SelfPacedLab;
+  selfPacedLab: SelfPacedLabWithResourceClaims;
   showModal: ({
     modal,
     action,
@@ -24,7 +24,7 @@ const renderSelfPacedLabRow = ({
   }: {
     modal: string;
     action?: ServiceActionActions;
-    selfPacedLab?: SelfPacedLab;
+    selfPacedLab?: SelfPacedLabWithResourceClaims;
   }) => void;
   isAdmin: boolean;
 }) => {
@@ -46,6 +46,11 @@ const renderSelfPacedLabRow = ({
       >
         {displayName(selfPacedLab)}
       </Link>
+      {selfPacedLab.isCollaborator ? (
+        <Label key="selfpacedlab-name__collaborator" tooltipDescription={<div>You have been granted access to this self-paced lab as a collaborator</div>}>
+          Shared Service
+        </Label>
+      ) : null}
       {stage !== 'prod' ? <Label key="selfpacedlab-name__stage">{stage}</Label> : null}
       <Label key="selfpacedlab-name__type" tooltipDescription={<div>Self-paced lab with warm pool of pre-provisioned instances</div>}>
         Self-Paced Lab
@@ -95,6 +100,7 @@ const renderSelfPacedLabRow = ({
           onClick={actionHandlers.delete}
           description="Delete"
           icon={TrashIcon}
+          isDisabled={selfPacedLab.isCollaborator}
         />
       </div>
     </React.Fragment>


### PR DESCRIPTION
ResourceClaims and Workshops already showed a "Shared Service" label and disabled the delete button for collaborators, but SelfPacedLabs were missing this treatment despite the isCollaborator flag being set correctly in ServicesList.