### PR TITLE
GPTEINFRA-17314: Add tooltip to Share Service With field in white glove request form

### DIFF
--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
@@ -388,7 +388,17 @@ const WhiteGloveCreateContent: React.FC = () => {
             </Select>
           </FormGroup>
 
-          <FormGroup label="Share Service With" fieldId="share-with">
+          <FormGroup
+            label={
+              <>
+                Share Service With{' '}
+                <Tooltip content="Grant other users access to this service by adding their email addresses.">
+                  <OutlinedQuestionCircleIcon className="tooltip-icon-only" />
+                </Tooltip>
+              </>
+            }
+            fieldId="share-with"
+          >
             <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
               <TextInput
                 id="share-with"


### PR DESCRIPTION
Adds a help tooltip explaining what the Share Service With field does, consistent with existing tooltips on Number of Users, Event Delivery Mode, and Audience Type fields.