### PR TITLE
Fix external item request API route

### DIFF
--- a/catalog/api/app.py
+++ b/catalog/api/app.py
@@ -956,7 +956,7 @@ async def catalog_item_incidents(request):
         url=f"{reporting_api}/catalog_incident/incidents/{quote(asset_uuid, safe='')}/{quote(stage, safe='')}",
     )
 
-@routes.post("/api/external_item/{asset_uuid}")
+@routes.post("/api/external_item/{asset_uuid}/request")
 async def external_item_request(request):
     asset_uuid = request.match_info.get('asset_uuid')
     data = await request.json()


### PR DESCRIPTION
## Summary
- The API route for external item requests was registered as `/api/external_item/{asset_uuid}` but the UI calls `/api/external_item/{asset_uuid}/request`, causing 404 errors when ordering external items.
- Added the missing `/request` suffix to the route decorator to match the frontend path.