### PR TITLE
Add Helm chart linting CI check for PRs

### DIFF
--- a/.github/workflows/helm-lint-pr.yaml
+++ b/.github/workflows/helm-lint-pr.yaml
@@ -1,0 +1,45 @@
+name: Helm Charts - Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/helm/**'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint Helm Charts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+
+      - name: Configure Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          version: v3.11.1
+
+      - name: Lint all charts
+        run: |
+          charts=(
+            helm
+            admin/helm
+            agnosticv-operator/helm
+            catalog/helm
+            catalog-manager/helm
+            cost-tracker/helm
+            lab-ui-manager/helm
+            notifier/helm
+            selfpacedlab-manager/helm
+            workshop-manager/helm
+          )
+          failed=0
+          for chart in "${charts[@]}"; do
+            echo "::group::$chart"
+            helm lint "$chart" || failed=1
+            echo "::endgroup::"
+          done
+          exit $failed

--- a/.github/workflows/helm-lint-pr.yaml
+++ b/.github/workflows/helm-lint-pr.yaml
@@ -24,20 +24,8 @@ jobs:
 
       - name: Lint all charts
         run: |
-          charts=(
-            helm
-            admin/helm
-            agnosticv-operator/helm
-            catalog/helm
-            catalog-manager/helm
-            cost-tracker/helm
-            lab-ui-manager/helm
-            notifier/helm
-            selfpacedlab-manager/helm
-            workshop-manager/helm
-          )
           failed=0
-          for chart in "${charts[@]}"; do
+          for chart in $(find . -name Chart.yaml -not -path '*/node_modules/*' -exec dirname {} \;); do
             echo "::group::$chart"
             helm lint "$chart" || failed=1
             echo "::endgroup::"

--- a/catalog/helm/templates/api/system-status-configmap.yaml
+++ b/catalog/helm/templates/api/system-status-configmap.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: babylon-system-status
-  namespace: {{ include "babylon-catalog.namespaceName" . }}
+  namespace: {{ include "babylonCatalog.namespaceName" . }}
   labels:
     component: babylon-system-status
-    {{- include "babylon-catalog.labels" . | nindent 4 }}
+    {{- include "babylonCatalog.labels" . | nindent 4 }}
 data:
   # Workshop ordering block configuration
   # Set to "true" to block all workshop ordering (during incidents, capacity issues, etc.)


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `helm lint` on all Helm charts when a PR touches any helm/ directory. Also fixes a template name mismatch in catalog/helm (babylon-catalog -> babylonCatalog).