### PR TITLE
feat: GPTEINFRA-17845 - Add offboarding safeguards and onboard button guards for tenant clusters

### DIFF
--- a/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPoolInstance.tsx
@@ -111,7 +111,7 @@ const ClusterRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, maxPlacements, updating, pendingAction, performAction } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, pendingAction, performAction, isRunning } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   return (
     <Tr>
@@ -134,8 +134,10 @@ const ClusterRow: React.FC<{
           updating={updating}
           pendingAction={pendingAction}
           performAction={performAction}
-          isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
+          isDisabled={!isRunning}
           size="sm"
+          placementCount={placementCount}
+          clusterName={cluster.name}
         />
       </Td>
     </Tr>

--- a/catalog/ui/src/app/Admin/TenantClusterPools.tsx
+++ b/catalog/ui/src/app/Admin/TenantClusterPools.tsx
@@ -49,7 +49,7 @@ const ClusterChildRow: React.FC<{
   cluster: TenantClusterPoolStatusCluster;
   namespace: string;
 }> = ({ cluster, namespace }) => {
-  const { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
+  const { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp, isRunning } = useSandboxApi(cluster.name, namespace, cluster.resourceClaimName);
 
   if (status === 'loading') {
     return (
@@ -102,8 +102,10 @@ const ClusterChildRow: React.FC<{
           updating={updating}
           pendingAction={pendingAction}
           performAction={performAction}
-          isDisabled={cluster.sandboxApiState !== 'available' && cluster.sandboxApiState !== 'removed'}
+          isDisabled={!isRunning}
           size="sm"
+          placementCount={placementCount}
+          clusterName={cluster.name}
         />
       </td>
       <td></td>

--- a/catalog/ui/src/app/Services/ServicesItem.tsx
+++ b/catalog/ui/src/app/Services/ServicesItem.tsx
@@ -404,15 +404,20 @@ const ServicesItemComponent: React.FC<{
     status: sandboxApiStatus,
     updating: tenantActionUpdating,
     performAction: performSandboxAction,
+    placementCount: sandboxPlacementCount,
   } = useSandboxApi(
     isTenantClusterItem ? clusterName : '',
     resourceClaim.metadata.namespace,
     resourceClaim.metadata.name,
   );
   const isRunning = useMemo(() => {
+    const summaryState = resourceClaim.status?.summary?.state;
+    if (summaryState) {
+      return summaryState === 'started' || summaryState === 'running';
+    }
     const resource = resourceClaim.status?.resources?.[0]?.state;
     return resource?.kind === 'AnarchySubject' && resource.spec?.vars?.current_state === 'started';
-  }, [resourceClaim.status?.resources]);
+  }, [resourceClaim.status?.summary?.state, resourceClaim.status?.resources]);
 
   const [serviceAlias, setServiceAlias] = useState(
     resourceClaim.metadata.annotations?.[`${DEMO_DOMAIN}/service-alias`] || '',
@@ -1297,6 +1302,8 @@ const ServicesItemComponent: React.FC<{
                               updating={tenantActionUpdating}
                               performAction={performSandboxAction}
                               isDisabled={!isRunning}
+                              placementCount={sandboxPlacementCount}
+                              clusterName={clusterName}
                             />
                           </div>
                         ) : sandboxApiStatus === 'available' ? (
@@ -1309,6 +1316,8 @@ const ServicesItemComponent: React.FC<{
                               status={sandboxApiStatus}
                               updating={tenantActionUpdating}
                               performAction={performSandboxAction}
+                              placementCount={sandboxPlacementCount}
+                              clusterName={clusterName}
                             />
                           </div>
                         ) : sandboxApiStatus === 'disabled' ? (
@@ -1320,6 +1329,8 @@ const ServicesItemComponent: React.FC<{
                               status={sandboxApiStatus}
                               updating={tenantActionUpdating}
                               performAction={performSandboxAction}
+                              placementCount={sandboxPlacementCount}
+                              clusterName={clusterName}
                             />
                           </div>
                         ) : null}

--- a/catalog/ui/src/app/components/SandboxApiActions.tsx
+++ b/catalog/ui/src/app/components/SandboxApiActions.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Button, Spinner } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Alert, Button, Modal, ModalBody, ModalFooter, ModalHeader, Spinner } from '@patternfly/react-core';
 import { SandboxApiStatus } from '@app/utils/useSandboxApi';
 
 const actionLabels: Record<string, string> = {
@@ -16,7 +16,11 @@ const SandboxApiActions: React.FC<{
   performAction: (action: string) => Promise<void>;
   isDisabled?: boolean;
   size?: 'sm' | 'lg';
-}> = ({ status, updating, pendingAction, performAction, isDisabled = false, size }) => {
+  placementCount?: number;
+  clusterName?: string;
+}> = ({ status, updating, pendingAction, performAction, isDisabled = false, size, placementCount = 0, clusterName }) => {
+  const [showOffboardConfirm, setShowOffboardConfirm] = useState(false);
+
   if (pendingAction) {
     return (
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
@@ -28,6 +32,14 @@ const SandboxApiActions: React.FC<{
 
   if (updating) {
     return <Spinner size="sm" />;
+  }
+
+  function handleOffboard() {
+    if (placementCount > 0) {
+      setShowOffboardConfirm(true);
+    } else {
+      performAction('offboard');
+    }
   }
 
   if (status === 'not onboarded') {
@@ -48,14 +60,42 @@ const SandboxApiActions: React.FC<{
 
   if (status === 'disabled') {
     return (
-      <span style={{ display: 'inline-flex', gap: '8px', alignSelf: 'flex-start' }}>
-        <Button variant="primary" size={size} onClick={() => performAction('enable')}>
-          Enable
-        </Button>
-        <Button variant="secondary" size={size} isDanger onClick={() => performAction('offboard')}>
-          Offboard
-        </Button>
-      </span>
+      <>
+        <span style={{ display: 'inline-flex', gap: '8px', alignSelf: 'flex-start' }}>
+          <Button variant="primary" size={size} onClick={() => performAction('enable')}>
+            Enable
+          </Button>
+          <Button variant="secondary" size={size} isDanger onClick={handleOffboard}>
+            Offboard
+          </Button>
+        </span>
+
+        <Modal variant="small" isOpen={showOffboardConfirm} onClose={() => setShowOffboardConfirm(false)} aria-labelledby="offboard-confirm">
+          <ModalHeader title="Confirm Force Offboard" labelId="offboard-confirm" titleIconVariant="warning" />
+          <ModalBody>
+            <Alert
+              variant="danger"
+              isInline
+              title={`This cluster has ${placementCount} active placement${placementCount !== 1 ? 's' : ''}`}
+              style={{ marginBottom: 12 }}
+            >
+              Offboarding {clusterName ? <strong>{clusterName}</strong> : 'this cluster'} will leave tenant services in an invalid or unavailable state.
+              Affected tenants will lose access to their placements on this cluster.
+            </Alert>
+            <p style={{ marginTop: 8, color: 'var(--pf-t--global--text--color--subtle)', fontSize: '0.88rem' }}>
+              This action cannot be undone. Ensure all tenants have been migrated before proceeding.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="danger" onClick={() => { setShowOffboardConfirm(false); performAction('offboard'); }}>
+              Force Offboard
+            </Button>
+            <Button variant="link" onClick={() => setShowOffboardConfirm(false)}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </>
     );
   }
 

--- a/catalog/ui/src/app/utils/useSandboxApi.ts
+++ b/catalog/ui/src/app/utils/useSandboxApi.ts
@@ -14,6 +14,7 @@ interface UseSandboxApiResult {
   pendingAction: string | null;
   performAction: (action: string) => Promise<void>;
   resourceClaimCreationTimestamp: string | null;
+  isRunning: boolean;
 }
 
 export default function useSandboxApi(
@@ -74,5 +75,14 @@ export default function useSandboxApi(
 
   const resourceClaimCreationTimestamp = resourceClaim?.metadata?.creationTimestamp ?? null;
 
-  return { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp };
+  const isRunning = useMemo(() => {
+    const summaryState = resourceClaim?.status?.summary?.state;
+    if (summaryState) {
+      return summaryState === 'started' || summaryState === 'running';
+    }
+    const resource = resourceClaim?.status?.resources?.[0]?.state;
+    return resource?.kind === 'AnarchySubject' && resource.spec?.vars?.current_state === 'started';
+  }, [resourceClaim?.status?.summary?.state, resourceClaim?.status?.resources]);
+
+  return { status, placementCount, maxPlacements, updating, pendingAction, performAction, resourceClaimCreationTimestamp, isRunning };
 }


### PR DESCRIPTION
## Summary
- Add confirmation modal with danger warning when offboarding a cluster that has active tenant placements, requiring explicit "Force Offboard" confirmation
- Disable onboard button on all tenant cluster pages until the service is fully started (not just provisioning)
- Fix `isRunning` check to use `summary.state` instead of only `AnarchySubject.current_state`, since the summary reflects the actual service status shown in the UI

## Test plan
- [ ] Cluster with 0 placements: "Offboard" button proceeds immediately (no modal)
- [ ] Cluster with >0 placements: "Offboard" shows warning modal requiring explicit "Force Offboard" confirmation
- [ ] Cluster in provisioning state: "Onboard" button is disabled on pool list, pool detail, and service detail pages
- [ ] Cluster in started state: "Onboard" button is enabled
- [ ] Verify offboard confirmation modal shows correct placement count and cluster name

🤖 Generated with [Claude Code](https://claude.com/claude-code)