### PR TITLE
GPTEINFRA-15058 Add white glove blocked dates for admins to disable calendar dates

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -1649,6 +1649,7 @@ async def get_system_status_from_configmap():
         'workshops_ordering_blocked_message': '',
         'services_ordering_blocked': False,
         'services_ordering_blocked_message': '',
+        'wg_blocked_dates': [],
         'last_updated_by': '',
         'last_updated_at': '',
     }
@@ -1658,11 +1659,16 @@ async def get_system_status_from_configmap():
             namespace=babylon_namespace
         )
         data = configmap.data or {}
+        try:
+            wg_blocked_dates = json.loads(data.get('wg_blocked_dates', '[]'))
+        except (json.JSONDecodeError, TypeError):
+            wg_blocked_dates = []
         return {
             'workshops_ordering_blocked': data.get('workshops_ordering_blocked', 'false').lower() == 'true',
             'workshops_ordering_blocked_message': data.get('workshops_ordering_blocked_message', ''),
             'services_ordering_blocked': data.get('services_ordering_blocked', 'false').lower() == 'true',
             'services_ordering_blocked_message': data.get('services_ordering_blocked_message', ''),
+            'wg_blocked_dates': wg_blocked_dates,
             'last_updated_by': data.get('last_updated_by', ''),
             'last_updated_at': data.get('last_updated_at', ''),
         }
@@ -1720,7 +1726,8 @@ async def update_system_status(request):
         'workshops_ordering_blocked',
         'workshops_ordering_blocked_message',
         'services_ordering_blocked',
-        'services_ordering_blocked_message'
+        'services_ordering_blocked_message',
+        'wg_blocked_dates',
     }
 
     for key in data.keys():
@@ -1751,7 +1758,16 @@ async def update_system_status(request):
 
         # Update with new values
         for key, value in data.items():
-            if key.endswith('_blocked'):
+            if key == 'wg_blocked_dates':
+                if not isinstance(value, list):
+                    raise web.HTTPBadRequest(reason="wg_blocked_dates must be a list")
+                for entry in value:
+                    if not isinstance(entry, dict) or 'startDate' not in entry or 'endDate' not in entry:
+                        raise web.HTTPBadRequest(reason="Each blocked date entry must have startDate and endDate")
+                    if entry['endDate'] < entry['startDate']:
+                        raise web.HTTPBadRequest(reason="endDate must be on or after startDate")
+                current_data[key] = json.dumps(value)
+            elif key.endswith('_blocked'):
                 current_data[key] = 'true' if value else 'false'
             else:
                 current_data[key] = str(value) if value is not None else ''

--- a/catalog/ui/src/app/Admin/WhiteGloveAdminList.tsx
+++ b/catalog/ui/src/app/Admin/WhiteGloveAdminList.tsx
@@ -2,10 +2,18 @@ import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
+  Button,
+  Card,
+  CardBody,
+  CardTitle,
+  FormGroup,
+  Form,
   PageSection,
   Pagination,
+  TextInput,
   Title,
 } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
@@ -13,13 +21,14 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ClockIcon from '@patternfly/react-icons/dist/js/icons/clock-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
-import { apiPaths, deleteWhiteGloveRequest, fetcher, silentFetcher } from '@app/api';
+import { apiPaths, deleteWhiteGloveRequest, fetcher, silentFetcher, updateSystemStatus } from '@app/api';
 import Modal, { useModal } from '@app/Modal/Modal';
 import ButtonCircleIcon from '@app/components/ButtonCircleIcon';
 import { WhiteGloveRequest, WhiteGloveRequestList } from '@app/types';
 import { DEMO_DOMAIN } from '@app/util';
 import TimeInterval from '@app/components/TimeInterval';
 import ErrorBoundaryPage from '@app/components/ErrorBoundaryPage';
+import useSystemStatus from '@app/utils/useSystemStatus';
 
 import '@app/Services/service-status.css';
 import '@app/WhiteGlove/white-glove.css';
@@ -45,6 +54,126 @@ const JiraAssigneeCell: React.FC<{ jiraTicketId: string; fallback: string }> = (
   );
   const assignee = data?.assignee?.displayName || fallback;
   return <>{assignee || <span style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>Unassigned</span>}</>;
+};
+
+const BlockedDatesManager: React.FC = () => {
+  const { wgBlockedDates, mutate } = useSystemStatus();
+  const [newStartDate, setNewStartDate] = useState('');
+  const [newEndDate, setNewEndDate] = useState('');
+  const [newMessage, setNewMessage] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function addBlockedRange() {
+    if (!newStartDate || !newEndDate) return;
+    if (newEndDate < newStartDate) {
+      setError('End date must be on or after start date');
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateSystemStatus({
+        wg_blocked_dates: [...wgBlockedDates, { startDate: newStartDate, endDate: newEndDate, message: newMessage }],
+      });
+      await mutate();
+      setNewStartDate('');
+      setNewEndDate('');
+      setNewMessage('');
+    } catch {
+      setError('Failed to add blocked dates');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function removeBlockedRange(index: number) {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateSystemStatus({
+        wg_blocked_dates: wgBlockedDates.filter((_, i) => i !== index),
+      });
+      await mutate();
+    } catch {
+      setError('Failed to remove blocked dates');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Card style={{ marginBottom: 'var(--pf-t--global--spacer--lg)' }}>
+      <CardTitle>Blocked Dates</CardTitle>
+      <CardBody>
+        <p style={{ marginBottom: '12px', color: 'var(--pf-t--global--text--color--subtle)' }}>
+          Block date ranges to prevent users from scheduling white glove requests on those days.
+        </p>
+        {error && <Alert variant="danger" isInline title={error} style={{ marginBottom: '12px' }} />}
+        <Form>
+          <div style={{ display: 'flex', gap: '12px', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+            <FormGroup label="Start Date" fieldId="blocked-start">
+              <TextInput
+                type="date"
+                id="blocked-start"
+                value={newStartDate}
+                onChange={(_e, v) => setNewStartDate(v)}
+              />
+            </FormGroup>
+            <FormGroup label="End Date" fieldId="blocked-end">
+              <TextInput
+                type="date"
+                id="blocked-end"
+                value={newEndDate}
+                onChange={(_e, v) => setNewEndDate(v)}
+              />
+            </FormGroup>
+            <FormGroup label="Message" fieldId="blocked-msg">
+              <TextInput
+                id="blocked-msg"
+                value={newMessage}
+                onChange={(_e, v) => setNewMessage(v)}
+                placeholder="e.g. On vacation, no capacity"
+                style={{ minWidth: '250px' }}
+              />
+            </FormGroup>
+            <Button
+              variant="primary"
+              onClick={addBlockedRange}
+              isDisabled={!newStartDate || !newEndDate || isSaving}
+              isLoading={isSaving}
+            >
+              Add
+            </Button>
+          </div>
+        </Form>
+        {wgBlockedDates.length > 0 && (
+          <Table aria-label="Blocked dates" variant="compact" style={{ marginTop: '16px' }}>
+            <Thead>
+              <Tr>
+                <Th>Start</Th>
+                <Th>End</Th>
+                <Th>Message</Th>
+                <Th>Actions</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {wgBlockedDates.map((range, i) => (
+                <Tr key={i}>
+                  <Td dataLabel="Start">{range.startDate}</Td>
+                  <Td dataLabel="End">{range.endDate}</Td>
+                  <Td dataLabel="Message">{range.message || '—'}</Td>
+                  <Td dataLabel="Actions">
+                    <ButtonCircleIcon onClick={() => removeBlockedRange(i)} description="Remove" icon={TrashIcon} />
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        )}
+      </CardBody>
+    </Card>
+  );
 };
 
 const defaultPerPage = 20;
@@ -98,6 +227,8 @@ const WhiteGloveAdminListContent: React.FC = () => {
         <Title headingLevel="h1" size="lg" style={{ marginBottom: 'var(--pf-t--global--spacer--lg)' }}>
           White Glove Requests
         </Title>
+
+        <BlockedDatesManager />
 
         <Pagination
           itemCount={requests.length}

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -23,7 +23,8 @@ import {
 } from '@patternfly/react-core';
 import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
-import { createWhiteGloveRequest, createJiraTicketForWgr, patchWhiteGloveRequest } from '@app/api';
+import { BlockedDateRange, createWhiteGloveRequest, createJiraTicketForWgr, patchWhiteGloveRequest } from '@app/api';
+import useSystemStatus from '@app/utils/useSystemStatus';
 import { CatalogItem, SalesforceItem } from '@app/types';
 import { DEMO_DOMAIN, displayName } from '@app/util';
 import CatalogItemIcon from '@app/Catalog/CatalogItemIcon';
@@ -42,9 +43,17 @@ import './white-glove.css';
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
 
+function createBlockedDateValidator(blockedDates: BlockedDateRange[]): (date: Date) => boolean {
+  return (date: Date) => {
+    const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    return !blockedDates.some((range) => dateStr >= range.startDate && dateStr <= range.endDate);
+  };
+}
+
 const WhiteGloveCreateContent: React.FC = () => {
   const navigate = useNavigate();
   const { userNamespace } = useSession().getSession();
+  const { wgBlockedDates } = useSystemStatus();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCatalogSelectorOpen, setIsCatalogSelectorOpen] = useState(false);
@@ -70,6 +79,8 @@ const WhiteGloveCreateContent: React.FC = () => {
   const [shareWith, setShareWith] = useState<string[]>([]);
   const [shareWithInput, setShareWithInput] = useState('');
   const [notes, setNotes] = useState('');
+
+  const blockedDateValidator = useMemo(() => createBlockedDateValidator(wgBlockedDates), [wgBlockedDates]);
 
   const isShortLeadTime = eventDate.getTime() - Date.now() < FOURTEEN_DAYS_MS;
 
@@ -290,6 +301,21 @@ const WhiteGloveCreateContent: React.FC = () => {
             />
           </FormGroup>
 
+          {wgBlockedDates.length > 0 && (
+            <Alert variant="info" isInline title="Some dates are unavailable">
+              <ul style={{ margin: 0, paddingLeft: '16px' }}>
+                {wgBlockedDates.map((range, i) => (
+                  <li key={i}>
+                    {range.startDate === range.endDate
+                      ? range.startDate
+                      : `${range.startDate} to ${range.endDate}`}
+                    {range.message ? ` — ${range.message}` : ''}
+                  </li>
+                ))}
+              </ul>
+            </Alert>
+          )}
+
           <FormGroup label="Event Start Date" isRequired fieldId="event-date">
             <DateTimePickerButton date={eventDate} timezone={timezone} onClick={() => setIsStartDateModalOpen(true)} />
             {isShortLeadTime && (
@@ -472,6 +498,7 @@ const WhiteGloveCreateContent: React.FC = () => {
         date={eventDate}
         minDate={Date.now()}
         title="Event Start Date"
+        additionalValidators={[blockedDateValidator]}
         onConfirm={(date) => {
           setEventDate(date);
           if (eventEndDate <= date) {
@@ -487,6 +514,7 @@ const WhiteGloveCreateContent: React.FC = () => {
         date={eventEndDate}
         minDate={eventDate.getTime()}
         title="Event End Date"
+        additionalValidators={[blockedDateValidator]}
         onConfirm={(date) => {
           setEventEndDate(date);
           setIsEndDateModalOpen(false);

--- a/catalog/ui/src/app/api.ts
+++ b/catalog/ui/src/app/api.ts
@@ -2993,11 +2993,18 @@ export const apiPaths = {
     }`,
 };
 
+export type BlockedDateRange = {
+  startDate: string;
+  endDate: string;
+  message: string;
+};
+
 export type SystemStatus = {
   workshops_ordering_blocked: boolean;
   workshops_ordering_blocked_message: string;
   services_ordering_blocked: boolean;
   services_ordering_blocked_message: string;
+  wg_blocked_dates: BlockedDateRange[];
   last_updated_by: string;
   last_updated_at: string;
 };

--- a/catalog/ui/src/app/components/DateTimePicker.tsx
+++ b/catalog/ui/src/app/components/DateTimePicker.tsx
@@ -43,7 +43,8 @@ const DateTimePicker: React.FC<{
   maxDate?: number;
   forceUpdateTimestamp?: number;
   timezone?: string;
-}> = ({ defaultTimestamp, isDisabled = false, onSelect, minDate, maxDate, forceUpdateTimestamp, timezone = getBrowserTimezone() }) => {
+  additionalValidators?: Array<(date: Date) => boolean>;
+}> = ({ defaultTimestamp, isDisabled = false, onSelect, minDate, maxDate, forceUpdateTimestamp, timezone = getBrowserTimezone(), additionalValidators }) => {
   const dateFormat = (date: Date) =>
     date.toLocaleDateString([getLang(), 'en-US'], {
       year: 'numeric',
@@ -166,7 +167,7 @@ const DateTimePicker: React.FC<{
     <CalendarMonth
       date={calendarDate}
       onChange={(_event, newValueDate: Date) => onSelectCalendar(newValueDate)}
-      validators={[rangeValidatorDate]}
+      validators={[rangeValidatorDate, ...(additionalValidators || [])]}
     />
   );
 

--- a/catalog/ui/src/app/components/DateTimePickerModal.tsx
+++ b/catalog/ui/src/app/components/DateTimePickerModal.tsx
@@ -31,7 +31,8 @@ const DateTimePickerModalDialog: React.FC<{
   title: string;
   onConfirm: (date: Date) => void;
   onClose: () => void;
-}> = ({ isOpen, date, minDate, title, onConfirm, onClose }) => {
+  additionalValidators?: Array<(date: Date) => boolean>;
+}> = ({ isOpen, date, minDate, title, onConfirm, onClose, additionalValidators }) => {
   const [modalRef, openModal] = useModal();
   const [timezone, setTimezone] = useState(getBrowserTimezone);
   const [selectedDate, setSelectedDate] = useState<Date>(date);
@@ -54,6 +55,7 @@ const DateTimePickerModalDialog: React.FC<{
             onSelect={(d: Date) => setSelectedDate(d)}
             minDate={minDate}
             timezone={timezone}
+            additionalValidators={additionalValidators}
           />
         </FormGroup>
       </Form>

--- a/catalog/ui/src/app/utils/useSystemStatus.tsx
+++ b/catalog/ui/src/app/utils/useSystemStatus.tsx
@@ -25,6 +25,7 @@ export default function useSystemStatus() {
         workshops_ordering_blocked_message: '',
         services_ordering_blocked: false,
         services_ordering_blocked_message: '',
+        wg_blocked_dates: [],
         last_updated_by: '',
         last_updated_at: '',
       },
@@ -41,6 +42,7 @@ export default function useSystemStatus() {
     workshopOrderingBlockedMessage: data?.workshops_ordering_blocked_message ?? '',
     isServiceOrderingBlocked: data?.services_ordering_blocked ?? false,
     serviceOrderingBlockedMessage: data?.services_ordering_blocked_message ?? '',
+    wgBlockedDates: data?.wg_blocked_dates ?? [],
   };
 }
 


### PR DESCRIPTION
Allow admins to block date ranges with a message (e.g. vacation, no capacity) from the white glove admin page. Blocked dates are stored in the babylon-system-status configmap and appear as disabled dates in the white glove create request form calendar.