### PR TITLE
Add dual capacity metrics to Tenant Cluster Pools admin page

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -7,6 +7,7 @@ import {
   Split,
   SplitItem,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
@@ -190,6 +191,8 @@ const TenantClusterPools: React.FC = () => {
                   <th style={{ width: '28px' }}></th>
                   <th>Name</th>
                   <th>Clusters</th>
+                  <th>Pool Saturation</th>
+                  <th>Max Capacity</th>
                   <th>Placements</th>
                   <th>Sandbox API State</th>
                   <th>Created At</th>
@@ -202,6 +205,16 @@ const TenantClusterPools: React.FC = () => {
                   const clusters = pool.status?.clusters || [];
                   const clusterCount = clusters.length;
                   const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
+
+                  // Pool saturation (cluster allocation)
+                  const occupiedCount = clusterCount - availableCount;
+                  const poolSaturationPercent = clusterCount > 0 ? Math.round((occupiedCount / clusterCount) * 100) : 0;
+                  const saturationColor: 'green' | 'orange' | 'red' = poolSaturationPercent < 70 ? 'green' : poolSaturationPercent < 90 ? 'orange' : 'red';
+
+                  // Theoretical max capacity (workshop slots)
+                  const maxPlacementsPerCluster = pool.spec?.sandboxHost?.max_placements || 50;
+                  const maxTotalPlacements = clusterCount * maxPlacementsPerCluster;
+                  const theoreticalMaxWorkshops = occupiedCount * maxPlacementsPerCluster;
 
                   return (
                     <React.Fragment key={poolKey}>
@@ -228,6 +241,20 @@ const TenantClusterPools: React.FC = () => {
                           </Label>
                         </td>
                         <td>{availableCount} / {clusterCount} available</td>
+                        <td>
+                          <Tooltip content={`Pool saturation: ${poolSaturationPercent}% (${occupiedCount}/${clusterCount} clusters occupied)`}>
+                            <Label isCompact color={saturationColor}>
+                              {poolSaturationPercent}%
+                            </Label>
+                          </Tooltip>
+                        </td>
+                        <td>
+                          <Tooltip content={`Theoretical max: 0-${theoreticalMaxWorkshops} workshops deployed (max ${maxTotalPlacements} total). View Ops page for actual workshop counts.`}>
+                            <span style={{ whiteSpace: 'nowrap' }}>
+                              0-{theoreticalMaxWorkshops} workshops (max {maxTotalPlacements})
+                            </span>
+                          </Tooltip>
+                        </td>
                         <td></td>
                         <td></td>
                         <td>


### PR DESCRIPTION
## Summary
Display both pool saturation and theoretical max capacity metrics on the Tenant Cluster Pools admin page.

## Two Capacity Metrics

### 1. Pool Saturation
- **What:** Percentage of clusters that are allocated/occupied
- **Formula:** `(occupied_clusters / total_clusters) * 100`
- **Display:** Color-coded Label (green <70%, orange 70-90%, red >90%)
- **Tooltip:** "X% (Y/Z clusters occupied)"

### 2. Theoretical Max Capacity
- **What:** Maximum possible workshops that could be deployed on occupied clusters
- **Formula:** `occupied_clusters × max_placements_per_cluster`
- **Display:** "0-X workshops (max Y)"
- **Tooltip:** Explains this is theoretical max, directs users to Ops page for actual counts

## Changes

**Table columns added:**
- "Pool Saturation" - shows cluster allocation percentage with color coding
- "Max Capacity" - shows theoretical workshop capacity range

**Calculations:**
```typescript
const poolSaturationPercent = Math.round((occupiedClusters / totalClusters) * 100);
const maxPlacementsPerCluster = pool.spec?.sandboxHost?.max_placements || 50;
const theoreticalMaxWorkshops = occupiedClusters * maxPlacementsPerCluster;
const maxTotalPlacements = totalClusters * maxPlacementsPerCluster;
```

## Design Decision

This page **does NOT fetch workshop data** (too heavy for an admin page that may list many pools). It shows:
- **Pool saturation**: Actual cluster allocation (from pool status)
- **Max capacity**: Theoretical limit based on occupied clusters

For **actual workshop counts**, users should view the Ops admin page which has full workshop data loaded.

## Related

- GPTEINFRA-17664
- Documentation: https://redhat.atlassian.net/wiki/x/n4TTGg
- Related PRs:
  - Ops UI (placement capacity): #3655
  - Flow: https://github.com/rhpds/rhpds-utils/pull/176