### PR TITLE
Restrict self-paced lab switch to admins only

### DIFF
--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.10
+    tag: v0.35.11
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
+++ b/catalog/ui/src/app/Catalog/CatalogItemForm.tsx
@@ -904,13 +904,13 @@ const CatalogItemFormData: React.FC<{ catalogItemName: string; catalogNamespaceN
           </FormGroup>
         ) : null}
 
-        {formState.workshop ? (
+        {formState.workshop && isAdmin ? (
           <FormGroup key="self-paced-lab-switch" fieldId="self-paced-lab-switch">
             <div className="catalog-item-form__group-control--single">
               <Switch
                 id="self-paced-lab-switch"
                 aria-label="Enable self-paced lab"
-                label="Enable self-paced lab"
+                label="Enable self-paced lab (admins only)"
                 isChecked={!!formState.selfPacedLab}
                 hasCheckIcon
                 onChange={(_event, isChecked) => {

--- a/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
+++ b/catalog/ui/src/app/MultiWorkshops/MultiWorkshopCreate.tsx
@@ -942,13 +942,13 @@ const MultiWorkshopCreate: React.FC = () => {
                       </Button>
                     </div>
                   </FormGroup>
-                  {asset.key && (
+                  {asset.key && isAdmin && (
                     <FormGroup fieldId={`asset-selfpacedlab-switch-${index}`} style={{ marginTop: '12px' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                         <Switch
                           id={`asset-selfpacedlab-switch-${index}`}
                           aria-label="Order as self-paced lab"
-                          label="Order as self-paced lab"
+                          label="Order as self-paced lab (admins only)"
                           isChecked={asset.type === 'SelfPacedLab'}
                           hasCheckIcon
                           onChange={(_event, isChecked) => toggleAssetSelfPacedLab(index, isChecked)}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.10
+        tag: v0.35.11
       replicaCount: 1
       resources:
         requests:


### PR DESCRIPTION
## Summary
- Hide the "Enable self-paced lab" switch in the catalog item form and the "Order as self-paced lab" switch in the multi-asset form for non-admin users
- Update switch labels to include "(admins only)" text
- Bump `babylon-catalog-ui` image tag from `v0.35.10` to `v0.35.11`

## Test plan
- [x] Log in as a non-admin user and verify the self-paced lab switch is not visible in the catalog item form
- [x] Log in as a non-admin user and verify the self-paced lab switch is not visible in the multi-asset form
- [x] Log in as an admin user and verify the switch is visible with "(admins only)" label in both forms
- [x] Verify toggling the switch still works correctly for admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)