### PR TITLE
Fix landing page to route SelfPacedLab assets to /selfpacedlab/ URL

### DIFF
--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopLanding.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopLanding.tsx
@@ -24,10 +24,12 @@ const WorkshopCard: React.FC<WorkshopCardProps> = ({ asset, isAvailable }) => {
   const displayName = asset.displayName || asset.key;
   
   // Determine the URL based on asset type
-  const workshopUrl = asset.type === 'external' 
-    ? asset.url 
-    : asset.workshopId 
-      ? `/workshop/${asset.workshopId}` 
+  const workshopUrl = asset.type === 'external'
+    ? asset.url
+    : asset.workshopId
+      ? asset.type === 'SelfPacedLab'
+        ? `/selfpacedlab/${asset.workshopId}`
+        : `/workshop/${asset.workshopId}`
       : null;
 
   if (!isAvailable) {


### PR DESCRIPTION
## Summary
- The multi-workshop landing page was routing all non-external assets to `/workshop/{id}`. SelfPacedLab assets now correctly route to `/selfpacedlab/{id}`.

## Test plan
- [x] Visit a multi-workshop event landing page that has a SelfPacedLab asset
- [x] Verify the SelfPacedLab card links to `/selfpacedlab/{id}` not `/workshop/{id}`
- [x] Verify Workshop cards still link to `/workshop/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)