### PR TITLE
Add include_dependencies to partner header API request

### DIFF
--- a/catalog/ui/src/app/AppLayout/AppLayout.tsx
+++ b/catalog/ui/src/app/AppLayout/AppLayout.tsx
@@ -38,7 +38,7 @@ const AppLayout: React.FC<{ children: React.ReactNode; title: string; accessCont
 
   const { data: partnerHeaderHtml } = useSWRImmutable<string>(
     partner_connect_header_enabled
-      ? 'https://connect.redhat.com/en/api/chrome/authenticated/3.0/universal_and_primary'
+      ? 'https://connect.redhat.com/en/api/chrome/authenticated/3.0/universal_and_primary?include_dependencies=true'
       : null,
     publicFetcher,
   );


### PR DESCRIPTION
## Summary
- Adds `?include_dependencies=true` query parameter to the partner header 3.0 API endpoint
- Without this parameter, the `pfe-navigation` web component renders without its CSS/JS dependencies, resulting in unstyled content

## Test plan
- [ ] Verify the partner header renders with proper styling on `partner.demo.redhat.com`
- [ ] Confirm CSS and JS assets are loaded from `connect.redhat.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)