### PR TITLE
GPTEINFRA-12020 - Feature: close catalog item details sidebar with ESC key

### DIFF
--- a/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import parseDuration from 'parse-duration';
 import { Link, useNavigate } from 'react-router-dom';
 import {
@@ -77,6 +77,16 @@ enum CatalogItemAccess {
 }
 
 const CatalogItemDetails: React.FC<{ catalogItem: CatalogItem; onClose: () => void }> = ({ catalogItem: catalogItemProp, onClose }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   const navigate = useNavigate();
   const { userNamespace, isAdmin, groups } = useSession().getSession();
   const { data: catalogItemFromApi } = useSWR<CatalogItem>(


### PR DESCRIPTION
## Summary
- Add keyboard shortcut (ESC) to close the catalog item details sidebar
- Adds a `useEffect` with a `keydown` listener in `CatalogItemDetails` that calls `onClose` when the Escape key is pressed

## Test plan
- [x] Open a catalog item details sidebar
- [x] Press ESC key — sidebar should close
- [x] Verify the close button (X) still works
- [x] Verify no regressions when navigating with keyboard in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)