### PR TITLE
GPTEINFRA-17791 - Improve Tenant Cluster Pools UI

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -342,7 +342,7 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                         value={spec?.minAvailableSandboxPlacements ?? 0}
                         mutate={mutate}
                       />
-                      {(spec?.maxClusters ?? 0) === 0 ? (
+                      {(spec?.maxClusters ?? 0) === 0 && (spec?.minAvailableSandboxPlacements ?? 0) > 0 ? (
                         <HelperText>
                           <HelperTextItem variant="warning">
                             Max Clusters is zero

--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   Breadcrumb,
@@ -8,6 +8,8 @@ import {
   DescriptionListGroup,
   DescriptionListDescription,
   EmptyState,
+  HelperText,
+  HelperTextItem,
   Label,
   NumberInput,
   PageSection,
@@ -16,6 +18,7 @@ import {
   SplitItem,
   Stack,
   StackItem,
+  Switch,
   Tabs,
   Tab,
   TabTitleText,
@@ -172,6 +175,20 @@ const TenantClusterPoolInstanceComponent: React.FC<{
   const clusters = tenantClusterPool?.status?.clusters || [];
   const spec = tenantClusterPool?.spec;
 
+  const [enabledUpdating, setEnabledUpdating] = useState(false);
+
+  const handleEnabledToggle = useCallback(async () => {
+    setEnabledUpdating(true);
+    try {
+      await patchTenantClusterPool(tenantClusterPoolNamespace, tenantClusterPoolName, {
+        spec: { enabled: spec?.enabled === false },
+      });
+      mutate();
+    } finally {
+      setEnabledUpdating(false);
+    }
+  }, [tenantClusterPoolNamespace, tenantClusterPoolName, spec?.enabled, mutate]);
+
   return (
     <>
       <PageSection hasBodyWrapper={false} key="header" className="admin-header">
@@ -268,6 +285,19 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                   </DescriptionListGroup>
 
                   <DescriptionListGroup>
+                    <DescriptionListTerm>Enabled</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Switch
+                        id="tenant-cluster-pool-enabled"
+                        isChecked={spec?.enabled !== false}
+                        onChange={handleEnabledToggle}
+                        isDisabled={clusters.length > 0 || enabledUpdating}
+                      />
+                      {enabledUpdating ? [' ', <Spinner key="spinner" size="md" />] : null}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+
+                  <DescriptionListGroup>
                     <DescriptionListTerm>Max Clusters</DescriptionListTerm>
                     <DescriptionListDescription>
                       <TenantClusterPoolNumberInput
@@ -292,6 +322,13 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                         max={spec?.maxClusters ?? 999}
                         mutate={mutate}
                       />
+                      {spec?.enabled === false && (spec?.minClusters ?? 0) > 0 ? (
+                        <HelperText>
+                          <HelperTextItem variant="warning">
+                            Tenant Cluster Pool is disabled, Min Clusters will have no effect
+                          </HelperTextItem>
+                        </HelperText>
+                      ) : null}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
 
@@ -305,6 +342,13 @@ const TenantClusterPoolInstanceComponent: React.FC<{
                         value={spec?.minAvailableSandboxPlacements ?? 0}
                         mutate={mutate}
                       />
+                      {(spec?.maxClusters ?? 0) === 0 ? (
+                        <HelperText>
+                          <HelperTextItem variant="warning">
+                            Max Clusters is zero
+                          </HelperTextItem>
+                        </HelperText>
+                      ) : null}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
 

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -3,7 +3,10 @@ import { Link, useSearchParams } from 'react-router-dom';
 import {
   EmptyState,
   Label,
+  List,
+  ListItem,
   PageSection,
+  Spinner,
   Split,
   SplitItem,
   Title,
@@ -46,7 +49,26 @@ const ClusterChildRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, maxPlacements, updating, pendingAction, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+
+  if (status === 'loading') {
+    return (
+      <tr className="tenant-pools-child-row">
+        <td></td>
+        <td>
+          <Link
+            to={`/services/${namespace}/${cluster.resourceClaimName}`}
+            className="tenant-pools-name-link"
+          >
+            {cluster.resourceClaimName}
+          </Link>
+        </td>
+        <td colSpan={6}>
+          <Spinner size="sm" />
+        </td>
+      </tr>
+    );
+  }
 
   return (
     <tr className="tenant-pools-child-row">
@@ -64,11 +86,9 @@ const ClusterChildRow: React.FC<{
           {cluster.sandboxApiState}
         </Label>
       </td>
-      <td>{status === 'loading' ? <span className="tenant-pools-muted">-</span> : `${placementCount}/${maxPlacements ?? '-'}`}</td>
+      <td>{`${placementCount}/${maxPlacements ?? '-'}`}</td>
       <td>
-        {status === 'loading' ? (
-          <span className="tenant-pools-muted">-</span>
-        ) : status === 'available' ? (
+        {status === 'available' ? (
           <span className="tenant-pools-onboarded"><CheckCircleIcon /> Onboarded</span>
         ) : status === 'disabled' ? (
           <span className="tenant-pools-not-onboarded">Disabled</span>
@@ -87,6 +107,11 @@ const ClusterChildRow: React.FC<{
         />
       </td>
       <td></td>
+      <td>
+        {resourceClaimCreationTimestamp ? (
+          <TimeInterval toTimestamp={resourceClaimCreationTimestamp} />
+        ) : '-'}
+      </td>
     </tr>
   );
 };
@@ -141,6 +166,16 @@ const TenantClusterPools: React.FC = () => {
     [filterFunction, tenantClusterPools],
   );
 
+  const enabledPools = useMemo(
+    () => filteredPools.filter((pool) => pool.spec.enabled !== false),
+    [filteredPools],
+  );
+
+  const disabledPools = useMemo(
+    () => filteredPools.filter((pool) => pool.spec.enabled === false),
+    [filteredPools],
+  );
+
   const togglePool = useCallback((poolKey: string) => {
     setExpandedPools((prev) => {
       const next = new Set(prev);
@@ -184,94 +219,108 @@ const TenantClusterPools: React.FC = () => {
         </PageSection>
       ) : (
         <PageSection hasBodyWrapper={false} key="body" className="admin-body">
-          <div className="tenant-pools-table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th style={{ width: '28px' }}></th>
-                  <th>Name</th>
-                  <th>Clusters</th>
-                  <th>Pool Saturation</th>
-                  <th>Max Capacity</th>
-                  <th>Placements</th>
-                  <th>Sandbox API State</th>
-                  <th>Created At</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredPools.map((pool) => {
-                  const poolKey = `${pool.metadata.namespace}/${pool.metadata.name}`;
-                  const isExpanded = expandedPools.has(poolKey);
-                  const clusters = pool.status?.clusters || [];
-                  const clusterCount = clusters.length;
-                  const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
+          {enabledPools.length > 0 && (
+            <div className="tenant-pools-table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th style={{ width: '28px' }}></th>
+                    <th>Name</th>
+                    <th>Clusters</th>
+                    <th>Pool Saturation</th>
+                    <th>Max Capacity</th>
+                    <th>Placements</th>
+                    <th>Sandbox API State</th>
+                    <th>Created At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {enabledPools.map((pool) => {
+                    const poolKey = `${pool.metadata.namespace}/${pool.metadata.name}`;
+                    const isExpanded = expandedPools.has(poolKey);
+                    const clusters = pool.status?.clusters || [];
+                    const clusterCount = clusters.length;
+                    const availableCount = clusters.filter((c) => c.sandboxApiState === 'available').length;
+                    const occupiedCount = clusterCount - availableCount;
+                    const poolSaturationPercent = clusterCount > 0 ? Math.round((occupiedCount / clusterCount) * 100) : 0;
+                    const saturationColor: 'green' | 'orange' | 'red' = poolSaturationPercent < 70 ? 'green' : poolSaturationPercent < 90 ? 'orange' : 'red';
+                    const maxPlacementsPerCluster = pool.spec?.sandboxHost?.max_placements || 50;
+                    const maxTotalPlacements = clusterCount * maxPlacementsPerCluster;
 
-                  // Pool saturation (cluster allocation)
-                  const occupiedCount = clusterCount - availableCount;
-                  const poolSaturationPercent = clusterCount > 0 ? Math.round((occupiedCount / clusterCount) * 100) : 0;
-                  const saturationColor: 'green' | 'orange' | 'red' = poolSaturationPercent < 70 ? 'green' : poolSaturationPercent < 90 ? 'orange' : 'red';
-
-                  // Theoretical max capacity (workshop slots)
-                  const maxPlacementsPerCluster = pool.spec?.sandboxHost?.max_placements || 50;
-                  const maxTotalPlacements = clusterCount * maxPlacementsPerCluster;
-                  const theoreticalMaxWorkshops = occupiedCount * maxPlacementsPerCluster;
-
-                  return (
-                    <React.Fragment key={poolKey}>
-                      <tr
-                        className="tenant-pools-group-header"
-                        onClick={() => togglePool(poolKey)}
-                      >
-                        <td className="tenant-pools-expand-cell">
-                          {isExpanded ? (
-                            <AngleDownIcon className="tenant-pools-expand-icon" />
-                          ) : (
-                            <AngleRightIcon className="tenant-pools-expand-icon" />
-                          )}
-                        </td>
-                        <td>
-                          <Link
-                            to={`/admin/tenantclusterpools/${pool.metadata.namespace}/${pool.metadata.name}`}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <strong>{pool.metadata.name}</strong>
-                          </Link>{' '}
-                          <Label isCompact color="blue">
-                            {clusterCount} cluster{clusterCount !== 1 ? 's' : ''}
-                          </Label>
-                        </td>
-                        <td>{availableCount} / {clusterCount} available</td>
-                        <td>
-                          <Tooltip content={`Pool saturation: ${poolSaturationPercent}% (${occupiedCount}/${clusterCount} clusters occupied)`}>
-                            <Label isCompact color={saturationColor}>
-                              {poolSaturationPercent}%
+                    return (
+                      <React.Fragment key={poolKey}>
+                        <tr
+                          className="tenant-pools-group-header"
+                          onClick={clusterCount > 0 ? () => togglePool(poolKey) : undefined}
+                          style={clusterCount === 0 ? { cursor: 'default' } : undefined}
+                        >
+                          <td className="tenant-pools-expand-cell">
+                            {clusterCount > 0 ? (
+                              isExpanded ? (
+                                <AngleDownIcon className="tenant-pools-expand-icon" />
+                              ) : (
+                                <AngleRightIcon className="tenant-pools-expand-icon" />
+                              )
+                            ) : null}
+                          </td>
+                          <td>
+                            <Link
+                              to={`/admin/tenantclusterpools/${pool.metadata.namespace}/${pool.metadata.name}`}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <strong>{pool.metadata.name}</strong>
+                            </Link>{' '}
+                            <Label isCompact color="blue">
+                              {clusterCount} cluster{clusterCount !== 1 ? 's' : ''}
                             </Label>
-                          </Tooltip>
-                        </td>
-                        <td>
-                          <Tooltip content={`Theoretical max: 0-${theoreticalMaxWorkshops} workshops deployed (max ${maxTotalPlacements} total). View Ops page for actual workshop counts.`}>
-                            <span style={{ whiteSpace: 'nowrap' }}>
-                              0-{theoreticalMaxWorkshops} workshops (max {maxTotalPlacements})
-                            </span>
-                          </Tooltip>
-                        </td>
-                        <td></td>
-                        <td></td>
-                        <td>
-                          <TimeInterval toTimestamp={pool.metadata.creationTimestamp} />
-                        </td>
-                      </tr>
-                      {isExpanded
-                        ? clusters.map((cluster: TenantClusterPoolStatusCluster, idx: number) => (
-                            <ClusterChildRow key={idx} cluster={cluster} namespace={pool.metadata.namespace} />
-                          ))
-                        : null}
-                    </React.Fragment>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                          </td>
+                          <td>{availableCount} / {clusterCount} available</td>
+                          <td>
+                            {clusterCount > 0 ? (
+                              <Tooltip content={`Pool saturation: ${poolSaturationPercent}% (${occupiedCount}/${clusterCount} clusters occupied)`}>
+                                <Label isCompact color={saturationColor}>
+                                  {poolSaturationPercent}%
+                                </Label>
+                              </Tooltip>
+                            ) : '-'}
+                          </td>
+                          <td>{maxTotalPlacements}</td>
+                          <td></td>
+                          <td></td>
+                          <td>
+                            <TimeInterval toTimestamp={pool.metadata.creationTimestamp} />
+                          </td>
+                        </tr>
+                        {isExpanded
+                          ? clusters.map((cluster: TenantClusterPoolStatusCluster, idx: number) => (
+                              <ClusterChildRow key={idx} cluster={cluster} namespace={pool.metadata.namespace} />
+                            ))
+                          : null}
+                      </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {disabledPools.length > 0 && (
+            <>
+              <Title headingLevel="h4" size="lg" style={{ marginTop: '2rem', marginBottom: '1rem' }}>
+                Disabled Tenant Cluster Pools
+              </Title>
+              <List isPlain isBordered>
+                {disabledPools.map((pool) => (
+                  <ListItem key={`${pool.metadata.namespace}/${pool.metadata.name}`}>
+                    <Link to={`/admin/tenantclusterpools/${pool.metadata.namespace}/${pool.metadata.name}`}>
+                      {pool.metadata.name}
+                    </Link>
+                    {' — '}
+                    <TimeInterval toTimestamp={pool.metadata.creationTimestamp} />
+                  </ListItem>
+                ))}
+              </List>
+            </>
+          )}
         </PageSection>
       )}
       <Footer />

--- a/catalog/ui/src/app/types.ts
+++ b/catalog/ui/src/app/types.ts
@@ -498,6 +498,7 @@ export interface TenantClusterPoolSpec {
   clusterProvisioning: {
     provider: { name: string; parameterValues?: Record<string, unknown> };
   };
+  enabled?: boolean;
   maxClusters?: number;
   minClusters?: number;
   minAvailableSandboxPlacements?: number;

--- a/catalog/ui/src/app/utils/useSandboxApi.ts
+++ b/catalog/ui/src/app/utils/useSandboxApi.ts
@@ -13,6 +13,7 @@ interface UseSandboxApiResult {
   updating: boolean;
   pendingAction: string | null;
   performAction: (action: string) => Promise<void>;
+  resourceClaimCreationTimestamp: string | null;
 }
 
 export default function useSandboxApi(
@@ -23,19 +24,19 @@ export default function useSandboxApi(
   const { data: placementsData, isLoading, mutate: mutatePlacements } = useSWR(
     clusterName ? apiPaths.SANDBOX_CLUSTER_PLACEMENTS({ clusterName }) : null,
     silentFetcher,
-    { shouldRetryOnError: false, refreshInterval: 8000 },
+    { shouldRetryOnError: false, refreshInterval: 8000, suspense: false },
   );
   const { data: configData, mutate: mutateConfig } = useSWR(
     clusterName && placementsData?.placements
       ? apiPaths.SANDBOX_CLUSTER_CONFIG({ clusterName })
       : null,
     silentFetcher,
-    { shouldRetryOnError: false, refreshInterval: 8000 },
+    { shouldRetryOnError: false, refreshInterval: 8000, suspense: false },
   );
   const { data: resourceClaim } = useSWR<ResourceClaim>(
     resourceClaimName ? apiPaths.RESOURCE_CLAIM({ namespace, resourceClaimName }) : null,
     silentFetcher,
-    { shouldRetryOnError: false, refreshInterval: 8000 },
+    { shouldRetryOnError: false, refreshInterval: 8000, suspense: false },
   );
 
   const pendingAction = useMemo(() => {
@@ -71,5 +72,7 @@ export default function useSandboxApi(
     }
   }, [namespace, resourceClaimName, mutatePlacements, mutateConfig]);
 
-  return { status, placementCount, maxPlacements, updating, pendingAction, performAction };
+  const resourceClaimCreationTimestamp = resourceClaim?.metadata?.creationTimestamp ?? null;
+
+  return { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp };
 }


### PR DESCRIPTION
## Summary
- Split pool list into enabled and disabled sections; disabled pools shown as a plain bordered list
- Simplify Max Capacity column to show just the number instead of `0-0 workshops (max N)`
- Show `-` for pool saturation when no clusters exist; hide expand icon for empty pools
- Add cluster creation date (from ResourceClaim) to expanded child rows
- Fix Suspense causing full page reload on row expand by disabling SWR suspense in `useSandboxApi`
- Show inline spinner per cluster row while data loads
- Add enabled/disabled toggle switch on pool detail page (disabled when clusters are linked)
- Add validation warnings: Min Clusters when pool is disabled, Min Placements when Max Clusters is zero

## Test plan
- [x] Verify pool list page shows enabled pools in the main table and disabled pools in a separate list below
- [x] Verify Max Capacity column shows a plain number (e.g. `25`)
- [x] Verify pools with 0 clusters show `-` for saturation and no expand icon
- [x] Verify expanding a pool shows a spinner then cluster details with creation date in the correct column
- [x] Verify the detail page shows an Enabled switch, togglable only when no clusters exist
- [x] Verify Min Clusters warning appears when pool is disabled and minClusters > 0
- [x] Verify Min Available Sandbox Placements warning appears when maxClusters is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)