### PR TITLE
GPTEINFRA-15063 Fix Jira ticket, version bump, workshop status

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -983,15 +983,26 @@ async def create_jira_wgr_ticket(request):
     display_name = data.get('displayName', 'White Glove Request')
     requester = user['metadata']['name']
 
+    catalog_item_names_list = data.get('catalogItemNames') or []
+    catalog_namespace = data.get('catalogItemNamespace', '')
+    if catalog_item_names_list:
+        catalog_items_str = ', '.join(f"{catalog_namespace}/{name}" for name in catalog_item_names_list)
+    else:
+        catalog_items_str = 'N/A (consultation)'
+
     description_lines = [
         f"Requester: {requester}",
-        f"Catalog Item: {data.get('catalogItemNamespace', '')}/{data.get('catalogItemName', '')}",
+        f"Catalog Item: {catalog_items_str}",
         f"Activity: {data.get('activity', 'N/A')}",
         f"Purpose: {data.get('purpose', 'N/A')}",
     ]
     if data.get('explanation'):
         description_lines.append(f"Explanation: {data['explanation']}")
     description_lines.append(f"Number of Users: {data.get('numberOfUsers', 'N/A')}")
+    if data.get('deliveryMode'):
+        description_lines.append(f"Delivery Mode: {data['deliveryMode']}")
+    if data.get('audienceType'):
+        description_lines.append(f"Audience Type: {data['audienceType']}")
     if data.get('eventDate'):
         description_lines.append(f"Event Start: {data['eventDate']}")
     if data.get('eventEndDate'):
@@ -999,16 +1010,17 @@ async def create_jira_wgr_ticket(request):
     if data.get('salesforceItems'):
         sf_ids = ', '.join(f"{item['type']}: {item['id']}" for item in data['salesforceItems'])
         description_lines.append(f"Salesforce IDs: {sf_ids}")
+    if data.get('shareWith'):
+        description_lines.append(f"Shared With: {', '.join(data['shareWith'])}")
     if data.get('notes'):
         description_lines.append(f"\nNotes:\n{data['notes']}")
 
     description_text = '\n'.join(description_lines)
 
     labels = ['whiteglove', 'whiteglove-pending']
-    catalog_item_names = data.get('catalogItemNames') or []
-    if len(catalog_item_names) > 1:
+    if len(catalog_item_names_list) > 1:
         labels.append('whiteglove-multi-asset')
-    if not catalog_item_names:
+    if not catalog_item_names_list:
         labels.append('whiteglove-consultation')
     event_date_str = data.get('eventDate')
     if event_date_str:

--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -15,7 +15,7 @@ api:
     threads: 1
   image:
     #override:
-    tag: v1.3.2
+    tag: v1.3.3
     repository: quay.io/redhat-gpte/babylon-catalog-api
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/catalog/ui/src/app/Workshops/WorkshopInfoTab.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopInfoTab.tsx
@@ -117,10 +117,10 @@ const WorkshopInfoTab: React.FC<{
                   <span className="services-item__status--scheduled" key="scheduled">
                     <CheckCircleIcon key="scheduled-icon" /> Scheduled
                   </span>
-                  {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} /> : null}
+                  {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
                 </>
               ) : resourceClaims.length > 0 ? (
-                <WorkshopStatus resourceClaims={resourceClaims} />
+                <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} />
               ) : (
                 <p>...</p>
               )}

--- a/catalog/ui/src/app/Workshops/WorkshopStatus.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopStatus.tsx
@@ -29,7 +29,8 @@ function cmp(a: { state: string }, b: { state: string }) {
 
 const WorkshopStatus: React.FC<{
   resourceClaims: ResourceClaim[];
-}> = ({ resourceClaims }) => {
+  totalCount?: number;
+}> = ({ resourceClaims, totalCount }) => {
   const resourceClaimsStatus: { uid: string; state: string }[] = [];
   for (let resourceClaim of resourceClaims.filter((rc) => !rc.metadata.deletionTimestamp)) {
     const summary = resourceClaim.status?.summary;
@@ -77,9 +78,14 @@ const WorkshopStatus: React.FC<{
     <>
       {Object.entries(statusCount).map(([status, count]: [string, unknown]) => {
         const { state, phase } = getPhaseState(status);
+        const isRunning = state.toLowerCase() === 'running';
+        const label =
+          isRunning && totalCount != null
+            ? `${count as number}/${totalCount} Instances`
+            : `${count as number} Instances`;
         return (
           <div key={state}>
-            <span style={{ paddingRight: '12px' }}>{count as number} Instances</span>
+            <span style={{ paddingRight: '12px' }}>{label}</span>
             <InnerStatus phase={phase} state={state} />
           </div>
         );

--- a/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
@@ -431,10 +431,10 @@ const WorkshopsItemDetails: React.FC<{
                 <span className="services-item__status--scheduled" key="scheduled">
                   <CheckCircleIcon key="scheduled-icon" /> Scheduled
                 </span>
-                {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} /> : null}
+                {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
               </>
             ) : resourceClaims.length > 0 ? (
-              <WorkshopStatus resourceClaims={resourceClaims} />
+              <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} />
             ) : (
               <p>...</p>
             )}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,7 +98,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-api
-        tag: v1.3.2
+        tag: v1.3.3
       loggingLevel: INFO
       replicaCount: 1
       resources:


### PR DESCRIPTION
## Summary
- **Fix Jira ticket missing catalog item name**: Was reading the old singular field (catalogItemName) instead of the array (catalogItemNames) sent by the frontend, causing tickets to show "babylon-catalog-prod/" with no name
- **Add missing fields to Jira description**: Include deliveryMode, audienceType, and shareWith in the Jira ticket
- **Bump API version**: v1.3.2 to v1.3.3 in both catalog/helm and root helm values
- **Workshop status running/total**: Show running instances as count/total (e.g. 1/5 Instances Running) using WorkshopProvision spec.count

## Test plan
- [x] Create a white glove request with a catalog item and verify the Jira ticket shows the full name
- [x] Create a request with multiple catalog items and verify all names appear
- [x] Create a consultation request (no catalog item) and verify it shows N/A (consultation)
- [x] Verify deliveryMode, audienceType, and shareWith appear in the Jira ticket when provided
- [ ] Open a workshop detail page and verify running status shows as count/total (e.g. 1/5 Instances Running)
- [ ] Verify the Info tab also shows the count/total format