### PR TITLE
Fix catalog-manager rating 404 failures and RBAC for status subresource

### DIFF
--- a/catalog-manager/helm/templates/rbac.yaml
+++ b/catalog-manager/helm/templates/rbac.yaml
@@ -44,6 +44,7 @@ rules:
   - {{ .Values.babylon.domain }}
   resources:
   - catalogitems
+  - catalogitems/status
   verbs:
   - get
   - list

--- a/catalog-manager/operator/operator.py
+++ b/catalog-manager/operator/operator.py
@@ -32,10 +32,12 @@ async def manage_catalog_item_is_disabled(catalog_item, logger):
 
 async def manage_catalog_item_rating(catalog_item, logger):
     rating = await CatalogItemService(catalog_item, logger=logger).get_rating_from_api()
+    if rating.rating_score is None:
+        return
     logger.info(
         f"Rating of {catalog_item.name} is {rating.rating_score} of {rating.total_ratings} -- was {catalog_item.rating.rating_score} of {catalog_item.rating.total_ratings}"
     )
-    if rating != catalog_item.rating and rating.rating_score is not None:
+    if rating != catalog_item.rating:
         patch = {
             "metadata": {
                 "labels": {Babylon.catalog_item_rating_label: str(rating.rating_score)},

--- a/catalog/helm/values.yaml
+++ b/catalog/helm/values.yaml
@@ -34,7 +34,7 @@ ui:
   name: # default use chart name + '-ui'
   image:
     #override:
-    tag: v0.35.11
+    tag: v0.35.12
     repository: quay.io/redhat-gpte/babylon-catalog-ui
     pullPolicy: IfNotPresent
   replicaCount: 1

--- a/helm/templates/catalog-manager/clusterrole.yaml
+++ b/helm/templates/catalog-manager/clusterrole.yaml
@@ -48,6 +48,7 @@ rules:
   - {{ .Values.catalog.api.group }}
   resources:
   - catalogitems
+  - catalogitems/status
   verbs:
   - get
   - list

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ catalog:
       image:
         pullPolicy: IfNotPresent
         repository: quay.io/redhat-gpte/babylon-catalog-ui
-        tag: v0.35.11
+        tag: v0.35.12
       replicaCount: 1
       resources:
         requests:
@@ -336,7 +336,7 @@ catalogManager:
   image:
     repository: quay.io/redhat-gpte/babylon-catalog-manager
     pullPolicy: Always
-    tag: v1.2.0
+    tag: v1.2.1
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
## Summary
- **Rating 404 handling**: `manage_catalog_item_rating` now returns early when the rating API returns 404 (no rating data), instead of letting the timer fail and retry indefinitely. Affects dev-namespace items and newly created catalog items that don't yet exist in the reporting API.
- **RBAC fix**: Added `catalogitems/status` to the ClusterRole in both helm charts. Kopf's `StatusDiffBaseStorage` and `StatusProgressStorage` write to the `/status` subresource, which Kubernetes RBAC treats as a separate resource — this was causing `APIForbiddenError` with 1621+ retries in `babylon-catalog-event`.

## Test plan
- [ ] Verify catalog items with no rating data (404 from reporting API) no longer produce timer failure/retry logs
- [ ] Verify catalog items with rating data still get their labels/annotations updated
- [ ] Confirm the `APIForbiddenError` on `catalogitems/status` in `babylon-catalog-event` is resolved after deploying the updated ClusterRole

🤖 Generated with [Claude Code](https://claude.com/claude-code)