### PR TITLE
fix: paginate TenantClusterPools fetch in Ops view

### DIFF
--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -82,7 +82,6 @@ import {
   dateToApiString,
   deleteResourceClaim,
   fetcher,
-  fetcherItemsInAllPages,
   lockWorkshop,
   patchWorkshop,
   patchWorkshopProvision,
@@ -93,7 +92,7 @@ import {
   WorkshopUserAssignment, WorkshopUserAssignmentList,
   ResourceClaim, ResourceClaimList,
   MultiWorkshop, MultiWorkshopList,
-  TenantClusterPool,
+  TenantClusterPool, TenantClusterPoolList,
   ServiceNamespace,
   WorkshopWithResourceClaims,
 } from '@app/types';
@@ -582,20 +581,17 @@ const Ops: React.FC = () => {
   }, [allMwData]);
 
   // Fetch TenantClusterPools for cluster assignment tracking (cluster-wide query)
-  const { data: allTcpData } = useSWR<TenantClusterPool[]>(
-    apiPaths.TENANT_CLUSTER_POOLS({ limit: 'ALL' }),
-    () =>
-      fetcherItemsInAllPages((continueId) =>
-        apiPaths.TENANT_CLUSTER_POOLS({ limit: FETCH_LIMIT, continueId }),
-      ),
+  const { data: allTcpData } = useSWR<TenantClusterPoolList>(
+    apiPaths.TENANT_CLUSTER_POOLS({ limit: FETCH_LIMIT }),
+    fetcher,
     { refreshInterval: 60000 }, // Refresh every 60s (less frequent than workshops)
   );
 
   // Build lookup map: resourceClaimName → { poolName, poolNamespace, clusterName, capacity }
   const tenantClusterLookup = useMemo(() => {
     const map = new Map<string, { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; maxPlacements: number }>();
-    if (allTcpData) {
-      for (const pool of allTcpData) {
+    if (allTcpData?.items) {
+      for (const pool of allTcpData.items) {
         if (pool.status?.clusters) {
           const totalClusters = pool.status.clusters.length;
           const availableClusters = pool.status.clusters.filter(c => c.sandboxApiState === 'available').length;

--- a/catalog/ui/src/app/Admin/Ops.tsx
+++ b/catalog/ui/src/app/Admin/Ops.tsx
@@ -82,6 +82,7 @@ import {
   dateToApiString,
   deleteResourceClaim,
   fetcher,
+  fetcherItemsInAllPages,
   lockWorkshop,
   patchWorkshop,
   patchWorkshopProvision,
@@ -92,7 +93,7 @@ import {
   WorkshopUserAssignment, WorkshopUserAssignmentList,
   ResourceClaim, ResourceClaimList,
   MultiWorkshop, MultiWorkshopList,
-  TenantClusterPool, TenantClusterPoolList,
+  TenantClusterPool,
   ServiceNamespace,
   WorkshopWithResourceClaims,
 } from '@app/types';
@@ -581,17 +582,20 @@ const Ops: React.FC = () => {
   }, [allMwData]);
 
   // Fetch TenantClusterPools for cluster assignment tracking (cluster-wide query)
-  const { data: allTcpData } = useSWR<TenantClusterPoolList>(
+  const { data: allTcpData } = useSWR<TenantClusterPool[]>(
     apiPaths.TENANT_CLUSTER_POOLS({ limit: 'ALL' }),
-    fetcher,
+    () =>
+      fetcherItemsInAllPages((continueId) =>
+        apiPaths.TENANT_CLUSTER_POOLS({ limit: FETCH_LIMIT, continueId }),
+      ),
     { refreshInterval: 60000 }, // Refresh every 60s (less frequent than workshops)
   );
 
   // Build lookup map: resourceClaimName → { poolName, poolNamespace, clusterName, capacity }
   const tenantClusterLookup = useMemo(() => {
     const map = new Map<string, { poolName: string; poolNamespace: string; clusterName: string; totalClusters: number; availableClusters: number; maxPlacements: number }>();
-    if (allTcpData?.items) {
-      for (const pool of allTcpData.items) {
+    if (allTcpData) {
+      for (const pool of allTcpData) {
         if (pool.status?.clusters) {
           const totalClusters = pool.status.clusters.length;
           const availableClusters = pool.status.clusters.filter(c => c.sandboxApiState === 'available').length;


### PR DESCRIPTION
## Summary

- `Ops.tsx` was calling `apiPaths.TENANT_CLUSTER_POOLS({ limit: 'ALL' })` which produced `?limit=ALL` — an invalid value for the OpenShift API (only numeric limits are accepted)
- Switched to `fetcherItemsInAllPages` (matching the existing pattern in `TenantClusterPools.tsx`) so pools are fetched via paginated requests with a numeric limit
- Updated the SWR type from `TenantClusterPoolList` to `TenantClusterPool[]` and adjusted the consumer to iterate the array directly

Reported by Aleix Casanovas.

## Test plan
- [ ] Navigate to the Ops admin view and confirm the tenant cluster pool assignment tracking loads without a 400/422 error on the `tenantclusterpools` API call
- [ ] Verify cluster assignment data renders correctly in the Ops view