### PR TITLE
Bump catalog API image tag to v1.3.4

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -15,7 +15,7 @@ api:
     threads: 1
   image:
     #override:
-    tag: v1.3.3
+    tag: v1.3.4
     repository: quay.io/redhat-gpte/babylon-catalog-api
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,7 +98,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-api
-        tag: v1.3.3
+        tag: v1.3.4
       loggingLevel: INFO
       replicaCount: 1
       resources:


### PR DESCRIPTION
Release fix-external-item-request-route (#3711).