### PR TITLE
GPTEINFRA-17685 Fix partner header login event race condition and enable for RHPDS

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -110,17 +110,31 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
     if (!partnerScriptsReady || !email) return;
 
     const loginName = email.includes('@') ? email.split('@')[0] : email;
+    const detail = {
+      login_name: loginName,
+      email_address: email,
+      ...(fullName ? { name: fullName } : {}),
+    };
 
-    document.dispatchEvent(
-      new CustomEvent('rhpc-nav:login', {
-        detail: {
-          login_name: loginName,
-          email_address: email,
-          company_name: '',
-          ...(fullName ? { name: fullName } : {}),
-        },
-      }),
-    );
+    const dispatchLogin = () => {
+      document.dispatchEvent(new CustomEvent('rhpc-nav:login', { detail }));
+    };
+
+    // Wait for the partner nav element to appear in the DOM before dispatching.
+    if (document.querySelector('.rhpc-portal-nav-universal')) {
+      dispatchLogin();
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (document.querySelector('.rhpc-portal-nav-universal')) {
+        observer.disconnect();
+        dispatchLogin();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
   }, [partnerScriptsReady, email, fullName]);
 
   if (accessControl === 'admin' && !isAdmin) throw new Error('Access denied');

--- a/catalog/ui/src/public/interfaces/rhpds.json
+++ b/catalog/ui/src/public/interfaces/rhpds.json
@@ -8,7 +8,7 @@
   "feedback_link": "https://redhat.atlassian.net/servicedesk/customer/portal/69/group/75/create/165",
   "learn_more_link": "https://content.redhat.com/us/en/product/cross-portfolio-initiatives/rhdp.html",
   "sfdc_enabled": true,
-  "partner_connect_header_enabled": false,
+  "partner_connect_header_enabled": true,
   "rcars_enabled": true,
   "white_glove_enabled": true
 }


### PR DESCRIPTION
Use MutationObserver to wait for .rhpc-portal-nav-universal before dispatching rhpc-nav:login, fixing a race where the event fired before the partner script registered its listener. Remove unused company_name field and enable partner_connect_header in rhpds.json.