### PR TITLE
GPTEINFRA-17814 Fix: SelfPacedLab asset display and ID lookup in multi-workshop

### DIFF
--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopDetail.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopDetail.tsx
@@ -1069,8 +1069,15 @@ const MultiWorkshopDetail: React.FC = () => {
                                   {asset.displayName || asset.key}
                                 </a>
                               ) : asset.name && asset.type === 'Workshop' ? (
-                                <Link 
+                                <Link
                                   to={`/workshops/${asset.namespace}/${asset.name}`}
+                                  style={{ textDecoration: 'none' }}
+                                >
+                                  {asset.name}
+                                </Link>
+                              ) : asset.name && asset.type === 'SelfPacedLab' ? (
+                                <Link
+                                  to={`/selfpacedlabs/${asset.namespace}/${asset.name}`}
                                   style={{ textDecoration: 'none' }}
                                 >
                                   {asset.name}
@@ -1106,6 +1113,11 @@ const MultiWorkshopDetail: React.FC = () => {
                             </div>
                             <div>
                               {(() => {
+                                if (asset.type === 'SelfPacedLab') {
+                                  const spl = selfPacedLabs?.find(s => s.metadata.name === asset.name) || sharedSelfPacedLabs?.find(s => s.metadata.name === asset.name);
+                                  const lifespanEnd = spl?.spec?.lifespan?.end;
+                                  return lifespanEnd ? <LocalTimestamp timestamp={lifespanEnd} /> : <span>-</span>;
+                                }
                                 if (asset.type !== 'Workshop' || !asset.name) return <span>-</span>;
                                 const workshop = workshops?.find(w => w.metadata.name === asset.name) || sharedWorkshops?.find(w => w.metadata.name === asset.name);
                                 const lifespanEnd = workshop?.spec?.lifespan?.end;

--- a/workshop-manager/operator/multiworkshop.py
+++ b/workshop-manager/operator/multiworkshop.py
@@ -763,33 +763,37 @@ class MultiWorkshop(CachedKopfObject):
         updated_assets = []
 
         for asset in assets:
-            workshop_name = asset.get('name')
-            if asset.get('workshopId') or not workshop_name:
+            asset_name = asset.get('name')
+            asset_type = asset.get('type', 'Workshop')
+            if asset.get('workshopId') or not asset_name:
                 updated_assets.append(asset)
                 continue
 
+            plural = 'selfpacedlabs' if asset_type == 'SelfPacedLab' else 'workshops'
+            id_label = f'{Babylon.babylon_domain}/workshop-id'
+
             try:
                 asset_namespace = asset.get('namespace', self.namespace)
-                workshop = await Babylon.custom_objects_api.get_namespaced_custom_object(
+                resource = await Babylon.custom_objects_api.get_namespaced_custom_object(
                     group=Babylon.babylon_domain,
                     version='v1',
                     namespace=asset_namespace,
-                    plural='workshops',
-                    name=workshop_name
+                    plural=plural,
+                    name=asset_name,
                 )
 
-                workshop_id = workshop.get('metadata', {}).get('labels', {}).get(f'{Babylon.babylon_domain}/workshop-id')
-                if workshop_id:
+                resource_id = resource.get('metadata', {}).get('labels', {}).get(id_label)
+                if resource_id:
                     asset_copy = asset.copy()
-                    asset_copy['workshopId'] = workshop_id
+                    asset_copy['workshopId'] = resource_id
                     updated_assets.append(asset_copy)
                     needs_update = True
-                    logger.info(f"Found workshop ID {workshop_id} for MultiWorkshop {self.name} asset {asset['key']}")
+                    logger.info(f"Found {plural} ID {resource_id} for MultiWorkshop {self.name} asset {asset['key']}")
                 else:
                     updated_assets.append(asset)
 
             except Exception as e:
-                logger.debug(f"Could not get workshop {workshop_name} for MultiWorkshop {self.name}: {e}")
+                logger.debug(f"Could not get {plural} {asset_name} for MultiWorkshop {self.name}: {e}")
                 updated_assets.append(asset)
 
         if needs_update:


### PR DESCRIPTION
## Summary
- **Operator**: `update_workshop_ids` now looks up `selfpacedlabs` for SelfPacedLab type assets instead of always checking `workshops`
- **Detail page**: SelfPacedLab assets now link to `/selfpacedlabs/...` instead of showing "Not created yet", and show the auto-destroy date from the SelfPacedLab lifespan

## Test plan
- [x] Create a multi-asset workshop with a SelfPacedLab asset
- [x] After operator creates the SelfPacedLab, verify the asset shows "Created" status and a clickable link to the self-paced lab detail page
- [x] Verify the auto-destroy column shows the correct date

🤖 Generated with [Claude Code](https://claude.com/claude-code)