### PR TITLE
fix: Remove multi-asset label filter from white glove catalog item selector

### DIFF
--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
@@ -49,7 +49,7 @@ import {
   DEMO_DOMAIN,
   READY_BY_LEAD_TIME_MS,
 } from '@app/util';
-import { formatCurrency, formatTime } from '@app/Catalog/catalog-utils';
+import { formatCurrency, formatTime, CUSTOM_LABELS, getSLA, SLAs } from '@app/Catalog/catalog-utils';
 import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
 import SalesforceItemsField from '@app/components/SalesforceItemsField';
 import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
@@ -120,6 +120,19 @@ const MultiWorkshopCreate: React.FC = () => {
       ],
     };
   });
+
+  const catalogItemsFilter = useCallback(
+    (items: CatalogItem[]) => {
+      const filtered = isAdmin
+        ? items
+        : items.filter(
+            (item) =>
+              item.metadata?.labels?.[`${CUSTOM_LABELS.MULTI_ASSET.domain}/${CUSTOM_LABELS.MULTI_ASSET.key}`] === 'true',
+          );
+      return filtered.filter((item) => !item.spec.workshopUiDisabled && getSLA(item) !== SLAs.Unsupported);
+    },
+    [isAdmin],
+  );
 
   const { data: whiteGloveRequest } = useSWR<WhiteGloveRequest>(
     wgrNamespace && wgrName
@@ -1034,6 +1047,7 @@ const MultiWorkshopCreate: React.FC = () => {
         onClose={closeCatalogSelector}
         onSelect={handleCatalogItemSelect}
         title="Select Catalog Item for Workshop"
+        catalogItemsFilter={catalogItemsFilter}
       />
       <UserDisabledModal
         isOpen={isUserDisabledModalOpen}

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useSWRImmutable from 'swr/immutable';
 import {
@@ -28,6 +28,7 @@ import { apiPaths, BlockedDateRange, createWhiteGloveRequest, createJiraTicketFo
 import useSystemStatus from '@app/utils/useSystemStatus';
 import { CatalogItem, SalesforceItem } from '@app/types';
 import { DEMO_DOMAIN, displayName, getPurposeOptsFromCatalogItem } from '@app/util';
+import { getSLA, SLAs } from '@app/Catalog/catalog-utils';
 import CatalogItemIcon from '@app/Catalog/CatalogItemIcon';
 import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
 import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
@@ -99,6 +100,11 @@ const WhiteGloveCreateContent: React.FC = () => {
     }
     return [];
   }, [selectedCatalogItems, defaultCatalogItems]);
+
+  const catalogItemsFilter = useCallback(
+    (items: CatalogItem[]) => items.filter((item) => getSLA(item) !== SLAs.Unsupported),
+    [],
+  );
 
   function handleCatalogItemSelect(catalogItemOrItems: CatalogItem | CatalogItem[]) {
     const items = Array.isArray(catalogItemOrItems) ? catalogItemOrItems : [catalogItemOrItems];
@@ -507,6 +513,7 @@ const WhiteGloveCreateContent: React.FC = () => {
         onSelect={handleCatalogItemSelect}
         title="Select Catalog Item for White Glove Request"
         defaultMultiSelect={false}
+        catalogItemsFilter={catalogItemsFilter}
       />
 
       <DateTimePickerModalDialog

--- a/catalog/ui/src/app/WhiteGlove/WhiteGloveDetail.tsx
+++ b/catalog/ui/src/app/WhiteGlove/WhiteGloveDetail.tsx
@@ -52,6 +52,7 @@ import ActivityPurposeSelector from '@app/components/ActivityPurposeSelector';
 import PatientNumberInput from '@app/components/PatientNumberInput';
 import { DateTimePickerModalDialog, DateTimePickerButton } from '@app/components/DateTimePickerModal';
 import { getBrowserTimezone } from '@app/components/timezones';
+import { getSLA, SLAs } from '@app/Catalog/catalog-utils';
 import CatalogItemIcon from '@app/Catalog/CatalogItemIcon';
 import CatalogItemSelectorModal from '@app/components/CatalogItemSelectorModal';
 import SalesforceItemsField from '@app/components/SalesforceItemsField';
@@ -355,6 +356,11 @@ const WhiteGloveDetailContent: React.FC = () => {
     const updated = current.filter((e) => e !== email);
     patchSpec({ shareWith: updated.length > 0 ? updated : null }, `Updated "Share With": removed ${email}`);
   }
+
+  const catalogItemsFilter = useCallback(
+    (items: CatalogItem[]) => items.filter((item) => getSLA(item) !== SLAs.Unsupported),
+    [],
+  );
 
   function handleCatalogItemSelect(catalogItemOrItems: CatalogItem | CatalogItem[]) {
     const items = Array.isArray(catalogItemOrItems) ? catalogItemOrItems : [catalogItemOrItems];
@@ -897,6 +903,7 @@ const WhiteGloveDetailContent: React.FC = () => {
           onSelect={handleCatalogItemSelect}
           title="Select Catalog Item"
           defaultMultiSelect={false}
+          catalogItemsFilter={catalogItemsFilter}
         />
       )}
 

--- a/catalog/ui/src/app/components/CatalogItemSelectorModal.tsx
+++ b/catalog/ui/src/app/components/CatalogItemSelectorModal.tsx
@@ -38,8 +38,6 @@ import {
   getSLA,
   getSLABadgeClass,
   formatString,
-  CUSTOM_LABELS,
-  SLAs,
 } from '@app/Catalog/catalog-utils';
 import StarRating from '@app/components/StarRating';
 import StatusPageIcons from '@app/components/StatusPageIcons';
@@ -221,6 +219,7 @@ interface CatalogItemSelectorModalProps {
   title?: string;
   singleSelect?: boolean;
   defaultMultiSelect?: boolean;
+  catalogItemsFilter?: (items: CatalogItem[]) => CatalogItem[];
 }
 
 // Fetch catalog items from multiple namespaces
@@ -239,26 +238,14 @@ async function fetchCatalog(namespaces: string[]): Promise<CatalogItem[]> {
   return catalogItems;
 }
 
-// Filter catalog items for multi-asset workshop selection
-// Non-admins: require multiAsset = true label
-// Admins: no filtering
-function filterCatalogItemsForMultiWorkshop(items: CatalogItem[], isAdmin: boolean): CatalogItem[] {
-  if (isAdmin) return items;
-
-  return items.filter((item) => {
-    const isMultiAsset =
-      item.metadata?.labels?.[`${CUSTOM_LABELS.MULTI_ASSET.domain}/${CUSTOM_LABELS.MULTI_ASSET.key}`];
-    return isMultiAsset === 'true';
-  });
-}
-
 // Component that fetches catalog items for category selector
 const CategorySelectorContent: React.FC<{
   selectedCatalogNamespace: string | null;
   onSelect: (categories: string[]) => void;
   selected: string[];
-}> = ({ selectedCatalogNamespace, onSelect, selected }) => {
-  const { catalogNamespaces, isAdmin } = useSession().getSession();
+  catalogItemsFilter?: (items: CatalogItem[]) => CatalogItem[];
+}> = ({ selectedCatalogNamespace, onSelect, selected, catalogItemsFilter }) => {
+  const { catalogNamespaces } = useSession().getSession();
   const catalogNamespaceNames = catalogNamespaces.map((ns) => ns.name);
 
   const { data: catalogItemsArr } = useSWR<CatalogItem[]>(
@@ -267,11 +254,8 @@ const CategorySelectorContent: React.FC<{
   );
 
   const catalogItems: CatalogItem[] = useMemo(
-    () =>
-      filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin).filter(
-        (item) => !item.spec.workshopUiDisabled && getSLA(item) !== SLAs.Unsupported,
-      ),
-    [catalogItemsArr, isAdmin],
+    () => catalogItemsFilter ? catalogItemsFilter(catalogItemsArr || []) : (catalogItemsArr || []),
+    [catalogItemsArr, catalogItemsFilter],
   );
 
   return (
@@ -290,6 +274,7 @@ const CatalogItemsContent: React.FC<{
   isMultiSelectMode: boolean;
   selectedItems: Map<string, CatalogItem>;
   onToggleItem: (catalogItem: CatalogItem, isSelected: boolean) => void;
+  catalogItemsFilter?: (items: CatalogItem[]) => CatalogItem[];
 }> = ({
   searchValue,
   selectedCatalogNamespace,
@@ -298,8 +283,9 @@ const CatalogItemsContent: React.FC<{
   isMultiSelectMode,
   selectedItems,
   onToggleItem,
+  catalogItemsFilter,
 }) => {
-  const { catalogNamespaces, isAdmin } = useSession().getSession();
+  const { catalogNamespaces } = useSession().getSession();
   const catalogNamespaceNames = catalogNamespaces.map((ns) => ns.name);
 
   const { data: catalogItemsArr } = useSWR<CatalogItem[]>(
@@ -308,11 +294,8 @@ const CatalogItemsContent: React.FC<{
   );
 
   const allowedCatalogItems = useMemo(
-    () =>
-      filterCatalogItemsForMultiWorkshop(catalogItemsArr || [], isAdmin).filter(
-        (item) => !item.spec.workshopUiDisabled && getSLA(item) !== SLAs.Unsupported,
-      ),
-    [catalogItemsArr, isAdmin],
+    () => catalogItemsFilter ? catalogItemsFilter(catalogItemsArr || []) : (catalogItemsArr || []),
+    [catalogItemsArr, catalogItemsFilter],
   );
 
   const filteredCatalogItems = useMemo(() => {
@@ -435,6 +418,7 @@ const CatalogItemSelectorModal: React.FC<CatalogItemSelectorModalProps> = ({
   title = 'Select Catalog Item',
   singleSelect = false,
   defaultMultiSelect,
+  catalogItemsFilter,
 }) => {
   const [searchValue, setSearchValue] = useState('');
   const [selectedCatalogNamespace, setSelectedCatalogNamespace] = useState<string | null>(null);
@@ -572,6 +556,7 @@ const CatalogItemSelectorModal: React.FC<CatalogItemSelectorModalProps> = ({
                 selectedCatalogNamespace={selectedCatalogNamespace}
                 onSelect={setSelectedCategories}
                 selected={selectedCategories}
+                catalogItemsFilter={catalogItemsFilter}
               />
             </Suspense>
           ) : null}
@@ -597,6 +582,7 @@ const CatalogItemSelectorModal: React.FC<CatalogItemSelectorModalProps> = ({
                 isMultiSelectMode={isMultiSelectMode}
                 selectedItems={selectedItems}
                 onToggleItem={handleToggleItem}
+                catalogItemsFilter={catalogItemsFilter}
               />
             </Suspense>
           ) : null}


### PR DESCRIPTION
## Summary
- Extracted catalog item filtering logic from `CatalogItemSelectorModal` into callers via an optional `catalogItemsFilter` prop
- Multi-workshop form keeps the multi-asset label filter and unsupported SLA filter
- White glove forms (create + detail) only filter out unsupported SLA items, showing all catalog items regardless of the multi-asset label

## Test plan
- [ ] Open multi-workshop create form → catalog item selector should only show items with `Multi_Asset=true` label (for non-admins)
- [ ] Open white glove create form → catalog item selector should show all catalog items (except unsupported SLA)
- [ ] Open white glove detail (admin) → catalog item selector should show all catalog items (except unsupported SLA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)