### PR TITLE
Add white_glove_enabled interface config and fix partner header CSS/l…

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -22,6 +22,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
   const [isNavOpen, setIsNavOpen] = useState(true);
   const [isMobileView, setIsMobileView] = useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = useState(false);
+  const [partnerScriptsReady, setPartnerScriptsReady] = useState(false);
   useDocumentTitle(title);
   const { isAdmin, email, fullName } = useSession().getSession();
   const { partner_connect_header_enabled } = useInterfaceConfig();
@@ -48,8 +49,22 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
 
     const parser = new DOMParser();
     const doc = parser.parseFromString(partnerHeaderHtml, 'text/html');
-    const scripts = doc.querySelectorAll('script[src]');
-    scripts.forEach((script) => {
+
+    const linkElements = doc.querySelectorAll('link[rel="stylesheet"]');
+    linkElements.forEach((link) => {
+      const href = link.getAttribute('href');
+      if (!href) return;
+      const absoluteHref = href.startsWith('/') ? `https://connect.redhat.com${href}` : href;
+      if (document.querySelector(`link[href="${absoluteHref}"]`)) return;
+      const el = document.createElement('link');
+      el.rel = 'stylesheet';
+      el.href = absoluteHref;
+      document.head.appendChild(el);
+    });
+
+    const scriptElements = doc.querySelectorAll('script[src]');
+    const newScripts: HTMLScriptElement[] = [];
+    scriptElements.forEach((script) => {
       const src = script.getAttribute('src');
       if (!src) return;
       const absoluteSrc = src.startsWith('/') ? `https://connect.redhat.com${src}` : src;
@@ -57,16 +72,33 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
       const el = document.createElement('script');
       el.src = absoluteSrc;
       if (script.getAttribute('type')) el.type = script.getAttribute('type');
+      newScripts.push(el);
       document.head.appendChild(el);
     });
 
+    if (newScripts.length === 0) {
+      setPartnerScriptsReady(true);
+    } else {
+      let loaded = 0;
+      const onLoad = () => {
+        loaded++;
+        if (loaded >= newScripts.length) setPartnerScriptsReady(true);
+      };
+      newScripts.forEach((el) => {
+        el.addEventListener('load', onLoad);
+        el.addEventListener('error', onLoad);
+      });
+    }
+
     return () => {
+      setPartnerScriptsReady(false);
+      document.head.querySelectorAll('link[href*="connect.redhat.com"]').forEach((el) => el.remove());
       document.head.querySelectorAll('script[src*="connect.redhat.com"]').forEach((el) => el.remove());
     };
   }, [partnerHeaderHtml]);
 
   useEffect(() => {
-    if (!partnerHeaderHtml || !email) return;
+    if (!partnerScriptsReady || !email) return;
 
     const loginName = email.includes('@') ? email.split('@')[0] : email;
 
@@ -79,7 +111,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
         },
       }),
     );
-  }, [partnerHeaderHtml, email, fullName]);
+  }, [partnerScriptsReady, email, fullName]);
 
   if (accessControl === 'admin' && !isAdmin) throw new Error('Access denied');
 

--- a/catalog/ui/src/app/AppLayout/Navigation.tsx
+++ b/catalog/ui/src/app/AppLayout/Navigation.tsx
@@ -20,7 +20,7 @@ const ExactNavLink = ({ children, to, className, ...props }: LinkProps) => {
 };
 const Navigation: React.FC = () => {
   const location = useLocation();
-  const { incidents_enabled, ratings_enabled, partner_connect_header_enabled, rcars_enabled } = useInterfaceConfig();
+  const { incidents_enabled, ratings_enabled, partner_connect_header_enabled, rcars_enabled, white_glove_enabled } = useInterfaceConfig();
   const { isAdmin, userNamespace } = useSession().getSession();
 
   function locationStartsWith(str: string): boolean {
@@ -101,7 +101,7 @@ const Navigation: React.FC = () => {
     </NavItem>
   ) : null;
 
-  const whiteGloveNavigation = userNamespace ? (
+  const whiteGloveNavigation = userNamespace && white_glove_enabled ? (
     <NavItem>
       <NavLink
         to="/white-glove"
@@ -201,11 +201,13 @@ const Navigation: React.FC = () => {
           ResourceProviders
         </NavLink>
       </NavItem>
-      <NavItem>
-        <NavLink className={locationStartsWith('/admin/white-glove-requests') ? 'pf-m-current' : ''} to="/admin/white-glove-requests">
-          White Glove Requests
-        </NavLink>
-      </NavItem>
+      {white_glove_enabled ? (
+        <NavItem>
+          <NavLink className={locationStartsWith('/admin/white-glove-requests') ? 'pf-m-current' : ''} to="/admin/white-glove-requests">
+            White Glove Requests
+          </NavLink>
+        </NavItem>
+      ) : null}
       <NavItem>
         <NavLink className={locationStartsWith('/admin/ops') ? 'pf-m-current' : ''} to="/admin/ops">
           Ops Workshop Control

--- a/catalog/ui/src/app/utils/useInterfaceConfig.tsx
+++ b/catalog/ui/src/app/utils/useInterfaceConfig.tsx
@@ -18,6 +18,7 @@ type TInterface = {
   sfdc_enabled: boolean;
   partner_connect_header_enabled: boolean;
   rcars_enabled: boolean;
+  white_glove_enabled: boolean;
 };
 export function useInterface(userInterface: string) {
   const { data, error } = useSWRImmutable<TInterface>(`./public/interfaces/${userInterface}.json`, publicFetcher);
@@ -43,7 +44,8 @@ export default function useInterfaceConfig() {
       onboarding_support_text: '',
       sfdc_enabled: true,
       partner_connect_header_enabled: false,
-      rcars_enabled: false
+      rcars_enabled: false,
+      white_glove_enabled: true
     };
   }
   return data;

--- a/catalog/ui/src/public/interfaces/rhdp-partners.json
+++ b/catalog/ui/src/public/interfaces/rhdp-partners.json
@@ -9,5 +9,6 @@
   "learn_more_link": "https://content.redhat.com/content/rhcc/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": false,
   "partner_connect_header_enabled": true,
-  "rcars_enabled": false
+  "rcars_enabled": false,
+  "white_glove_enabled": false
 }

--- a/catalog/ui/src/public/interfaces/rhpds.json
+++ b/catalog/ui/src/public/interfaces/rhpds.json
@@ -9,5 +9,6 @@
   "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": true,
   "partner_connect_header_enabled": false,
-  "rcars_enabled": true
+  "rcars_enabled": true,
+  "white_glove_enabled": true
 }

--- a/helm/templates/clusterroles/babylon-user-service-access.yaml
+++ b/helm/templates/clusterroles/babylon-user-service-access.yaml
@@ -59,3 +59,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - {{ .Values.catalog.api.group }}
+  resources:
+  - whitegloverequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
…ogin

- Add white_glove_enabled flag to interface JSON configs (true for rhpds, false for rhdp-partners) to control White Glove menu visibility per interface
- Gate both user and admin White Glove navigation items on the new flag
- Fix partner header missing CSS by extracting and loading <link> stylesheets from the fetched partner header HTML
- Fix rhpc-nav:login dispatch timing by waiting for partner scripts to fully load before dispatching the CustomEvent