### PR TITLE
GPTEINFRA-17685 Upgrade partner nav chroming from v3 to v4

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -400,6 +400,7 @@ async def get_auth_session(request):
             "consoleURL": console_url,
             "groups": user_groups,
             "user": user['metadata']['name'],
+            "fullName": user.get('fullName', ''),
             "token": token,
             "catalogNamespaces": session['catalogNamespaces'],
             "lifetime": session_lifetime,

--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Suspense } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import { Page, PageSection, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { IAppRouteAccessControl } from '@app/types';
 import Header from '@app/Header/Header';
@@ -23,7 +23,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
   const [isMobileView, setIsMobileView] = useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = useState(false);
   useDocumentTitle(title);
-  const { isAdmin } = useSession().getSession();
+  const { isAdmin, email } = useSession().getSession();
   const { partner_connect_header_enabled } = useInterfaceConfig();
 
   const onNavToggleMobile = () => {
@@ -38,10 +38,49 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
 
   const { data: partnerHeaderHtml } = useSWRImmutable<string>(
     partner_connect_header_enabled
-      ? 'https://connect.redhat.com/en/api/chrome/authenticated/3.0/universal_and_primary'
+      ? 'https://connect.redhat.com/en/api/chrome/authenticated/4.0/universal_and_primary?include_dependencies=true'
       : null,
     publicFetcher,
   );
+
+  useEffect(() => {
+    if (!partnerHeaderHtml) return () => {};
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(partnerHeaderHtml, 'text/html');
+    const scripts = doc.querySelectorAll('script[src]');
+    scripts.forEach((script) => {
+      const src = script.getAttribute('src');
+      if (!src) return;
+      const absoluteSrc = src.startsWith('/') ? `https://connect.redhat.com${src}` : src;
+      if (document.querySelector(`script[src="${absoluteSrc}"]`)) return;
+      const el = document.createElement('script');
+      el.src = absoluteSrc;
+      if (script.getAttribute('type')) el.type = script.getAttribute('type');
+      document.head.appendChild(el);
+    });
+
+    return () => {
+      document.head.querySelectorAll('script[src*="connect.redhat.com"]').forEach((el) => el.remove());
+    };
+  }, [partnerHeaderHtml]);
+
+  useEffect(() => {
+    if (!partnerHeaderHtml || !email) return;
+
+    const userData: Record<string, string> = { login_name: email };
+
+    document.querySelectorAll('[data-rhpc-personal-info-key]').forEach((el) => {
+      const key = el.getAttribute('data-rhpc-personal-info-key');
+      if (key && userData[key] != null) {
+        el.textContent = userData[key];
+        const ancestor = el.closest('[data-rhpc-personal-info-provided]');
+        if (ancestor) {
+          ancestor.setAttribute('data-rhpc-personal-info-provided', 'true');
+        }
+      }
+    });
+  }, [partnerHeaderHtml, email]);
 
   if (accessControl === 'admin' && !isAdmin) throw new Error('Access denied');
 
@@ -96,17 +135,34 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
                     ),
                     {
                       FORCE_BODY: true,
-                      ADD_TAGS: ['style', 'pfe-navigation', 'pfe-navigation-dropdown', 'svg', 'path'],
+                      ADD_TAGS: [
+                        'style',
+                        'rh-navigation-primary',
+                        'rh-navigation-primary-item',
+                        'rh-cta',
+                        'rh-icon',
+                        'svg',
+                        'path',
+                      ],
                       ADD_ATTR: [
                         'part',
                         'slot',
-                        'dropdown-width',
                         'icon',
+                        'set',
                         'name',
+                        'variant',
+                        'color-palette',
                         'viewBox',
                         'fill',
                         'd',
                         'xmlns',
+                        'data-rhpc-personal-info-provided',
+                        'data-rhpc-personal-info-key',
+                        'data-pii',
+                        'data-analytics-region',
+                        'data-analytics-category',
+                        'data-analytics-level',
+                        'data-analytics-text',
                       ],
                     },
                   ),

--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -23,7 +23,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
   const [isMobileView, setIsMobileView] = useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = useState(false);
   useDocumentTitle(title);
-  const { isAdmin, email } = useSession().getSession();
+  const { isAdmin, email, fullName } = useSession().getSession();
   const { partner_connect_header_enabled } = useInterfaceConfig();
 
   const onNavToggleMobile = () => {
@@ -68,19 +68,18 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
   useEffect(() => {
     if (!partnerHeaderHtml || !email) return;
 
-    const userData: Record<string, string> = { login_name: email };
+    const loginName = email.includes('@') ? email.split('@')[0] : email;
 
-    document.querySelectorAll('[data-rhpc-personal-info-key]').forEach((el) => {
-      const key = el.getAttribute('data-rhpc-personal-info-key');
-      if (key && userData[key] != null) {
-        el.textContent = userData[key];
-        const ancestor = el.closest('[data-rhpc-personal-info-provided]');
-        if (ancestor) {
-          ancestor.setAttribute('data-rhpc-personal-info-provided', 'true');
-        }
-      }
-    });
-  }, [partnerHeaderHtml, email]);
+    document.dispatchEvent(
+      new CustomEvent('rhpc-nav:login', {
+        detail: {
+          login_name: loginName,
+          email_address: email,
+          ...(fullName ? { name: fullName } : {}),
+        },
+      }),
+    );
+  }, [partnerHeaderHtml, email, fullName]);
 
   if (accessControl === 'admin' && !isAdmin) throw new Error('Access denied');
 

--- a/catalog/ui/src/app/store/index.ts
+++ b/catalog/ui/src/app/store/index.ts
@@ -15,6 +15,7 @@ export interface ActionStartSession {
   admin: boolean;
   consoleURL: string;
   user: string;
+  fullName: string;
   groups: string[];
   roles: string[];
   interface: string;
@@ -34,6 +35,7 @@ interface AppState {
     admin: boolean | null;
     groups: string[];
     user: string | null;
+    fullName: string | null;
     catalogNamespaces: CatalogNamespace[];
     serviceNamespaces: ServiceNamespace[];
     userNamespace: UserNamespace | null;
@@ -59,6 +61,7 @@ const initialState: AppState = {
     admin: null,
     groups: [],
     user: null,
+    fullName: null,
     catalogNamespaces: [],
     serviceNamespaces: [],
     userNamespace: null,
@@ -94,6 +97,7 @@ const rootReducer = createReducer(initialState, (builder) => {
       state.auth.groups = action.payload.groups || [];
       state.auth.roles = action.payload.roles || [];
       state.auth.user = action.payload.user;
+      state.auth.fullName = action.payload.fullName || '';
       state.auth.catalogNamespaces = action.payload.catalogNamespaces;
       state.auth.serviceNamespaces = action.payload.serviceNamespaces;
       state.auth.userNamespace = action.payload.userNamespace;
@@ -127,6 +131,8 @@ export const selectConsoleURL = createSelector(selectSelf, (state): string => st
 export const selectInterface = createSelector(selectSelf, (state): string => state.interface);
 
 export const selectUser = createSelector(selectAuth, (state): string => state.user);
+
+export const selectUserFullName = createSelector(selectSelf, (state): string => state.auth.fullName || '');
 
 export const selectUserGroups = createSelector(selectAuth, (state): string[] =>
   (state.groups || []).filter(Boolean).concat('system:authenticated'),

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -869,6 +869,7 @@ export type Session = {
   roles: string[];
   interface: string;
   user: string;
+  fullName: string;
   catalogNamespaces: CatalogNamespace[];
   serviceNamespaces: ServiceNamespace[];
   userNamespace: UserNamespace;

--- a/catalog/ui/src/app/utils/useSession.tsx
+++ b/catalog/ui/src/app/utils/useSession.tsx
@@ -8,6 +8,7 @@ import {
   selectInterface,
   selectServiceNamespaces,
   selectUser,
+  selectUserFullName,
   selectUserGroups,
   selectUserIsAdmin,
   selectUserNamespace,
@@ -30,6 +31,7 @@ async function getSessionFn(dispatch: AppDispatch) {
       roles: session.roles || [],
       interface: session.interface,
       user: session.user,
+      fullName: session.fullName || '',
       catalogNamespaces: session.catalogNamespaces,
       serviceNamespaces: session.serviceNamespaces,
       userNamespace: session.userNamespace,
@@ -41,6 +43,7 @@ export default function useSession(): {
   getSession: () => {
     authUser: string;
     email: string;
+    fullName: string;
     isAdmin: boolean;
     groups: string[];
     roles: string[];
@@ -54,6 +57,7 @@ export default function useSession(): {
   const dispatch = useAppDispatch();
   const authUser = useAppSelector(selectAuthUser);
   const email = useAppSelector(selectUser);
+  const fullName = useAppSelector(selectUserFullName);
   const isAdmin = useAppSelector(selectUserIsAdmin);
   const groups = useAppSelector(selectUserGroups);
   const roles = useAppSelector(selectUserRoles);
@@ -83,6 +87,7 @@ export default function useSession(): {
     return {
       authUser,
       email: userImpersonated ? userImpersonated : email,
+      fullName,
       isAdmin,
       groups,
       roles,
@@ -95,6 +100,7 @@ export default function useSession(): {
   }, [
     authUser,
     email,
+    fullName,
     isAdmin,
     promise,
     groups,

--- a/catalog/ui/src/index.html
+++ b/catalog/ui/src/index.html
@@ -29,11 +29,6 @@
     ></script>
     <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script>
     <% } %>
-    <link
-      rel="stylesheet"
-      media="all"
-      href="https://cdn.jsdelivr.net/npm/@cpelements/pfe-navigation@1.0.134/dist/pfe-navigation--lightdom.min.css"
-    />
   </head>
 
   <body>
@@ -48,9 +43,5 @@
       }
     </script>
     <% } %>
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/@cpelements/pfe-navigation@1.0.134/dist/pfe-navigation.min.js"
-    ></script>
   </body>
 </html>


### PR DESCRIPTION
Switch from pfe-navigation to RHDS rh-navigation-primary by updating the chroming API endpoint to v4 with include_dependencies=true. Scripts from the response are loaded dynamically since DOMPurify strips script tags. The user account dropdown is populated with login_name from the session.