### PR TITLE
Bump catalog UI image tag to v0.35.9

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.8
+    tag: v0.35.9
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.8
+        tag: v0.35.9
       replicaCount: 1
       resources:
         requests:


### PR DESCRIPTION
## Summary
- Bump `babylon-catalog-ui` image tag from `v0.35.8` to `v0.35.9` in both `catalog/helm/values.yaml` and `helm/values.yaml`

## Test plan
- [ ] Verify catalog UI pods pick up the new image after deployment
- [ ] Confirm UI loads correctly with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)