### PR TITLE
GPTEINFRA-17814 fix: Use selfpacedlab-id label for SelfPacedLab assets in multi-workshop

### DIFF
--- a/workshop-manager/operator/multiworkshop.py
+++ b/workshop-manager/operator/multiworkshop.py
@@ -770,7 +770,7 @@ class MultiWorkshop(CachedKopfObject):
                 continue
 
             plural = 'selfpacedlabs' if asset_type == 'SelfPacedLab' else 'workshops'
-            id_label = f'{Babylon.babylon_domain}/workshop-id'
+            id_label = f'{Babylon.babylon_domain}/selfpacedlab-id' if asset_type == 'SelfPacedLab' else f'{Babylon.babylon_domain}/workshop-id'
 
             try:
                 asset_namespace = asset.get('namespace', self.namespace)


### PR DESCRIPTION
## Summary
- The selfpacedlab-manager assigns a `babylon.gpte.redhat.com/selfpacedlab-id` label to SelfPacedLab resources (not `workshop-id`)
- `update_workshop_ids` now reads the correct label per asset type so `workshopId` gets populated on SelfPacedLab assets in the MultiWorkshop spec

## Test plan
- [x] Create a multi-asset workshop with a SelfPacedLab asset
- [x] Wait for the selfpacedlab-manager to assign the `selfpacedlab-id` label
- [x] Verify the MultiWorkshop asset gets `workshopId` populated and shows "Created" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)