### PR TITLE
Add placement capacity metric to Ops admin UI

### DIFF
--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -589,12 +589,13 @@ const Ops: React.FC = () => {
 
   // Build lookup map: resourceClaimName → { poolName, poolNamespace, clusterName, capacity }
   const tenantClusterLookup = useMemo(() => {
-    const map = new Map<string, { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number }>();
+    const map = new Map<string, { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; maxPlacements: number }>();
     if (allTcpData?.items) {
       for (const pool of allTcpData.items) {
         if (pool.status?.clusters) {
           const totalClusters = pool.status.clusters.length;
           const availableClusters = pool.status.clusters.filter(c => c.sandboxApiState === 'available').length;
+          const maxPlacements = pool.spec?.sandboxHost?.max_placements || 50;
 
           for (const cluster of pool.status.clusters) {
             if (cluster.resourceClaimName) {
@@ -604,6 +605,7 @@ const Ops: React.FC = () => {
                 clusterName: cluster.name || 'unknown',
                 totalClusters,
                 availableClusters,
+                maxPlacements,
               });
             }
           }
@@ -713,22 +715,42 @@ const Ops: React.FC = () => {
   }, [workshops, allRcData]);
 
   // Helper to get full tenant cluster info for a workshop
-  const getWorkshopClusterInfo = useCallback((ws: WorkshopWithResourceClaims): { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; utilizationPercent: number } | null => {
+  const getWorkshopClusterInfo = useCallback((ws: WorkshopWithResourceClaims): { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null => {
     const rcs = ws.resourceClaims || [];
     for (const rc of rcs) {
       const handleName = rc.status?.resourceHandle?.name;
       if (handleName) {
         const cluster = tenantClusterLookup.get(handleName);
         if (cluster) {
-          const utilizationPercent = cluster.totalClusters > 0
+          // Pool saturation (cluster allocation)
+          const poolSaturationPercent = cluster.totalClusters > 0
             ? Math.round(((cluster.totalClusters - cluster.availableClusters) / cluster.totalClusters) * 100)
             : 0;
-          return { ...cluster, utilizationPercent };
+
+          // Placement capacity (workshop slots)
+          // Count workshops on this cluster by checking all workshops for matching cluster
+          const placementCount = workshops.filter(w => {
+            const wRcs = w.resourceClaims || [];
+            return wRcs.some(wRc => wRc.status?.resourceHandle?.name === handleName);
+          }).length;
+
+          const maxTotalPlacements = cluster.totalClusters * cluster.maxPlacements;
+          const placementCapacityPercent = maxTotalPlacements > 0
+            ? Math.round((placementCount / maxTotalPlacements) * 100)
+            : 0;
+
+          return {
+            ...cluster,
+            poolSaturationPercent,
+            placementCount,
+            maxTotalPlacements,
+            placementCapacityPercent,
+          };
         }
       }
     }
     return null;
-  }, [tenantClusterLookup]);
+  }, [tenantClusterLookup, workshops]);
 
   // Helper to get tenant cluster display name for a workshop
   const getWorkshopCluster = useCallback((ws: WorkshopWithResourceClaims): string | null => {

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -714,53 +714,6 @@ const Ops: React.FC = () => {
     return map;
   }, [workshops, allRcData]);
 
-  // Helper to get full tenant cluster info for a workshop
-  const getWorkshopClusterInfo = useCallback((ws: WorkshopWithResourceClaims): { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null => {
-    const rcs = ws.resourceClaims || [];
-    for (const rc of rcs) {
-      const handleName = rc.status?.resourceHandle?.name;
-      if (handleName) {
-        const cluster = tenantClusterLookup.get(handleName);
-        if (cluster) {
-          // Pool saturation (cluster allocation)
-          const poolSaturationPercent = cluster.totalClusters > 0
-            ? Math.round(((cluster.totalClusters - cluster.availableClusters) / cluster.totalClusters) * 100)
-            : 0;
-
-          // Placement capacity (workshop slots)
-          // Count workshops on this cluster by checking all workshops for matching cluster
-          const placementCount = workshops.filter(w => {
-            const wRcs = w.resourceClaims || [];
-            return wRcs.some(wRc => wRc.status?.resourceHandle?.name === handleName);
-          }).length;
-
-          const maxTotalPlacements = cluster.totalClusters * cluster.maxPlacements;
-          const placementCapacityPercent = maxTotalPlacements > 0
-            ? Math.round((placementCount / maxTotalPlacements) * 100)
-            : 0;
-
-          return {
-            ...cluster,
-            poolSaturationPercent,
-            placementCount,
-            maxTotalPlacements,
-            placementCapacityPercent,
-          };
-        }
-      }
-    }
-    return null;
-  }, [tenantClusterLookup, workshops]);
-
-  // Helper to get tenant cluster display name for a workshop
-  const getWorkshopCluster = useCallback((ws: WorkshopWithResourceClaims): string | null => {
-    const info = getWorkshopClusterInfo(ws);
-    if (!info) return null;
-    // Return short cluster name (truncate prefix if too long)
-    const shortName = info.clusterName.replace(/^tenant-cluster-pool-/, '');
-    return shortName.length > 15 ? shortName.slice(0, 15) + '…' : shortName;
-  }, [getWorkshopClusterInfo]);
-
   const [showPasswords, setShowPasswords] = useState(false);
 
   const isRefreshing = wsValidating || provValidating || assignValidating;
@@ -823,6 +776,53 @@ const Ops: React.FC = () => {
       resourceClaims: resourceClaimsByWorkshop.get(wsKey(ws)) || [],
     } as WorkshopWithResourceClaims));
   }, [workshops, resourceClaimsByWorkshop]);
+
+  // Helper to get full tenant cluster info for a workshop
+  const getWorkshopClusterInfo = useCallback((ws: WorkshopWithResourceClaims): { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null => {
+    const rcs = ws.resourceClaims || [];
+    for (const rc of rcs) {
+      const handleName = rc.status?.resourceHandle?.name;
+      if (handleName) {
+        const cluster = tenantClusterLookup.get(handleName);
+        if (cluster) {
+          // Pool saturation (cluster allocation)
+          const poolSaturationPercent = cluster.totalClusters > 0
+            ? Math.round(((cluster.totalClusters - cluster.availableClusters) / cluster.totalClusters) * 100)
+            : 0;
+
+          // Placement capacity (workshop slots)
+          // Count workshops on this cluster by checking all workshops for matching cluster
+          const placementCount = workshopsWithRc.filter(w => {
+            const wRcs = w.resourceClaims || [];
+            return wRcs.some(wRc => wRc.status?.resourceHandle?.name === handleName);
+          }).length;
+
+          const maxTotalPlacements = cluster.totalClusters * cluster.maxPlacements;
+          const placementCapacityPercent = maxTotalPlacements > 0
+            ? Math.round((placementCount / maxTotalPlacements) * 100)
+            : 0;
+
+          return {
+            ...cluster,
+            poolSaturationPercent,
+            placementCount,
+            maxTotalPlacements,
+            placementCapacityPercent,
+          };
+        }
+      }
+    }
+    return null;
+  }, [tenantClusterLookup, workshopsWithRc]);
+
+  // Helper to get tenant cluster display name for a workshop
+  const getWorkshopCluster = useCallback((ws: WorkshopWithResourceClaims): string | null => {
+    const info = getWorkshopClusterInfo(ws);
+    if (!info) return null;
+    // Return short cluster name (truncate prefix if too long)
+    const shortName = info.clusterName.replace(/^tenant-cluster-pool-/, '');
+    return shortName.length > 15 ? shortName.slice(0, 15) + '…' : shortName;
+  }, [getWorkshopClusterInfo]);
 
   // Base-filtered list: applies white glove, search, and stage filters.
   // Used by regionStats and status counts so chips reflect the visible scope.
@@ -2915,7 +2915,7 @@ const Ops: React.FC = () => {
                       const grpUrls: { id: string; url: string }[] = [];
                       let grpWhiteGlove = 0;
                       const grpClusters = new Set<string>();
-                      let grpClusterInfo: { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; utilizationPercent: number } | null = null;
+                      let grpClusterInfo: { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null = null;
 
                       for (const ws of group.items) {
                         const c = getCurrentCount(ws);
@@ -3067,7 +3067,7 @@ const Ops: React.FC = () => {
                           <td>
                             {grpClusters.size === 1 && grpClusterInfo ? (
                               (() => {
-                                const capacityState = grpClusterInfo.utilizationPercent >= 85 ? 'critical' : grpClusterInfo.utilizationPercent >= 70 ? 'warning' : 'healthy';
+                                const capacityState = grpClusterInfo.placementCapacityPercent >= 85 ? 'critical' : grpClusterInfo.placementCapacityPercent >= 70 ? 'warning' : 'healthy';
                                 const clusterName = Array.from(grpClusters)[0];
                                 return (
                                   <Label
@@ -3156,7 +3156,7 @@ const Ops: React.FC = () => {
                         const assetKey = ws.metadata.labels?.[`${BABYLON_DOMAIN}/asset-key`];
                         const wsClusterName = getWorkshopCluster(ws);
                         const wsClusterInfo = getWorkshopClusterInfo(ws);
-                        const wsCapacityState = wsClusterInfo ? (wsClusterInfo.utilizationPercent >= 85 ? 'critical' : wsClusterInfo.utilizationPercent >= 70 ? 'warning' : 'healthy') : null;
+                        const wsCapacityState = wsClusterInfo ? (wsClusterInfo.placementCapacityPercent >= 85 ? 'critical' : wsClusterInfo.placementCapacityPercent >= 70 ? 'warning' : 'healthy') : null;
 
                         return (
                           <tr key={wsKey(ws)} className={`ops-child-row ${isMultiAsset ? 'ops-asset-row' : ''}`}>

--- a/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
+++ b/catalog/ui/src/app/Admin/Ops/TimelineSwimlane.tsx
@@ -24,7 +24,7 @@ export interface TimelineSwimlaneProps {
   getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
   getCurrentCount: (ws: Workshop) => number | null;
   getCluster?: (ws: Workshop) => string | null;
-  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; utilizationPercent: number } | null;
+  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null;
   multiWorkshopsByName: Map<string, MultiWorkshop>;
   isMultiNs: boolean;
   timezone: string;

--- a/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopBar.tsx
@@ -23,7 +23,7 @@ export interface WorkshopBarProps {
   getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
   getCurrentCount: (ws: Workshop) => number | null;
   getCluster?: (ws: Workshop) => string | null;
-  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; utilizationPercent: number } | null;
+  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null;
   multiWorkshopsByName: Map<string, MultiWorkshop>;
   isMultiNs: boolean;
   timezone: string;
@@ -91,11 +91,12 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
   const clusterName = useMemo(() => getCluster?.(workshop) || null, [getCluster, workshop]);
   const clusterInfo = useMemo(() => getClusterInfo?.(workshop) || null, [getClusterInfo, workshop]);
 
-  // Calculate cluster capacity state (green < 70%, orange 70-85%, red > 85%)
+  // Calculate cluster capacity state using placement capacity as primary metric
+  // (green < 70%, orange 70-90%, red > 90%)
   const capacityState = useMemo(() => {
     if (!clusterInfo) return null;
-    if (clusterInfo.utilizationPercent >= 85) return 'critical';
-    if (clusterInfo.utilizationPercent >= 70) return 'warning';
+    if (clusterInfo.placementCapacityPercent >= 90) return 'critical';
+    if (clusterInfo.placementCapacityPercent >= 70) return 'warning';
     return 'healthy';
   }, [clusterInfo]);
 
@@ -182,12 +183,18 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
           {stage && <tr><td>Stage</td><td>{stage}</td></tr>}
           {clusterName && <tr><td>Tenant Cluster</td><td><code>{clusterName}</code></td></tr>}
           {clusterInfo && (
-            <tr>
-              <td>Cluster Capacity</td>
-              <td className={capacityState === 'critical' ? 'timeline-tooltip-critical' : capacityState === 'warning' ? 'timeline-tooltip-warning' : ''}>
-                {clusterInfo.availableClusters}/{clusterInfo.totalClusters} available ({clusterInfo.utilizationPercent}% utilized)
-              </td>
-            </tr>
+            <>
+              <tr>
+                <td>Pool Saturation</td>
+                <td>{clusterInfo.totalClusters - clusterInfo.availableClusters}/{clusterInfo.totalClusters} clusters occupied ({clusterInfo.poolSaturationPercent}%)</td>
+              </tr>
+              <tr>
+                <td>Placement Capacity</td>
+                <td className={capacityState === 'critical' ? 'timeline-tooltip-critical' : capacityState === 'warning' ? 'timeline-tooltip-warning' : ''}>
+                  {clusterInfo.placementCount}/{clusterInfo.maxTotalPlacements} workshops ({clusterInfo.placementCapacityPercent}% utilized)
+                </td>
+              </tr>
+            </>
           )}
           {isMultiAsset && <tr><td>Type</td><td>Multi-Asset</td></tr>}
           {seats && <tr><td>Seats</td><td>{seats.assigned} / {seats.total} assigned</td></tr>}
@@ -252,7 +259,7 @@ export const WorkshopBar: React.FC<WorkshopBarProps> = ({
           {clusterName && (
             <span
               className={`timeline-bar__badge timeline-bar__badge--cluster${capacityState ? ` timeline-bar__badge--cluster-${capacityState}` : ''}`}
-              title={`Tenant cluster: ${clusterName}${clusterInfo ? ` (${clusterInfo.utilizationPercent}% utilized)` : ''} - click to view`}
+              title={`Tenant cluster: ${clusterName}${clusterInfo ? ` (${clusterInfo.placementCapacityPercent}% capacity)` : ''} - click to view`}
               onClick={handleClusterBadgeClick}
               style={{ cursor: 'pointer' }}
             >

--- a/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
+++ b/catalog/ui/src/app/Admin/Ops/WorkshopTimeline.tsx
@@ -19,7 +19,7 @@ export interface WorkshopTimelineProps {
   getProvisionProgress: (ws: Workshop) => ProvisionProgress | null;
   getCurrentCount: (ws: Workshop) => number | null;
   getCluster?: (ws: Workshop) => string | null;
-  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; utilizationPercent: number } | null;
+  getClusterInfo?: (ws: Workshop) => { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; poolSaturationPercent: number; maxPlacements: number; placementCount: number; maxTotalPlacements: number; placementCapacityPercent: number } | null;
   multiWorkshopsByName: Map<string, MultiWorkshop>;
   isMultiNs: boolean;
   timezone: string;


### PR DESCRIPTION
## Summary
Implement dual-metric capacity tracking for workshop cluster visibility in the Ops admin UI.

## Two Capacity Metrics

We now track **two complementary metrics** for tenant cluster capacity:

### 1. Pool Saturation (existing, renamed)
- **What:** Percentage of clusters that are allocated/occupied
- **Formula:** `(occupied_clusters / total_clusters) * 100`
- **Use case:** Cluster provisioning decisions

### 2. Placement Capacity (new)
- **What:** Percentage of workshop placement slots that are filled
- **Formula:** `(workshops_deployed / (total_clusters × max_placements_per_cluster)) * 100`
- **Use case:** Workshop deployment capacity planning

## Changes

**Ops.tsx:**
- Update `tenantClusterLookup` to include `max_placements` from TenantClusterPool spec
- Calculate placement capacity by counting workshops per cluster
- Update `getWorkshopClusterInfo` return type with new fields:
  - `poolSaturationPercent` (renamed from `utilizationPercent`)
  - `placementCount` (number of workshops on this cluster)
  - `maxTotalPlacements` (totalClusters × maxPlacements)
  - `placementCapacityPercent` (calculated metric)

**WorkshopBar.tsx:**
- Update tooltip to show **both metrics**:
  - Pool Saturation: "X/Y clusters occupied (Z%)"
  - Placement Capacity: "A/B workshops (C% utilized)"
- Use **placement capacity as primary metric** for color coding:
  - Green: <70% utilized
  - Orange: 70-90% utilized
  - Red: >90% utilized

## Example Tooltip

```
Tenant Cluster: example-pool
Pool Saturation: 7/10 clusters occupied (70%)
Placement Capacity: 87/500 workshops (17% utilized)
```

## Testing

- TypeScript compilation clean
- Tooltip displays both metrics correctly
- Color coding uses placement capacity thresholds
- Badge click navigates to TenantClusterPool detail page

## Related

- GPTEINFRA-17588
- Builds on: #3644 (pool saturation only)
- Documentation: https://redhat.atlassian.net/wiki/x/n4TTGg
- Related PRs:
  - Flow: https://github.com/rhpds/rhpds-utils/pull/176
  - Labugator: (in progress)