### PR TITLE
GPTEINFRA-17791 ref: Handle cluster info in Workshop dashboard

### DIFF
--- a/catalog/ui/src/app/Workshops/WorkshopInfoTab.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopInfoTab.tsx
@@ -42,9 +42,10 @@ export function getWorkshopInfoMessageTemplate(workshop?: Workshop): MessageTemp
 const WorkshopInfoTab: React.FC<{
   workshop: Workshop;
   resourceClaims: ResourceClaim[];
+  clusterResourceClaims?: ResourceClaim[];
   workshopProvisions: WorkshopProvision[];
   showModal: ({ action, resourceClaims }: ModalState) => void;
-}> = ({ workshop, resourceClaims, workshopProvisions, showModal }) => {
+}> = ({ workshop, resourceClaims, clusterResourceClaims = [], workshopProvisions, showModal }) => {
   const [now] = useState(() => Date.now());
   const [selectedInfoClaimIndex, setSelectedInfoClaimIndex] = useState(0);
   const [infoSourceSelectOpen, setInfoSourceSelectOpen] = useState(false);
@@ -118,9 +119,13 @@ const WorkshopInfoTab: React.FC<{
                     <CheckCircleIcon key="scheduled-icon" /> Scheduled
                   </span>
                   {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
+                  {clusterResourceClaims.length > 0 ? <WorkshopStatus resourceClaims={clusterResourceClaims} label="Clusters" /> : null}
                 </>
-              ) : resourceClaims.length > 0 ? (
-                <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} />
+              ) : resourceClaims.length > 0 || clusterResourceClaims.length > 0 ? (
+                <>
+                  {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
+                  {clusterResourceClaims.length > 0 ? <WorkshopStatus resourceClaims={clusterResourceClaims} label="Clusters" /> : null}
+                </>
               ) : (
                 <p>...</p>
               )}

--- a/catalog/ui/src/app/Workshops/WorkshopStatus.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopStatus.tsx
@@ -30,7 +30,8 @@ function cmp(a: { state: string }, b: { state: string }) {
 const WorkshopStatus: React.FC<{
   resourceClaims: ResourceClaim[];
   totalCount?: number;
-}> = ({ resourceClaims, totalCount }) => {
+  label?: string;
+}> = ({ resourceClaims, totalCount, label = 'Instances' }) => {
   const resourceClaimsStatus: { uid: string; state: string }[] = [];
   for (let resourceClaim of resourceClaims.filter((rc) => !rc.metadata.deletionTimestamp)) {
     const summary = resourceClaim.status?.summary;
@@ -79,13 +80,13 @@ const WorkshopStatus: React.FC<{
       {Object.entries(statusCount).map(([status, count]: [string, unknown]) => {
         const { state, phase } = getPhaseState(status);
         const isRunning = state.toLowerCase() === 'running';
-        const label =
+        const statusLabel =
           isRunning && totalCount != null
-            ? `${count as number}/${totalCount} Instances`
-            : `${count as number} Instances`;
+            ? `${count as number}/${totalCount} ${label}`
+            : `${count as number} ${label}`;
         return (
           <div key={state}>
-            <span style={{ paddingRight: '12px' }}>{label}</span>
+            <span style={{ paddingRight: '12px' }}>{statusLabel}</span>
             <InnerStatus phase={phase} state={state} />
           </div>
         );

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -369,7 +369,7 @@ const WorkshopsItemComponent: React.FC<{
       workshop,
       dateToApiString(new Date()),
       dateToApiString(new Date(Date.now() + parseDuration('30h'))),
-      resourceClaims,
+      instanceResourceClaims,
     );
     mutateWorkshop(workshopUpdated);
   }
@@ -426,7 +426,7 @@ const WorkshopsItemComponent: React.FC<{
         !isWorkshopStarted(workshop, workshopProvisions)
           ? dateToApiString(new Date(date.getTime() + parseDuration('30h')))
           : dateToApiString(new Date(Date.now() + parseDuration('30h'))),
-        resourceClaims,
+        instanceResourceClaims,
       );
       // If workshop has readyBy date, update it to be provisioning date + lead time
       if (workshop.spec?.lifespan?.readyBy) {
@@ -454,7 +454,7 @@ const WorkshopsItemComponent: React.FC<{
         !isWorkshopStarted(workshop, workshopProvisions)
           ? dateToApiString(new Date(date.getTime() + parseDuration('30h')))
           : dateToApiString(new Date(Date.now() + parseDuration('30h'))),
-        resourceClaims,
+        instanceResourceClaims,
       );
       mutateWorkshop(workshopUpdated);
       // Highlight auto-destroy in details after changing start date
@@ -469,7 +469,7 @@ const WorkshopsItemComponent: React.FC<{
         !isWorkshopStarted(workshop, workshopProvisions)
           ? dateToApiString(new Date(date.getTime() + parseDuration('30h')))
           : dateToApiString(new Date(Date.now() + parseDuration('30h'))),
-        resourceClaims,
+        instanceResourceClaims,
       );
       const workshopUpdated = await patchWorkshop({
         name: workshop.metadata.name,
@@ -530,7 +530,7 @@ const WorkshopsItemComponent: React.FC<{
                   : 'stop'
           }
           workshop={workshop}
-          resourceClaims={resourceClaims}
+          resourceClaims={instanceResourceClaims}
           workshopProvisions={workshopProvisions}
         />
       </Modal>
@@ -627,15 +627,15 @@ const WorkshopsItemComponent: React.FC<{
                       ? null
                       : () => showModal({ action: 'deleteService', resourceClaims: selectedResourceClaims }),
                   start:
-                    Array.isArray(resourceClaims) && resourceClaims.length === 0
+                    Array.isArray(instanceResourceClaims) && instanceResourceClaims.length === 0
                       ? enableManageWorkshopProvisions && !isWorkshopStarted(workshop, workshopProvisions)
                         ? () => showModal({ action: 'startWorkshop', resourceClaims: [] })
                         : null
-                      : checkWorkshopCanStart(resourceClaims)
-                        ? () => showModal({ action: 'startServices', resourceClaims })
+                      : checkWorkshopCanStart(instanceResourceClaims)
+                        ? () => showModal({ action: 'startServices', resourceClaims: instanceResourceClaims })
                         : null,
-                  stop: checkWorkshopCanStop(resourceClaims)
-                    ? () => showModal({ action: 'stopServices', resourceClaims })
+                  stop: checkWorkshopCanStop(instanceResourceClaims)
+                    ? () => showModal({ action: 'stopServices', resourceClaims: instanceResourceClaims })
                     : null,
                   reorder: canReorderWorkshop(workshop, catalogItem, workshopProvision, groups, isAdmin)
                     ? () => openModalReorder()
@@ -667,7 +667,7 @@ const WorkshopsItemComponent: React.FC<{
                 onWorkshopUpdate={(workshop: Workshop) => mutateWorkshop(workshop)}
                 workshop={workshop}
                 showModal={showModal}
-                resourceClaims={resourceClaims}
+                resourceClaims={instanceResourceClaims}
                 workshopProvisions={workshopProvisions}
                 workshopUserAssignments={userAssigmentsList?.items || []}
                 usageCost={usageCost}
@@ -681,7 +681,7 @@ const WorkshopsItemComponent: React.FC<{
               {activeTab === 'info' ? (
                 <WorkshopInfoTab
                   workshop={workshop}
-                  resourceClaims={resourceClaims || []}
+                  resourceClaims={instanceResourceClaims}
                   workshopProvisions={workshopProvisions || []}
                   showModal={showModal}
                 />
@@ -692,6 +692,13 @@ const WorkshopsItemComponent: React.FC<{
             <Tab eventKey="provision" title={<TabTitleText>Provisioning</TabTitleText>}>
               {activeTab === 'provision' ? (
                 <WorkshopsItemProvisioning workshop={workshop} workshopProvisions={workshopProvisions} />
+              ) : null}
+            </Tab>
+          ) : null}
+          {clusterResourceClaims.length > 0 ? (
+            <Tab eventKey="clusters" title={<TabTitleText>Clusters</TabTitleText>}>
+              {activeTab === 'clusters' ? (
+                <WorkshopsItemClusters resourceClaims={clusterResourceClaims} />
               ) : null}
             </Tab>
           ) : null}
@@ -707,13 +714,6 @@ const WorkshopsItemComponent: React.FC<{
               />
             ) : null}
           </Tab>
-          {clusterResourceClaims.length > 0 ? (
-            <Tab eventKey="clusters" title={<TabTitleText>Clusters</TabTitleText>}>
-              {activeTab === 'clusters' ? (
-                <WorkshopsItemClusters resourceClaims={clusterResourceClaims} />
-              ) : null}
-            </Tab>
-          ) : null}
           <Tab eventKey="users" title={<TabTitleText>Users</TabTitleText>}>
             {activeTab === 'users' ? (
               <WorkshopsItemUserAssignments

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -62,6 +62,7 @@ import WorkshopActionModal from '@app/components/WorkshopActionModal';
 import WorkshopActions from './WorkshopActions';
 import WorkshopsItemDetails from './WorkshopsItemDetails';
 import WorkshopsItemProvisioning from './WorkshopsItemProvisioning';
+import WorkshopsItemClusters from './WorkshopsItemClusters';
 import WorkshopsItemServices from './WorkshopsItemServices';
 import WorkshopsItemUserAssignments from './WorkshopsItemUserAssignments';
 import WorkshopScheduleAction from './WorkshopScheduleAction';
@@ -251,6 +252,16 @@ const WorkshopsItemComponent: React.FC<{
       revalidateIfStale: false, // Don't auto-revalidate stale data
       dedupingInterval: 3000, // Dedupe requests
     },
+  );
+
+  const instanceResourceClaims = useMemo(
+    () => (resourceClaims || []).filter((r) => !r.metadata.labels?.[`${BABYLON_DOMAIN}/tenant-cluster-pool`]),
+    [resourceClaims],
+  );
+
+  const clusterResourceClaims = useMemo(
+    () => (resourceClaims || []).filter((r) => !!r.metadata.labels?.[`${BABYLON_DOMAIN}/tenant-cluster-pool`]),
+    [resourceClaims],
   );
 
   // Check if workshop has an info message template
@@ -690,12 +701,19 @@ const WorkshopsItemComponent: React.FC<{
                 modalState={modalState}
                 showModal={showModal}
                 setSelectedResourceClaims={setSelectedResourceClaims}
-                resourceClaims={resourceClaims || []}
+                resourceClaims={instanceResourceClaims}
                 workshopProvisions={workshopProvisions}
                 userAssignments={userAssigmentsList?.items || []}
               />
             ) : null}
           </Tab>
+          {clusterResourceClaims.length > 0 ? (
+            <Tab eventKey="clusters" title={<TabTitleText>Clusters</TabTitleText>}>
+              {activeTab === 'clusters' ? (
+                <WorkshopsItemClusters resourceClaims={clusterResourceClaims} />
+              ) : null}
+            </Tab>
+          ) : null}
           <Tab eventKey="users" title={<TabTitleText>Users</TabTitleText>}>
             {activeTab === 'users' ? (
               <WorkshopsItemUserAssignments

--- a/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItem.tsx
@@ -668,6 +668,7 @@ const WorkshopsItemComponent: React.FC<{
                 workshop={workshop}
                 showModal={showModal}
                 resourceClaims={instanceResourceClaims}
+                clusterResourceClaims={clusterResourceClaims}
                 workshopProvisions={workshopProvisions}
                 workshopUserAssignments={userAssigmentsList?.items || []}
                 usageCost={usageCost}
@@ -682,6 +683,7 @@ const WorkshopsItemComponent: React.FC<{
                 <WorkshopInfoTab
                   workshop={workshop}
                   resourceClaims={instanceResourceClaims}
+                  clusterResourceClaims={clusterResourceClaims}
                   workshopProvisions={workshopProvisions || []}
                   showModal={showModal}
                 />

--- a/catalog/ui/src/app/Workshops/WorkshopsItemClusters.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemClusters.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import { K8sObjectReference, ResourceClaim } from '@app/types';
+import { displayName } from '@app/util';
+import LocalTimestamp from '@app/components/LocalTimestamp';
+import OpenshiftConsoleLink from '@app/components/OpenshiftConsoleLink';
+import SelectableTable from '@app/components/SelectableTable';
+import TimeInterval from '@app/components/TimeInterval';
+import ServiceStatus from '@app/Services/ServiceStatus';
+import useSession from '@app/utils/useSession';
+
+const WorkshopsItemClusters: React.FC<{
+  resourceClaims: ResourceClaim[];
+}> = ({ resourceClaims }) => {
+  const { isAdmin } = useSession().getSession();
+
+  const activeClaims = resourceClaims.filter((r) => !r.metadata.deletionTimestamp);
+
+  if (activeClaims.length === 0) {
+    return (
+      <EmptyState headingLevel="h1" icon={ExclamationTriangleIcon} titleText="No Clusters Found" variant="full">
+        <EmptyStateBody>No clusters have been provisioned for this workshop.</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <SelectableTable
+      columns={['Name', 'GUID', 'Status', 'Created']}
+      onSelectAll={() => undefined}
+      rows={activeClaims.map((resourceClaim: ResourceClaim) => {
+        const resourceHandle: K8sObjectReference = resourceClaim.status?.resourceHandle;
+        const guid = resourceHandle?.name ? resourceHandle.name.replace(/^guid-/, '') : null;
+
+        return {
+          cells: [
+            <>
+              <Link
+                key="services"
+                to={`/services/${resourceClaim.metadata.namespace}/${resourceClaim.metadata.name}`}
+              >
+                {displayName(resourceClaim)}
+              </Link>
+              {isAdmin ? <OpenshiftConsoleLink key="console" resource={resourceClaim} /> : null}
+            </>,
+            <>
+              {guid ? (
+                isAdmin && resourceHandle ? (
+                  [
+                    <Link key="admin" to={`/admin/resourcehandles/${resourceHandle.name}`}>
+                      {guid}
+                    </Link>,
+                    <OpenshiftConsoleLink key="console" reference={resourceHandle} />,
+                  ]
+                ) : (
+                  guid
+                )
+              ) : (
+                <p>-</p>
+              )}
+            </>,
+            <ServiceStatus key="status" resourceClaim={resourceClaim} />,
+            <>
+              <LocalTimestamp key="timestamp" timestamp={resourceClaim.metadata.creationTimestamp} />
+              <br key="break" />
+              (<TimeInterval key="interval" toTimestamp={resourceClaim.metadata.creationTimestamp} />)
+            </>,
+          ],
+        };
+      })}
+    />
+  );
+};
+
+export default WorkshopsItemClusters;

--- a/catalog/ui/src/app/Workshops/WorkshopsItemClusters.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemClusters.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { K8sObjectReference, ResourceClaim } from '@app/types';
 import { displayName } from '@app/util';
 import LocalTimestamp from '@app/components/LocalTimestamp';
 import OpenshiftConsoleLink from '@app/components/OpenshiftConsoleLink';
-import SelectableTable from '@app/components/SelectableTable';
 import TimeInterval from '@app/components/TimeInterval';
 import ServiceStatus from '@app/Services/ServiceStatus';
 import useSession from '@app/utils/useSession';
@@ -27,50 +27,55 @@ const WorkshopsItemClusters: React.FC<{
   }
 
   return (
-    <SelectableTable
-      columns={['Name', 'GUID', 'Status', 'Created']}
-      onSelectAll={() => undefined}
-      rows={activeClaims.map((resourceClaim: ResourceClaim) => {
-        const resourceHandle: K8sObjectReference = resourceClaim.status?.resourceHandle;
-        const guid = resourceHandle?.name ? resourceHandle.name.replace(/^guid-/, '') : null;
+    <Table aria-label="Clusters" variant="compact">
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>GUID</Th>
+          <Th>Status</Th>
+          <Th>Created</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {activeClaims.map((resourceClaim: ResourceClaim) => {
+          const resourceHandle: K8sObjectReference = resourceClaim.status?.resourceHandle;
+          const guid = resourceHandle?.name ? resourceHandle.name.replace(/^guid-/, '') : null;
 
-        return {
-          cells: [
-            <>
-              <Link
-                key="services"
-                to={`/services/${resourceClaim.metadata.namespace}/${resourceClaim.metadata.name}`}
-              >
-                {displayName(resourceClaim)}
-              </Link>
-              {isAdmin ? <OpenshiftConsoleLink key="console" resource={resourceClaim} /> : null}
-            </>,
-            <>
-              {guid ? (
-                isAdmin && resourceHandle ? (
-                  [
-                    <Link key="admin" to={`/admin/resourcehandles/${resourceHandle.name}`}>
-                      {guid}
-                    </Link>,
-                    <OpenshiftConsoleLink key="console" reference={resourceHandle} />,
-                  ]
+          return (
+            <Tr key={resourceClaim.metadata.uid}>
+              <Td>
+                <Link to={`/services/${resourceClaim.metadata.namespace}/${resourceClaim.metadata.name}`}>
+                  {displayName(resourceClaim)}
+                </Link>
+                {isAdmin ? <OpenshiftConsoleLink resource={resourceClaim} /> : null}
+              </Td>
+              <Td>
+                {guid ? (
+                  isAdmin && resourceHandle ? (
+                    <>
+                      <Link to={`/admin/resourcehandles/${resourceHandle.name}`}>{guid}</Link>
+                      <OpenshiftConsoleLink reference={resourceHandle} />
+                    </>
+                  ) : (
+                    guid
+                  )
                 ) : (
-                  guid
-                )
-              ) : (
-                <p>-</p>
-              )}
-            </>,
-            <ServiceStatus key="status" resourceClaim={resourceClaim} />,
-            <>
-              <LocalTimestamp key="timestamp" timestamp={resourceClaim.metadata.creationTimestamp} />
-              <br key="break" />
-              (<TimeInterval key="interval" toTimestamp={resourceClaim.metadata.creationTimestamp} />)
-            </>,
-          ],
-        };
-      })}
-    />
+                  '-'
+                )}
+              </Td>
+              <Td>
+                <ServiceStatus resourceClaim={resourceClaim} />
+              </Td>
+              <Td>
+                <LocalTimestamp timestamp={resourceClaim.metadata.creationTimestamp} />
+                <br />
+                (<TimeInterval toTimestamp={resourceClaim.metadata.creationTimestamp} />)
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
   );
 };
 

--- a/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
+++ b/catalog/ui/src/app/Workshops/WorkshopsItemDetails.tsx
@@ -70,6 +70,7 @@ const WorkshopsItemDetails: React.FC<{
   onWorkshopUpdate: (workshop: Workshop) => void;
   workshop: Workshop;
   resourceClaims?: ResourceClaim[];
+  clusterResourceClaims?: ResourceClaim[];
   workshopProvisions?: WorkshopProvision[];
   workshopUserAssignments?: WorkshopUserAssignment[];
   showModal?: ({ action, resourceClaims }: ModalState) => void;
@@ -80,6 +81,7 @@ const WorkshopsItemDetails: React.FC<{
   onWorkshopUpdate,
   workshopProvisions = [],
   resourceClaims,
+  clusterResourceClaims = [],
   workshop,
   showModal,
   workshopUserAssignments,
@@ -432,9 +434,13 @@ const WorkshopsItemDetails: React.FC<{
                   <CheckCircleIcon key="scheduled-icon" /> Scheduled
                 </span>
                 {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
+                {clusterResourceClaims.length > 0 ? <WorkshopStatus resourceClaims={clusterResourceClaims} label="Clusters" /> : null}
               </>
-            ) : resourceClaims.length > 0 ? (
-              <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} />
+            ) : resourceClaims.length > 0 || clusterResourceClaims.length > 0 ? (
+              <>
+                {resourceClaims.length > 0 ? <WorkshopStatus resourceClaims={resourceClaims} totalCount={workshopProvisions.reduce((sum, wp) => sum + (wp.spec.count || 0), 0)} /> : null}
+                {clusterResourceClaims.length > 0 ? <WorkshopStatus resourceClaims={clusterResourceClaims} label="Clusters" /> : null}
+              </>
             ) : (
               <p>...</p>
             )}


### PR DESCRIPTION
## Summary
  - Separate TenantClusterPool ResourceClaims from workshop instances into a dedicated **Clusters** tab (placed before Instances), hidden when no clusters exist
  - Clusters tab is read-only with a non-selectable table (Name, GUID, Status, Created) — no delete/restart actions
  - Workshop status in **Details** and **Info** tabs now shows cluster status alongside instance status (e.g. "3 Instances Provision Failed, 1 Clusters Running")
 <img width="382" height="63" alt="Captura de pantalla 2026-09-10 a las 11 38 56" src="https://github.com/user-attachments/assets/61b72319-2105-4de5-8e34-87f0b4475925" />

  - All status calculations, start/stop checks, scheduling actions, and delete unused instances now exclude TenantClusterPool items — filtering by the `babylon.gpte.redhat.com/tenant-cluster-pool` label

