### PR TITLE
Fix partner header CSS sanitization and add company_name to login event

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -107,6 +107,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
         detail: {
           login_name: loginName,
           email_address: email,
+          company_name: '',
           ...(fullName ? { name: fullName } : {}),
         },
       }),
@@ -166,15 +167,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
                     ),
                     {
                       FORCE_BODY: true,
-                      ADD_TAGS: [
-                        'style',
-                        'rh-navigation-primary',
-                        'rh-navigation-primary-item',
-                        'rh-cta',
-                        'rh-icon',
-                        'svg',
-                        'path',
-                      ],
+                      ADD_TAGS: ['style', 'svg', 'path'],
                       ADD_ATTR: [
                         'part',
                         'slot',
@@ -187,14 +180,12 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
                         'fill',
                         'd',
                         'xmlns',
-                        'data-rhpc-personal-info-provided',
-                        'data-rhpc-personal-info-key',
-                        'data-pii',
-                        'data-analytics-region',
-                        'data-analytics-category',
-                        'data-analytics-level',
-                        'data-analytics-text',
                       ],
+                      CUSTOM_ELEMENT_HANDLING: {
+                        tagNameCheck: /^(rh|pfe)-/,
+                        attributeNameCheck: /^data-/,
+                        allowCustomizedBuiltInElements: true,
+                      },
                     },
                   ),
                 }}


### PR DESCRIPTION
## Summary
- Use DOMPurify CUSTOM_ELEMENT_HANDLING with tagNameCheck regex to allow all rh-* and pfe-* custom elements instead of a hardcoded list, fixing missing dropdown styles (cards, backgrounds)
- Use attributeNameCheck regex for data-* attributes instead of listing each individually
- Add company_name field to rhpc-nav:login CustomEvent detail

## Test plan
- [ ] Verify partner header dropdown menus render with correct CSS (card boxes, white background)
- [ ] Verify partner header shows logged-in user info after scripts load
- [ ] Verify no XSS regression — only rh-*/pfe-* custom elements and data-* attributes are allowed