### PR TITLE
GPTEINFRA-17314 White glove: UX improvements and open to all users

### DIFF
--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -101,7 +101,7 @@ const Navigation: React.FC = () => {
     </NavItem>
   ) : null;
 
-  const whiteGloveNavigation = userNamespace && isAdmin ? (
+  const whiteGloveNavigation = userNamespace ? (
     <NavItem>
       <NavLink
         to="/white-glove"

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
@@ -388,7 +388,17 @@ const WhiteGloveCreateContent: React.FC = () => {
             </Select>
           </FormGroup>
 
-          <FormGroup label="Share Service With" fieldId="share-with">
+          <FormGroup
+            label={
+              <>
+                Share Service With{' '}
+                <Tooltip content="Grant other users access to this service by adding their email addresses.">
+                  <OutlinedQuestionCircleIcon className="tooltip-icon-only" />
+                </Tooltip>
+              </>
+            }
+            fieldId="share-with"
+          >
             <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
               <TextInput
                 id="share-with"

--- a/catalog/ui/src/app/components/CatalogItemSelectorModal.tsx
+++ b/catalog/ui/src/app/components/CatalogItemSelectorModal.tsx
@@ -39,6 +39,7 @@ import {
   getSLABadgeClass,
   formatString,
   CUSTOM_LABELS,
+  SLAs,
 } from '@app/Catalog/catalog-utils';
 import StarRating from '@app/components/StarRating';
 import StatusPageIcons from '@app/components/StatusPageIcons';
@@ -264,7 +265,10 @@ const CategorySelectorContent: React.FC<{
   );
 
   const catalogItems: CatalogItem[] = useMemo(
-    () => filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin),
+    () =>
+      filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin).filter(
+        (item) => !item.spec.workshopUiDisabled && getSLA(item) !== SLAs.Unsupported,
+      ),
     [catalogItemsArr, isAdmin],
   );
 
@@ -302,7 +306,10 @@ const CatalogItemsContent: React.FC<{
   );
 
   const allowedCatalogItems = useMemo(
-    () => filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin),
+    () =>
+      filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin).filter(
+        (item) => !item.spec.workshopUiDisabled && getSLA(item) !== SLAs.Unsupported,
+      ),
     [catalogItemsArr, isAdmin],
   );
 


### PR DESCRIPTION
## Summary
- **Open navigation to all users**: White Glove Requests menu entry is now visible to all authenticated users, not just admins (admin-only list at /admin/white-glove-requests remains unchanged)
- **Filter catalog items in selector**: Hide items with workshopUiDisabled: true and SLA label Unsupported from the catalog item selector modal
- **Add tooltip to Share Service With**: Help icon explaining the field purpose, consistent with other form field tooltips

## Test plan
- [x] Log in as a non-admin user and verify the White Glove Requests nav entry is visible
- [x] Open the white glove request form and verify workshopUiDisabled items are hidden from the catalog selector
- [ ] Verify items with SLA label Unsupported are hidden from the catalog selector
- [ ] Verify items with SLA Featured still appear in the selector
- [x] Hover over the Share Service With tooltip icon and confirm it displays correctly
- [x] Verify the admin White Glove Requests list at /admin/white-glove-requests is still admin-only