### PR TITLE
Bump catalog-manager to v1.2.2 and catalog-ui to v0.35.12

### DIFF
--- a/catalog-manager/helm/Chart.yaml
+++ b/catalog-manager/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: babylon-catalog-manager
 description: A Helm chart for the babylon catalog manager component.
 type: application
-version: 1.2.1
-appVersion: 1.2.1
+version: 1.2.2
+appVersion: 1.2.2

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -336,7 +336,7 @@ catalogManager:
   image:
     repository: quay.io/redhat-gpte/babylon-catalog-manager
     pullPolicy: Always
-    tag: v1.2.1
+    tag: v1.2.2
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
## Summary
- Bump catalog-manager image tag to `v1.2.2` in `helm/values.yaml` and chart version in `catalog-manager/helm/Chart.yaml`
- Bump catalog-ui image tag to `v0.35.12` in `helm/values.yaml` and `catalog/helm/values.yaml`

## Test plan
- [ ] Verify catalog-manager deploys with the new image tag
- [ ] Verify catalog-ui deploys with the new image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)